### PR TITLE
Fix untable test -- Change the cluster start up order from backup->live to live->backup

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ClusterWithBackupFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ClusterWithBackupFailoverTestBase.java
@@ -326,7 +326,7 @@ public abstract class ClusterWithBackupFailoverTestBase extends ClusterTestBase
    {
       setupCluster();
 
-      startServers(3, 4, 5, 0, 1, 2);
+      startServers(0, 1, 2, 3, 4, 5);
 
       setupSessionFactory(0, 3, isNetty(), false);
       setupSessionFactory(1, 4, isNetty(), false);


### PR DESCRIPTION
The reason: In the test it starts a 3 live-backup cluster. First it starts the backups and then the lives. Then immediately three connections are created to each of the three live nodes. Because of the internal discovery implementation, if you start live servers after its backups, the live may take some time to receive the first broadcast from the backup. So by the time the live server is started, we can't be sure it has its backup in its topology. If a ClientSessionFactory is then created on to the live right after,
the session factory may not be able to receive the backup connector information. So in the following tests, when the live is stopped and we expect the session factory to failover, it will never happen because it doesn't have the backup information-- it just keep reconnecting to the same 'dead' live server forever, until timeout and test failed. By simply change the startup order we can make sure the backup broadcasting
its topology to its live after the cluster is started.
