### PR TITLE
Fix test failures and change the UDPBroadcastGroupConfiguration's constructor

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/config/UDPBroadcastGroupConfiguration.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/config/UDPBroadcastGroupConfiguration.java
@@ -38,15 +38,15 @@ public class UDPBroadcastGroupConfiguration implements BroadcastEndpointFactoryC
 
    private int groupPort;
 
-   public UDPBroadcastGroupConfiguration(final String localBindAddress,
-                                      final int localBindPort,
-                                      final String groupAddress,
-                                      final int groupPort)
+   public UDPBroadcastGroupConfiguration(final String groupAddress,
+                                         final int groupPort, 
+                                         final String localBindAddress,
+                                         final int localBindPort)
    {
-      this.localBindAddress = localBindAddress;
-      this.localBindPort = localBindPort;
       this.groupAddress = groupAddress;
       this.groupPort = groupPort;
+      this.localBindAddress = localBindAddress;
+      this.localBindPort = localBindPort;
    }
 
    public BroadcastEndpointFactory createBroadcastEndpointFactory()

--- a/hornetq-core/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
@@ -993,7 +993,7 @@ public final class FileConfigurationParser
       }
       else
       {
-         endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(localAddress, localBindPort, groupAddress, groupPort);
+         endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(groupAddress, groupPort, localAddress, localBindPort);
       }
 
       BroadcastGroupConfiguration config = new BroadcastGroupConfiguration(name, broadcastPeriod, connectorNames, endpointFactoryConfiguration);
@@ -1035,7 +1035,7 @@ public final class FileConfigurationParser
       }
       else
       {
-         endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(localBindAddress, localBindPort, groupAddress, groupPort);
+         endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(groupAddress, groupPort, localBindAddress, localBindPort);
       }
 
       DiscoveryGroupConfiguration config = new DiscoveryGroupConfiguration(name, refreshTimeout, discoveryInitialWaitTimeout, endpointFactoryConfiguration);

--- a/hornetq-ra/hornetq-ra-jar/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
+++ b/hornetq-ra/hornetq-ra-jar/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
@@ -1832,7 +1832,7 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
          {
             String localBindAddress = overrideProperties.getDiscoveryLocalBindAddress() != null ? overrideProperties.getDiscoveryLocalBindAddress()
                                                                            : raProperties.getDiscoveryLocalBindAddress();
-            endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(localBindAddress, -1, discoveryAddress, discoveryPort);
+            endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(discoveryAddress, discoveryPort, localBindAddress, -1);
          }
          else
          {
@@ -1954,7 +1954,7 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
          {
             String localBindAddress = overrideProperties.getDiscoveryLocalBindAddress() != null ? overrideProperties.getDiscoveryLocalBindAddress()
                                                                            : raProperties.getDiscoveryLocalBindAddress();
-            endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(localBindAddress, -1, discoveryAddress, discoveryPort);
+            endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(discoveryAddress, discoveryPort, localBindAddress, -1);
          }
          else
          {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/SessionFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/SessionFactoryTest.java
@@ -50,7 +50,7 @@ public class SessionFactoryTest extends ServiceTestBase
 {
    private final DiscoveryGroupConfiguration groupConfiguration =
             new DiscoveryGroupConfiguration(HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT, HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT,
-                                            new UDPBroadcastGroupConfiguration(null, -1, getUDPDiscoveryAddress(), getUDPDiscoveryPort()));
+                                            new UDPBroadcastGroupConfiguration(getUDPDiscoveryAddress(), getUDPDiscoveryPort(), null, -1));
 
    private HornetQServer liveService;
 
@@ -569,10 +569,11 @@ public class SessionFactoryTest extends ServiceTestBase
       BroadcastGroupConfiguration bcConfig1 = new BroadcastGroupConfiguration(bcGroupName,
                                                                               broadcastPeriod,
                                                                               Arrays.asList(liveTC.getName()),
-                                                                              new UDPBroadcastGroupConfiguration(                                                                              null,
-                                                                              localBindPort,
+                                                                              new UDPBroadcastGroupConfiguration(
                                                                               getUDPDiscoveryAddress(),
-                                                                              getUDPDiscoveryPort()));
+                                                                              getUDPDiscoveryPort(),
+                                                                              null,
+                                                                              localBindPort));
 
       List<BroadcastGroupConfiguration> bcConfigs1 = new ArrayList<BroadcastGroupConfiguration>();
       bcConfigs1.add(bcConfig1);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/topology/HAClientTopologyWithDiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/topology/HAClientTopologyWithDiscoveryTest.java
@@ -63,7 +63,7 @@ public class HAClientTopologyWithDiscoveryTest extends TopologyClusterTestBase
    {
       ServerLocator locator = HornetQClient.createServerLocatorWithHA(
                   new DiscoveryGroupConfiguration(HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT, HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT,
-                  new UDPBroadcastGroupConfiguration(null, -1, groupAddress, groupPort)));
+                  new UDPBroadcastGroupConfiguration(groupAddress, groupPort, null, -1)));
       locator.setBlockOnNonDurableSend(true);
       locator.setBlockOnDurableSend(true);
       addServerLocator(locator);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
