### PR TITLE
HornetQ-854 uuid hardware address

### DIFF
--- a/src/main/org/hornetq/utils/UUIDGenerator.java
+++ b/src/main/org/hornetq/utils/UUIDGenerator.java
@@ -17,10 +17,19 @@ package org.hornetq.utils;
 
 import java.lang.reflect.Method;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.core.logging.Logger;
@@ -150,46 +159,29 @@ public final class UUIDGenerator
 
       try
       {
-         Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-         while (networkInterfaces.hasMoreElements())
-         {
-            NetworkInterface networkInterface = networkInterfaces.nextElement();
-            boolean up = (Boolean)isUpMethod.invoke(networkInterface);
-            boolean loopback = (Boolean)isLoopbackMethod.invoke(networkInterface);
-            boolean virtual = (Boolean)isVirtualMethod.invoke(networkInterface);
+         List<NetworkInterface> ifaces = getAllNetworkInterfaces();
 
-            if (loopback || virtual || !up)
-            {
-               continue;
-            }
-
-            Object res = getHardwareAddressMethod.invoke(networkInterface);
-            if (res != null && res instanceof byte[])
-            {
-               byte[] address = (byte[])res;
-               byte[] paddedAddress = UUIDGenerator.getZeroPaddedSixBytes(address);
-
-               if (UUIDGenerator.isBlackList(address))
-               {
-                  continue;
-               }
-
-               if (paddedAddress != null)
-               {
-                  if (UUIDGenerator.log.isDebugEnabled())
-                  {
-                     UUIDGenerator.log.debug("using hardware address " + UUIDGenerator.asString(paddedAddress));
-                  }
-                  return paddedAddress;
-               }
-            }
+         if (ifaces.size() == 0) {
+            return null;
          }
-      }
-      catch (Throwable t)
-      {
-      }
 
-      return null;
+         byte[] address = findFirstMatchingHardwareAddress(ifaces,
+                                              getHardwareAddressMethod,
+                                              isUpMethod,
+                                              isLoopbackMethod,
+                                              isVirtualMethod);
+         if (address != null) {
+            if (UUIDGenerator.log.isDebugEnabled())
+            {
+               UUIDGenerator.log.debug("using hardware address " + UUIDGenerator.asString(address));
+            }
+            return address;
+         }
+         return null;
+      } catch(Exception e)
+      {
+         return null;
+      }
    }
 
    public final SimpleString generateSimpleStringUUID()
@@ -289,5 +281,86 @@ public final class UUIDGenerator
       }
       s += bytes[bytes.length - 1];
       return s;
+   }
+
+   private static List<NetworkInterface> getAllNetworkInterfaces()
+   {
+      Enumeration<NetworkInterface> networkInterfaces;
+      try
+      {
+         networkInterfaces = NetworkInterface.getNetworkInterfaces();
+
+         List<NetworkInterface> ifaces = new ArrayList<NetworkInterface>();
+         while (networkInterfaces.hasMoreElements())
+         {
+            ifaces.add(networkInterfaces.nextElement());
+         }
+         return ifaces;
+      }
+      catch (SocketException e)
+      {
+         return Collections.emptyList();
+      }
+   }
+
+   private static byte[] findFirstMatchingHardwareAddress(List<NetworkInterface> ifaces,
+                                                          final Method getHardwareAddressMethod,
+                                                          final Method isUpMethod,
+                                                          final Method isLoopbackMethod,
+                                                          final Method isVirtualMethod)
+   {
+      ExecutorService executor = Executors.newFixedThreadPool(ifaces.size());
+      Collection<Callable<byte[]>> tasks = new ArrayList<Callable<byte[]>>();
+
+      for (final NetworkInterface networkInterface : ifaces)
+      {
+         tasks.add(new Callable<byte[]>()
+                   {
+            public byte[] call() throws Exception
+            {
+               boolean up = (Boolean)isUpMethod.invoke(networkInterface );
+               boolean loopback = (Boolean)isLoopbackMethod.invoke(networkInterface);
+               boolean virtual = (Boolean)isVirtualMethod.invoke(networkInterface);
+
+               if (loopback || virtual || !up)
+               {
+                  throw new Exception("not suitable interface");
+               }
+
+               Object res = getHardwareAddressMethod.invoke(networkInterface);
+               if (res != null && res instanceof byte[]) {
+
+                  byte[] address = (byte[])res;
+                  byte[] paddedAddress = UUIDGenerator.getZeroPaddedSixBytes(address);
+
+                  if (UUIDGenerator.isBlackList(address))
+                  {
+                     throw new Exception("black listed address");
+                  }
+
+                  if (paddedAddress != null)
+                  {
+                     return paddedAddress;
+                  }
+               }
+
+               throw new Exception("invalid network interface");
+            }
+         });
+      }
+      try
+      {
+         // we wait 5 seconds to get the first matching hardware address. After that, we give up and return null
+         byte[] address = executor.invokeAny(tasks, 5, TimeUnit.SECONDS);
+         return address;
+      }
+      catch (Exception e)
+      {
+         return null;
+      }
+      finally
+      {
+         executor.shutdownNow();
+      }
    }
 }

--- a/tests/src/org/hornetq/tests/timing/util/UUIDTest.java
+++ b/tests/src/org/hornetq/tests/timing/util/UUIDTest.java
@@ -13,6 +13,8 @@
 
 package org.hornetq.tests.timing.util;
 
+import org.hornetq.utils.UUIDGenerator;
+
 /**
  * 
  * @author <a href="mailto:clebert.suconic@jboss.com">Clebert Suconic</a>
@@ -26,6 +28,19 @@ public class UUIDTest extends org.hornetq.tests.unit.util.UUIDTest
    // Attributes ----------------------------------------------------
 
    // Static --------------------------------------------------------
+
+   public static void main(String[] args)
+   {
+      long start = System.currentTimeMillis();
+      int count = 10000;
+      for (int i = 0; i < count; i++)
+      {
+         // System.out.println(i + " " + UUIDGenerator.asString(UUIDGenerator.getHardwareAddress()));
+         byte[] address = UUIDGenerator.getHardwareAddress();
+      }
+      long end = System.currentTimeMillis();
+      System.out.println("getHardwareAddress() => " + 1.0 * (end - start) / count + " ms");
+   }
 
    // Constructors --------------------------------------------------
 


### PR DESCRIPTION
- parallelize code checking for a suitable hardware address
- add a simple main method in timing.util.UUIDTest

On my linux Laptop (with 3 interfaces), the call to getHardwareAddress()
takes 0.8ms (against 0.37ms without the parallelization).
However on a machine with many network interfaces, I expect this code
to be faster than a sequential search (to be confirmed...)
