### PR TITLE
A (live) server stopping for fail-back should stop with stop(true)

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/config/Configuration.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/config/Configuration.java
@@ -430,13 +430,19 @@ public interface Configuration extends Serializable
    String getClusterPassword();
 
    /**
-    * should we notify any clients on close that they should failover
+    * Should we notify any clients on close that they should failover.
+    * @see #setFailoverOnServerShutdown(boolean)
     * @return true if clients should failover
     */
    boolean isFailoverOnServerShutdown();
 
    /**
     * Sets whether to allow clients to failover on server shutdown.
+    * <p>
+    * When a live server is restarted after failover the backup will shutdown if
+    * {@link #isAllowAutoFailBack()} is true. This is not regarded as a normal shutdown. In this
+    * case {@code failoverOnServerShutdown} is ignored, and the server will behave as if it was set
+    * to {@code true}.
     */
    void setFailoverOnServerShutdown(boolean failoverOnServerShutdown);
 

--- a/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -2426,7 +2426,7 @@ public class HornetQServerImpl implements HornetQServer
                         // we delay stopping the server in order to allow the backup to announce
                         // itself.
                         Thread.sleep(5000);
-                        stop();
+                        stop(true);
                      }
                      catch (Exception e)
                      {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -165,7 +165,6 @@ public abstract class FailoverTestBase extends ServiceTestBase
       backupConfig.setSharedStore(true);
       backupConfig.setBackup(true);
       backupConfig.setClustered(true);
-      backupConfig.setFailoverOnServerShutdown(true);
       backupConfig.setFailbackDelay(1000);
 
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
@@ -182,7 +181,6 @@ public abstract class FailoverTestBase extends ServiceTestBase
       liveConfig.getAcceptorConfigurations().add(getAcceptorTransportConfiguration(true));
       liveConfig.setSharedStore(true);
       liveConfig.setClustered(true);
-      liveConfig.setFailoverOnServerShutdown(true);
       liveConfig.setFailbackDelay(1000);
 
       ReplicatedBackupUtils.createClusterConnectionConf(liveConfig, liveConnector.getName());


### PR DESCRIPTION
This should happen regardless of the FailoverOnServerShutdown setting.
