### PR TITLE
Some concurrency fixes at the backup start-up cause a NPE here,

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/ClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/ClusterTestBase.java
@@ -264,6 +264,13 @@ public abstract class ClusterTestBase extends ServiceTestBase
 
       long start = System.currentTimeMillis();
 
+      final int waitMillis = 2000;
+      final int sleepTime = 50;
+      int nWaits = 0;
+      while (server.getClusterManager() == null && nWaits++ < waitMillis / sleepTime)
+      {
+         Thread.sleep(sleepTime);
+      }
       Set<ClusterConnection> ccs = server.getClusterManager().getClusterConnections();
 
       if (ccs.size() != 1)


### PR DESCRIPTION
The issue is: the backup returns isStarted()=true, but it has no clusterManager yet.
