### PR TITLE
HORNETQ-945 - NPE when stopping a MDB while it handles a message

### DIFF
--- a/src/main/org/hornetq/ra/inflow/HornetQMessageHandler.java
+++ b/src/main/org/hornetq/ra/inflow/HornetQMessageHandler.java
@@ -297,7 +297,10 @@ public class HornetQMessageHandler implements MessageHandler
          
          try
          {
-            endpoint.afterDelivery();
+            if (endpoint != null)
+            {
+               endpoint.afterDelivery();
+            }
          }
          catch (ResourceException e)
          {
@@ -346,7 +349,10 @@ public class HornetQMessageHandler implements MessageHandler
 
             try
             {
-               endpoint.afterDelivery();
+               if (endpoint != null)
+               {
+                  endpoint.afterDelivery();
+               }
             }
             catch (ResourceException e1)
             {


### PR DESCRIPTION
- check that the handler's endpoint is not null before calling it
  (this can occur if the MDB is teared down while it was handling a
  message)