@@ -119,7 +119,7 @@ public class DiscoveryTest extends UnitTestCase
 
       bg = new BroadcastGroupImpl(new FakeNodeManager(nodeID),
          RandomUtil.randomString(),
-         0,  null, new UDPBroadcastGroupConfiguration(null, -1, address1, groupPort).createBroadcastEndpointFactory());
+         0,  null, new UDPBroadcastGroupConfiguration(address1, groupPort, null, -1).createBroadcastEndpointFactory());
 
       bg.start();
 
@@ -1115,7 +1115,7 @@ public class DiscoveryTest extends UnitTestCase
                                            final int groupPort) throws Exception
    {
       return new BroadcastGroupImpl(new FakeNodeManager(nodeID), name, 0, null,
-         new UDPBroadcastGroupConfiguration(localAddress.getHostAddress(), localPort, groupAddress.getHostAddress(), groupPort).createBroadcastEndpointFactory());
+         new UDPBroadcastGroupConfiguration(groupAddress.getHostAddress(), groupPort, localAddress.getHostAddress(), localPort).createBroadcastEndpointFactory());
    }
 
    private DiscoveryGroup newDiscoveryGroup(final String nodeID, final String name, final InetAddress localBindAddress,
@@ -1128,7 +1128,7 @@ public class DiscoveryTest extends UnitTestCase
                                             final InetAddress groupAddress, final int groupPort, final long timeout, NotificationService notif) throws Exception
    {
       return new DiscoveryGroup(nodeID, name, timeout, 
-            new UDPBroadcastGroupConfiguration(localBindAddress.getHostAddress(), -1, groupAddress.getHostAddress(), groupPort).createBroadcastEndpointFactory(), notif);
+            new UDPBroadcastGroupConfiguration(groupAddress.getHostAddress(), groupPort, localBindAddress.getHostAddress(), -1).createBroadcastEndpointFactory(), notif);
    }
 
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/HornetQConnectionFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/HornetQConnectionFactoryTest.java
@@ -159,7 +159,7 @@ public class HornetQConnectionFactoryTest extends UnitTestCase
    public void testDiscoveryConstructor() throws Exception
    {
       DiscoveryGroupConfiguration groupConfiguration = new DiscoveryGroupConfiguration(HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT, HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT,
-            new UDPBroadcastGroupConfiguration(null, -1, groupAddress, groupPort));
+            new UDPBroadcastGroupConfiguration(groupAddress, groupPort, null, -1));
       HornetQConnectionFactory cf = HornetQJMSClient.createConnectionFactoryWithoutHA(groupConfiguration, JMSFactoryType.CF);
       assertFactoryParams(cf,
                           null,
@@ -717,7 +717,7 @@ public class HornetQConnectionFactoryTest extends UnitTestCase
       BroadcastGroupConfiguration bcConfig1 = new BroadcastGroupConfiguration(bcGroupName,
                                                                               broadcastPeriod,
                                                                               connectorNames,
-                                              new UDPBroadcastGroupConfiguration(null, localBindPort, groupAddress, groupPort));
+                                              new UDPBroadcastGroupConfiguration(groupAddress, groupPort, null, localBindPort));
 
       List<BroadcastGroupConfiguration> bcConfigs1 = new ArrayList<BroadcastGroupConfiguration>();
       bcConfigs1.add(bcConfig1);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/JMSServerDeployerTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/JMSServerDeployerTest.java
