### PR TITLE
Fix FailoverTest : put some delay between server start() and stop() to avoid the two calls being called too closely.

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
@@ -610,6 +610,8 @@ public class FailoverTest extends FailoverTestBase
       backupServer.stop(); // Backup stops!
       beforeRestart(backupServer);
       backupServer.start();
+      Thread.yield();
+      Thread.sleep(20);//https://community.jboss.org/message/744585
       backupServer.stop(); // Backup stops!
 
       liveServer.stop();


### PR DESCRIPTION
Fix FailoverTest : put some delay between server start() and stop() to avoid the two calls being called too closely.
