### PR TITLE
HORNETQ-812

### DIFF
--- a/hornetq-jms/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
+++ b/hornetq-jms/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
@@ -152,8 +152,6 @@ public class JMSJournalStorageManagerImpl implements JMSStorageManager
       {
          jmsJournal.appendDeleteRecord(oldCF.getId(), false);
       }
-
-      this.deleteJNDI(PersistedType.ConnectionFactory, cfName);
    }
 
    /* (non-Javadoc)


### PR DESCRIPTION
This commit fixes added JNDI being deleted on eap server restart issue. JNDI will be recovered after each queue/topic/connection factory having been deployed
during startup time.
