### PR TITLE
HORNETQ-945 - NPE when stopping a MDB while it handles a message

### DIFF
--- a/hornetq-ra/hornetq-ra-jar/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
+++ b/hornetq-ra/hornetq-ra-jar/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
@@ -311,7 +311,10 @@ public class HornetQMessageHandler implements MessageHandler
          
          try
          {
-            endpoint.afterDelivery();
+            if (endpoint != null)
+            {
+               endpoint.afterDelivery();
+            }
          }
          catch (ResourceException e)
          {
@@ -365,7 +368,10 @@ public class HornetQMessageHandler implements MessageHandler
 
             try
             {
-               endpoint.afterDelivery();
+               if (endpoint != null)
+               {
+                  endpoint.afterDelivery();
+               }
             }
             catch (ResourceException e1)
             {


### PR DESCRIPTION
- check that the handler's endpoint is not null before calling it (this
  can occur if the MDB is teared down while it was handling a message)
