### PR TITLE
Cancel fail-back checker restart if server is stopped

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
@@ -670,8 +670,6 @@ public class FailoverTest extends FailoverTestBase
             Thread.sleep(100);
          }
          assertFalse("Backup should stop!", backupServer.isStarted());
-         // TODO: get rid of this, the activation has a race if we stop the server too soon
-         Thread.sleep(1000);
       }
       else
       {
@@ -679,7 +677,6 @@ public class FailoverTest extends FailoverTestBase
          beforeRestart(backupServer);
          backupServer.start();
          backupServer.getServer().waitForInitialization(10, TimeUnit.SECONDS);
-         Thread.sleep(1000);
       }
 
       ClientSession session2 = createSession(sf, false, false);


### PR DESCRIPTION
This is the cause of the start/stop 'race' in fail-back tests.  
