### PR TITLE
replication fixes

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -2214,6 +2214,9 @@ public class HornetQServerImpl implements HornetQServer
             serverLocator0.setReconnectAttempts(-1);
             serverLocator0.setInitialConnectAttempts(-1);
 
+            if (!initialisePart1())
+               return;
+
             synchronized (this)
             {
                if (closed)
@@ -2233,10 +2236,7 @@ public class HornetQServerImpl implements HornetQServer
 
             nodeManager.startBackup();
 
-            if (!initialisePart1())
-               return;
             clusterManager.start();
-
 
             replicationEndpoint.setQuorumManager(quorumManager);
 

--- a/hornetq-core/src/main/java/org/hornetq/core/server/impl/QuorumManager.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/server/impl/QuorumManager.java
@@ -21,7 +21,6 @@ import org.hornetq.core.client.impl.ServerLocatorImpl;
 import org.hornetq.core.client.impl.Topology;
 import org.hornetq.core.client.impl.TopologyMember;
 import org.hornetq.core.protocol.core.CoreRemotingConnection;
-import org.hornetq.core.remoting.CloseListener;
 import org.hornetq.core.remoting.FailureListener;
 import org.hornetq.core.server.HornetQLogger;
 
@@ -32,7 +31,7 @@ import org.hornetq.core.server.HornetQLogger;
  * quorum will help a remote backup deciding whether to replace its 'live' server or to keep trying
  * to reconnect.
  */
-public final class QuorumManager implements FailureListener, CloseListener, ClusterTopologyListener
+public final class QuorumManager implements FailureListener, ClusterTopologyListener
 {
    private String targetServerID = "";
    private final ExecutorService executor;
@@ -46,6 +45,8 @@ public final class QuorumManager implements FailureListener, CloseListener, Clus
    /** safety parameter to make _sure_ we get out of await() */
    private static final int LATCH_TIMEOUT = 30;
    private static final int RECONNECT_ATTEMPTS = 5;
+
+   private final Object decisionGuard = new Object();
 
    public QuorumManager(ServerLocator serverLocator, ExecutorService executor, String identity)
    {
@@ -251,29 +252,30 @@ public final class QuorumManager implements FailureListener, CloseListener, Clus
 
    private void decideOnAction()
    {
-      if (signal != null)
-         return;
-      // Check if connection was reestablished by the sessionFactory:
-      if (sessionFactory.numConnections() > 0)
+      //we may get called via multiple paths so need to guard
+      synchronized (decisionGuard)
       {
-         return;
-      }
-      if (!isLiveDown())
-      {
-         try
+         if(signal == BACKUP_ACTIVATION.FAIL_OVER)
          {
-            // no point in repeating all the reconnection logic
-            sessionFactory.connect(RECONNECT_ATTEMPTS, false);
             return;
          }
-         catch (HornetQException e)
+         if (!isLiveDown())
          {
-            if (e.getType() != HornetQExceptionType.NOT_CONNECTED)
-               HornetQLogger.LOGGER.errorReConnecting(e);
+            try
+            {
+               // no point in repeating all the reconnection logic
+               sessionFactory.connect(RECONNECT_ATTEMPTS, false);
+               return;
+            }
+            catch (HornetQException e)
+            {
+               if (e.getType() != HornetQExceptionType.NOT_CONNECTED)
+                  HornetQLogger.LOGGER.errorReConnecting(e);
+            }
          }
+         // live is assumed to be down, backup fails-over
+         signal = BACKUP_ACTIVATION.FAIL_OVER;
       }
-      // live is assumed to be down, backup fails-over
-      signal = BACKUP_ACTIVATION.FAIL_OVER;
       latch.countDown();
    }
 
@@ -316,7 +318,6 @@ public final class QuorumManager implements FailureListener, CloseListener, Clus
       if (connection == null)
          return;
       connection.removeFailureListener(this);
-      connection.removeCloseListener(this);
    }
 
    /**
@@ -344,16 +345,11 @@ public final class QuorumManager implements FailureListener, CloseListener, Clus
    {
       this.connection = liveConnection;
       connection.addFailureListener(this);
-      connection.addCloseListener(this);
+      //connection.addCloseListener(this);
    }
 
    public synchronized void reset()
    {
       latch = new CountDownLatch(1);
-   }
-   @Override
-   public void connectionClosed()
-   {
-      decideOnAction();
    }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/NettyReplicatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/NettyReplicatedFailoverTest.java
@@ -13,9 +13,13 @@
 
 package org.hornetq.tests.integration.cluster.failover;
 
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.core.client.impl.ClientSessionInternal;
 import org.hornetq.core.config.Configuration;
 import org.hornetq.tests.integration.cluster.util.SameProcessHornetQServer;
 import org.hornetq.tests.integration.cluster.util.TestableServer;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * A NettyReplicatedFailoverTest
@@ -35,5 +39,40 @@ public class NettyReplicatedFailoverTest extends NettyFailoverTest
    protected void createConfigs() throws Exception
    {
       createReplicatedConfigs();
+   }
+
+
+   @Override
+   protected void crash(boolean waitFailure, ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(waitFailure, sessions);
+   }
+
+   @Override
+   protected void crash(ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(sessions);
    }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/QuorumFailOverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/QuorumFailOverTest.java
@@ -12,12 +12,23 @@ import org.hornetq.tests.integration.cluster.util.BackupSyncDelay;
 
 public class QuorumFailOverTest extends StaticClusterWithBackupFailoverTest
 {
+   @Override
+   protected void setupServers() throws Exception
+   {
+      super.setupServers();
+      //we need to know who is connected to who
+      servers[0].getConfiguration().setNodeGroupName("group0");
+      servers[1].getConfiguration().setNodeGroupName("group1");
+      servers[2].getConfiguration().setNodeGroupName("group2");
+      servers[3].getConfiguration().setNodeGroupName("group0");
+      servers[4].getConfiguration().setNodeGroupName("group1");
+      servers[5].getConfiguration().setNodeGroupName("group2");
+   }
 
    public void testQuorumVoting() throws Exception
    {
       int[] liveServerIDs = new int[] { 0, 1, 2 };
       setupCluster();
-
       startServers(0, 1, 2);
       new BackupSyncDelay(servers[4], servers[1], PacketImpl.REPLICATION_SCHEDULED_FAILOVER);
       startServers(3, 4, 5);
@@ -39,6 +50,8 @@ public class QuorumFailOverTest extends StaticClusterWithBackupFailoverTest
       }
 
       waitForBindings(0, QUEUES_TESTADDRESS, 1, 1, true);
+      waitForBindings(1, QUEUES_TESTADDRESS, 1, 1, true);
+      waitForBindings(2, QUEUES_TESTADDRESS, 1, 1, true);
 
       send(0, QUEUES_TESTADDRESS, 10, false, null);
       verifyReceiveRoundRobinInSomeOrder(true, 10, 0, 1, 2);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedFailoverTest.java
@@ -13,6 +13,11 @@
 
 package org.hornetq.tests.integration.cluster.failover;
 
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.core.client.impl.ClientSessionInternal;
+
+import java.util.concurrent.TimeUnit;
+
 public class ReplicatedFailoverTest extends FailoverTest
 {
 
@@ -20,5 +25,39 @@ public class ReplicatedFailoverTest extends FailoverTest
    protected void createConfigs() throws Exception
    {
       createReplicatedConfigs();
+   }
+
+   @Override
+   protected void crash(boolean waitFailure, ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(waitFailure, sessions);
+   }
+
+   @Override
+   protected void crash(ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(sessions);
    }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedLargeMessageFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedLargeMessageFailoverTest.java
@@ -14,6 +14,11 @@
 package org.hornetq.tests.integration.cluster.failover;
 
 
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.core.client.impl.ClientSessionInternal;
+
+import java.util.concurrent.TimeUnit;
+
 /**
  * A ReplicatedLargeMessageFailoverTest
  * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
@@ -25,5 +30,39 @@ public class ReplicatedLargeMessageFailoverTest extends LargeMessageFailoverTest
    protected void createConfigs() throws Exception
    {
       createReplicatedConfigs();
+   }
+
+   @Override
+   protected void crash(boolean waitFailure, ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(waitFailure, sessions);
+   }
+
+   @Override
+   protected void crash(ClientSession... sessions) throws Exception
+   {
+      if (sessions.length > 0)
+      {
+         for (ClientSession session : sessions)
+         {
+            waitForRemoteBackup(((ClientSessionInternal)session).getSessionFactory(), 5, true, backupServer.getServer());
+         }
+      }
+      else
+      {
+         waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      }
+      super.crash(sessions);
    }
 }


### PR DESCRIPTION
1) initialise the server before creating the qourum manager as it needs the thread pools

2) since we now create a new connection per attempt the close listener on quorum manager was causing problems, I have removed it as we dont need it

3) ive alsosimplified and removed some redundant checks as they werent needed

4) changed the replication tests to wait for replication to start, after my changes i noticed a race condition, we were crashing the live server before replication had actually started
