### PR TITLE
change last pulled commit 

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -666,12 +666,7 @@ public class HornetQServerImpl implements HornetQServer
          }
          if (backupActivationThread != null)
          {
-
-            backupActivationThread.join(30000);
-            if (backupActivationThread.isAlive())
-            {
-               backupActivationThread.interrupt();
-            }
+            backupActivationThread.join();
          }
 
          stopComponent(nodeManager);
@@ -1742,7 +1737,7 @@ public class HornetQServerImpl implements HornetQServer
       }
    }
 
-   private synchronized void deployGroupingHandlerConfiguration(final GroupingHandlerConfiguration config) throws Exception
+   private void deployGroupingHandlerConfiguration(final GroupingHandlerConfiguration config) throws Exception
    {
       if (config != null)
       {


### PR DESCRIPTION
between server.stop() (which is synchronized on "server"), and
HornetQServerImpl.SharedStoreBackupActivation.run() which calls
HornetQServerImpl.initialize1(), at the end of initialize1() there is a call to
HornetQServerImpl.deployGroupingHandlerConfiguration(GroupingHandlerConfiguration)
which WAS also sync'ed on 'server'.
