### PR TITLE
Use context loader in org.hornetq.core.config.impl.FileConfiguration

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
@@ -56,7 +56,7 @@ public class FileConfiguration extends ConfigurationImpl
       }
 
 
-      URL url = getClass().getClassLoader().getResource(configurationUrl);
+      URL url = Thread.currentThread().getContextClassLoader().getResource(configurationUrl);
 
       if (url == null)
       {


### PR DESCRIPTION
I have HornetQ embedded in Tomcat. To externalize the HornetQ config, i attempted to build my own URL class loader and set it as the context loader while the code bootstrapping HornetQ is executed.

Unfortunately, my approach did not work as the class loader used in org.hornetq.core.config.impl.FileConfiguration is the one that had loaded the class FileConfiguration. 

Back to my use case, the config file are forced to be under the classpath of Tomcat.

I suggest to use context loader in FileConfiguration.
