### PR TITLE
Uuid generator security permission

### DIFF
--- a/src/main/org/hornetq/utils/UUIDGenerator.java
+++ b/src/main/org/hornetq/utils/UUIDGenerator.java
@@ -150,6 +150,9 @@ public final class UUIDGenerator
          isUpMethod = NetworkInterface.class.getMethod("isUp");
          isLoopbackMethod = NetworkInterface.class.getMethod("isLoopback");
          isVirtualMethod = NetworkInterface.class.getMethod("isVirtual");
+         // check if we have enough security permissions to create and shutdown an executor
+         ExecutorService executor = Executors.newFixedThreadPool(0);
+         executor.shutdownNow();
       }
       catch (Throwable t)
       {


### PR DESCRIPTION
- check whether we are able to create and shutdown an executor prior
  to determine an hardware address. This can fail if the JVM has a
  Security Manager with restricted RuntimePermission
