### PR TITLE
fixed JMSServerManagerImpl to activate on start if not already activated

### DIFF
--- a/hornetq-jms/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -387,6 +387,10 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       }
 
       started = true;
+      if(!active)
+      {
+         activated();
+      }
    }
 
    public void stop() throws Exception


### PR DESCRIPTION
This is for Justin to look at, Justin turns out your last commit broke the jms tests because the JMSServerManager was never activated, could you check its ok please
