### PR TITLE
Remove extra byte-copy on FrameDecoder implementation

### DIFF
--- a/hornetq-core/src/main/java/org/hornetq/core/remoting/impl/netty/HornetQFrameDecoder.java
+++ b/hornetq-core/src/main/java/org/hornetq/core/remoting/impl/netty/HornetQFrameDecoder.java
@@ -55,13 +55,10 @@ public class HornetQFrameDecoder extends FrameDecoder
       {
          return null;
       }
-      
-      ChannelBuffer buffer = in.readBytes(length);
 
-      ChannelBuffer newBuffer = ChannelBuffers.dynamicBuffer(buffer.writerIndex());
+      ChannelBuffer newBuffer = ChannelBuffers.dynamicBuffer(length);
+      newBuffer.writeBytes(in, length);
 
-      newBuffer.writeBytes(buffer);
-      
       return newBuffer;
    }
 }


### PR DESCRIPTION
In HornetQ's FrameDecoder implementation one unnecessary byte copy is done. This can be removed and so frame processing optimized.
