### PR TITLE
master - remove unnecessary 'throws Exception' from the Configuration.setClusterPassword() declaration.

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/config/Configuration.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/config/Configuration.java
@@ -428,7 +428,7 @@ public interface Configuration extends Serializable
    /**
     * Sets the cluster password for this server.
     */
-   void setClusterPassword(String password) throws Exception;
+   void setClusterPassword(String password);
 
    /**
     * Returns the size of the cache for pre-creating message IDs.

--- a/hornetq-core/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
@@ -935,7 +935,7 @@ public class ConfigurationImpl implements Configuration
       this.failoverOnServerShutdown = failoverOnServerShutdown;
    }
 
-   public void setClusterPassword(final String theclusterPassword) throws Exception
+   public void setClusterPassword(final String theclusterPassword)
    {
       clusterPassword = theclusterPassword;
    }


### PR DESCRIPTION
remove unnecessary 'throws Exception' from the Configuration.setClusterPassword() declaration.
