### PR TITLE
Hornetq 912 synchronize hardware address

### DIFF
--- a/src/main/org/hornetq/utils/UUIDGenerator.java
+++ b/src/main/org/hornetq/utils/UUIDGenerator.java
@@ -265,10 +265,19 @@ public final class UUIDGenerator
    {
       if (address == null)
       {
-         address = UUIDGenerator.getHardwareAddress();
-         if (address == null)
+         // calling UUIDGenerator.getHardwareAddress() is a
+         // time-expensive operation, let make sure it is called
+         // only once
+         synchronized (this)
          {
-            address = generateDummyAddress();
+            if (address == null)
+            {
+               address = UUIDGenerator.getHardwareAddress();
+               if (address == null)
+               {
+                  address = generateDummyAddress();
+               }
+            }
          }
       }
 


### PR DESCRIPTION
- ensure that the call to getHardwareAddress() occurs only once
  even when getAddressBytes() is called in parallel
