### PR TITLE
Failover on Server Shutdown avoids threads locked trying to get permit f...

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -165,6 +165,7 @@ public abstract class FailoverTestBase extends ServiceTestBase
       backupConfig.setSharedStore(true);
       backupConfig.setBackup(true);
       backupConfig.setClustered(true);
+      backupConfig.setFailoverOnServerShutdown(true);
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
       TransportConfiguration backupConnector = getConnectorTransportConfiguration(false);
       backupConfig.getConnectorConfigurations().put(liveConnector.getName(), liveConnector);
@@ -178,6 +179,8 @@ public abstract class FailoverTestBase extends ServiceTestBase
       liveConfig.getAcceptorConfigurations().add(getAcceptorTransportConfiguration(true));
       liveConfig.setSharedStore(true);
       liveConfig.setClustered(true);
+      liveConfig.setFailoverOnServerShutdown(true);
+
       ReplicatedBackupUtils.createClusterConnectionConf(liveConfig, liveConnector.getName());
       liveConfig.getConnectorConfigurations().put(liveConnector.getName(), liveConnector);
       liveServer = createTestableServer(liveConfig);


### PR DESCRIPTION
While this fixes the thread left trying to get a permit the test FailoverTest.testFailBack() still fails.
