### PR TITLE
HORNETQ-1043 - ClientRequestor.close() should not close the underlying s...

### DIFF
--- a/src/main/org/hornetq/api/core/client/ClientRequestor.java
+++ b/src/main/org/hornetq/api/core/client/ClientRequestor.java
@@ -104,7 +104,7 @@ public class ClientRequestor
    {
       replyConsumer.close();
       queueSession.deleteQueue(replyQueue);
-      queueSession.close();
+      requestProducer.close();
    }
 
 }


### PR DESCRIPTION
...ession and it should close the producer