@@ -341,8 +341,8 @@ public class JMSServerDeployerTest extends ServiceTestBase
 
       DiscoveryGroupConfiguration dcg = new DiscoveryGroupConfiguration("mygroup",
                                                                         5432, 5432,
-                                                                        new UDPBroadcastGroupConfiguration("172.16.8.10", -1,
-                                                                        "243.7.7.7", 12345));
+                                                                        new UDPBroadcastGroupConfiguration("243.7.7.7", 12345,
+                                                                        "172.16.8.10", -1));
       config.getDiscoveryGroupConfigurations().put("mygroup", dcg);
       HornetQServer server = createServer(false, config);
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/BroadcastGroupControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/BroadcastGroupControlTest.java
@@ -44,7 +44,7 @@ public class BroadcastGroupControlTest extends ManagementTestBase
       return new BroadcastGroupConfiguration(RandomUtil.randomString(),
                                              RandomUtil.randomPositiveInt(),
                                              connectorInfos,
-                                             new UDPBroadcastGroupConfiguration(null, 1198, "231.7.7.7", 1199));
+                                             new UDPBroadcastGroupConfiguration("231.7.7.7", 1199, null, 1198));
    }
 
    public static Pair<String, String> randomPair()

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ClusterConnectionControl2Test.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ClusterConnectionControl2Test.java
@@ -122,11 +122,11 @@ public class ClusterConnectionControl2Test extends ManagementTestBase
       BroadcastGroupConfiguration broadcastGroupConfig = new BroadcastGroupConfiguration(discoveryName,
                                                                                          250,
                                                                                          connectorInfos,
-                                             new UDPBroadcastGroupConfiguration(null, -1, groupAddress, groupPort));
+                                             new UDPBroadcastGroupConfiguration(groupAddress, groupPort, null, -1));
       DiscoveryGroupConfiguration discoveryGroupConfig = new DiscoveryGroupConfiguration(discoveryName,
                                                                                          0,
                                                                                          0,
-                                             new UDPBroadcastGroupConfiguration(null, -1, groupAddress, groupPort));
+                                             new UDPBroadcastGroupConfiguration(groupAddress, groupPort, null, -1));
 
       Configuration conf_1 = createBasicConfig();
       conf_1.setSecurityEnabled(false);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ClusterConnectionControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ClusterConnectionControlTest.java
@@ -206,7 +206,7 @@ public class ClusterConnectionControlTest extends ManagementTestBase
       String discoveryGroupName = RandomUtil.randomString();
       DiscoveryGroupConfiguration discoveryGroupConfig =
                new DiscoveryGroupConfiguration(discoveryGroupName, 500, 0,
-                     new UDPBroadcastGroupConfiguration(null, -1, "230.1.2.3", 6745));
+                     new UDPBroadcastGroupConfiguration("230.1.2.3", 6745, null, -1));
 
       Configuration conf_1 = createBasicConfig();
       conf_1.setSecurityEnabled(false);


### PR DESCRIPTION
Change the order of parameters of UDPBroadcastGroupConfiguration's constructor to be groupAddress, groupPort, localAddress, localPort.
