### PR TITLE
Change version from *.BETA1 to *.BETA-SNAPSHOT

### DIFF
--- a/distribution/hornetq/pom.xml
+++ b/distribution/hornetq/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-distribution</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq</artifactId>

--- a/distribution/jboss-mc/pom.xml
+++ b/distribution/jboss-mc/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-distribution</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>jboss-mc</artifactId>

--- a/distribution/jnp-client/pom.xml
+++ b/distribution/jnp-client/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-distribution</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>jnp-client</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-distribution</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <groupId>org.hornetq.docs</groupId>

--- a/docs/quickstart-guide/pom.xml
+++ b/docs/quickstart-guide/pom.xml
@@ -8,7 +8,7 @@
    <parent>
       <groupId>org.hornetq.docs</groupId>
       <artifactId>hornetq-docs</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
 	<groupId>org.hornetq.docs</groupId>

--- a/docs/rest-manual/pom.xml
+++ b/docs/rest-manual/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.hornetq.docs</groupId>
       <artifactId>hornetq-docs</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
 	<groupId>org.hornetq.docs</groupId>

--- a/docs/user-manual/pom.xml
+++ b/docs/user-manual/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.hornetq.docs</groupId>
       <artifactId>hornetq-docs</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
 	<groupId>org.hornetq.docs</groupId>

--- a/examples/jms/application-layer-failover/pom.xml
+++ b/examples/jms/application-layer-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-application-layer-failover-example</artifactId>

--- a/examples/jms/bridge/pom.xml
+++ b/examples/jms/bridge/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-bridge-example</artifactId>

--- a/examples/jms/browser/pom.xml
+++ b/examples/jms/browser/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-browser-example</artifactId>

--- a/examples/jms/client-kickoff/pom.xml
+++ b/examples/jms/client-kickoff/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-client-kickoff-example</artifactId>

--- a/examples/jms/client-side-failoverlistener/pom.xml
+++ b/examples/jms/client-side-failoverlistener/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-client-side-fileoverlistener-example</artifactId>

--- a/examples/jms/client-side-load-balancing/pom.xml
+++ b/examples/jms/client-side-load-balancing/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-client-side-load-balancing-example</artifactId>

--- a/examples/jms/clustered-durable-subscription/pom.xml
+++ b/examples/jms/clustered-durable-subscription/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-durable-subscription-example</artifactId>

--- a/examples/jms/clustered-grouping/pom.xml
+++ b/examples/jms/clustered-grouping/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-grouping-example</artifactId>

--- a/examples/jms/clustered-queue/pom.xml
+++ b/examples/jms/clustered-queue/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-queue</artifactId>

--- a/examples/jms/clustered-standalone/pom.xml
+++ b/examples/jms/clustered-standalone/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-standalone-example</artifactId>

--- a/examples/jms/clustered-static-discovery/pom.xml
+++ b/examples/jms/clustered-static-discovery/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-static-discovery-example</artifactId>

--- a/examples/jms/clustered-static-oneway/pom.xml
+++ b/examples/jms/clustered-static-oneway/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-static-oneway-example</artifactId>

--- a/examples/jms/clustered-topic/pom.xml
+++ b/examples/jms/clustered-topic/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-clustered-topic-example</artifactId>

--- a/examples/jms/common/pom.xml
+++ b/examples/jms/common/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>common</artifactId>

--- a/examples/jms/consumer-rate-limit/pom.xml
+++ b/examples/jms/consumer-rate-limit/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-consumer-rate-limit-example</artifactId>

--- a/examples/jms/dead-letter/pom.xml
+++ b/examples/jms/dead-letter/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-dead-letter-example</artifactId>

--- a/examples/jms/delayed-redelivery/pom.xml
+++ b/examples/jms/delayed-redelivery/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-delayed-redelivery-example</artifactId>

--- a/examples/jms/divert/pom.xml
+++ b/examples/jms/divert/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-divert-example</artifactId>

--- a/examples/jms/durable-subscription/pom.xml
+++ b/examples/jms/durable-subscription/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-durable-subscription-example</artifactId>

--- a/examples/jms/embedded-simple/pom.xml
+++ b/examples/jms/embedded-simple/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-embedded-simple-example</artifactId>

--- a/examples/jms/embedded/pom.xml
+++ b/examples/jms/embedded/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-embedded-example</artifactId>

--- a/examples/jms/expiry/pom.xml
+++ b/examples/jms/expiry/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-expiry-example</artifactId>

--- a/examples/jms/http-transport/pom.xml
+++ b/examples/jms/http-transport/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-http-transport-example</artifactId>

--- a/examples/jms/instantiate-connection-factory/pom.xml
+++ b/examples/jms/instantiate-connection-factory/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-instantiate-connection-factory-example</artifactId>

--- a/examples/jms/interceptor/pom.xml
+++ b/examples/jms/interceptor/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-interceptor-example</artifactId>

--- a/examples/jms/jms-bridge/pom.xml
+++ b/examples/jms/jms-bridge/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-jms-bridge-example</artifactId>

--- a/examples/jms/jmx/pom.xml
+++ b/examples/jms/jmx/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-jmx-example</artifactId>

--- a/examples/jms/large-message/pom.xml
+++ b/examples/jms/large-message/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-large-message-example</artifactId>

--- a/examples/jms/last-value-queue/pom.xml
+++ b/examples/jms/last-value-queue/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-last-value-queue-example</artifactId>

--- a/examples/jms/management-notifications/pom.xml
+++ b/examples/jms/management-notifications/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-management-notifications-example</artifactId>

--- a/examples/jms/management/pom.xml
+++ b/examples/jms/management/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-management-example</artifactId>

--- a/examples/jms/message-counters/pom.xml
+++ b/examples/jms/message-counters/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-message-counters-example</artifactId>

--- a/examples/jms/message-group/pom.xml
+++ b/examples/jms/message-group/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-message-group-example</artifactId>

--- a/examples/jms/message-group2/pom.xml
+++ b/examples/jms/message-group2/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-message-group2-example</artifactId>

--- a/examples/jms/message-priority/pom.xml
+++ b/examples/jms/message-priority/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-message-priority-example</artifactId>

--- a/examples/jms/multiple-failover-failback/pom.xml
+++ b/examples/jms/multiple-failover-failback/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-multiple-failover-failback-example</artifactId>

--- a/examples/jms/multiple-failover/pom.xml
+++ b/examples/jms/multiple-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-multiple-failover-example</artifactId>

--- a/examples/jms/no-consumer-buffering/pom.xml
+++ b/examples/jms/no-consumer-buffering/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-no-consumer-buffering-example</artifactId>

--- a/examples/jms/non-transaction-failover/pom.xml
+++ b/examples/jms/non-transaction-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>non-transaction-failover</artifactId>

--- a/examples/jms/paging/pom.xml
+++ b/examples/jms/paging/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-paging-example</artifactId>

--- a/examples/jms/pom.xml
+++ b/examples/jms/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples</groupId>
       <artifactId>hornetq-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <groupId>org.hornetq.examples.jms</groupId>

--- a/examples/jms/producer-rate-limit/pom.xml
+++ b/examples/jms/producer-rate-limit/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-producer-rate-limit-example</artifactId>

--- a/examples/jms/queue-message-redistribution/pom.xml
+++ b/examples/jms/queue-message-redistribution/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-queue-message-redistribution-example</artifactId>

--- a/examples/jms/queue-requestor/pom.xml
+++ b/examples/jms/queue-requestor/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-queue-requestor-example</artifactId>

--- a/examples/jms/queue-selector/pom.xml
+++ b/examples/jms/queue-selector/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-queue-selector-example</artifactId>

--- a/examples/jms/queue/pom.xml
+++ b/examples/jms/queue/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-queue-example</artifactId>

--- a/examples/jms/reattach-node/pom.xml
+++ b/examples/jms/reattach-node/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-reattach-node-example</artifactId>

--- a/examples/jms/replicated-multiple-failover/pom.xml
+++ b/examples/jms/replicated-multiple-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-replicated-multiple-failover-example</artifactId>

--- a/examples/jms/replicated-transaction-failover/pom.xml
+++ b/examples/jms/replicated-transaction-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-replicated-transaction-failover-example</artifactId>

--- a/examples/jms/request-reply/pom.xml
+++ b/examples/jms/request-reply/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-request-reply-example</artifactId>

--- a/examples/jms/scheduled-message/pom.xml
+++ b/examples/jms/scheduled-message/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-scheduled-message-example</artifactId>

--- a/examples/jms/security/pom.xml
+++ b/examples/jms/security/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-security-example</artifactId>

--- a/examples/jms/send-acknowledgements/pom.xml
+++ b/examples/jms/send-acknowledgements/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-send-acknowledgements-example</artifactId>

--- a/examples/jms/spring-integration/pom.xml
+++ b/examples/jms/spring-integration/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-spring-integration-example</artifactId>

--- a/examples/jms/ssl-enabled/pom.xml
+++ b/examples/jms/ssl-enabled/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-ssl-enabled-example</artifactId>

--- a/examples/jms/stomp/pom.xml
+++ b/examples/jms/stomp/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-stomp-example</artifactId>

--- a/examples/jms/stomp1.1/pom.xml
+++ b/examples/jms/stomp1.1/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-stomp1.1-example</artifactId>

--- a/examples/jms/symmetric-cluster/pom.xml
+++ b/examples/jms/symmetric-cluster/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-symmetric-cluster-example</artifactId>

--- a/examples/jms/temp-queue/pom.xml
+++ b/examples/jms/temp-queue/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-temp-queue-example</artifactId>

--- a/examples/jms/topic-hierarchies/pom.xml
+++ b/examples/jms/topic-hierarchies/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-topic-hierarchies-example</artifactId>

--- a/examples/jms/topic-selector-example1/pom.xml
+++ b/examples/jms/topic-selector-example1/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-topic-selector-example1-example</artifactId>

--- a/examples/jms/topic-selector-example2/pom.xml
+++ b/examples/jms/topic-selector-example2/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-topic-selector-example2-example</artifactId>

--- a/examples/jms/topic/pom.xml
+++ b/examples/jms/topic/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-topic-example</artifactId>

--- a/examples/jms/transaction-failover/pom.xml
+++ b/examples/jms/transaction-failover/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-transaction-failover-example</artifactId>

--- a/examples/jms/transactional/pom.xml
+++ b/examples/jms/transactional/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-transactional-example</artifactId>

--- a/examples/jms/xa-heuristic/pom.xml
+++ b/examples/jms/xa-heuristic/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-xa-heuristic-example</artifactId>

--- a/examples/jms/xa-receive/pom.xml
+++ b/examples/jms/xa-receive/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-xa-receive-example</artifactId>

--- a/examples/jms/xa-send/pom.xml
+++ b/examples/jms/xa-send/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-xa-send-example</artifactId>

--- a/examples/jms/xa-with-jta/pom.xml
+++ b/examples/jms/xa-with-jta/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq.examples.jms</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-xa-with-jta-example</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <groupId>org.hornetq.examples</groupId>

--- a/hornetq-bootstrap/pom.xml
+++ b/hornetq-bootstrap/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
     <artifactId>hornetq-bootstrap</artifactId>

--- a/hornetq-commons/pom.xml
+++ b/hornetq-commons/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-commons</artifactId>

--- a/hornetq-core-client/pom.xml
+++ b/hornetq-core-client/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-core-client</artifactId>

--- a/hornetq-core/pom.xml
+++ b/hornetq-core/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-core</artifactId>

--- a/hornetq-jboss-as-integration/pom.xml
+++ b/hornetq-jboss-as-integration/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jboss-as-integration</artifactId>

--- a/hornetq-jms-client/pom.xml
+++ b/hornetq-jms-client/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-jms-client</artifactId>

--- a/hornetq-jms/pom.xml
+++ b/hornetq-jms/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
     <artifactId>hornetq-jms</artifactId>

--- a/hornetq-journal/pom.xml
+++ b/hornetq-journal/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-journal</artifactId>

--- a/hornetq-ra/pom.xml
+++ b/hornetq-ra/pom.xml
@@ -6,7 +6,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-ra</artifactId>

--- a/hornetq-rest/pom.xml
+++ b/hornetq-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.hornetq</groupId>
         <artifactId>hornetq-pom</artifactId>
-        <version>2.3.0.BETA1</version>
+        <version>2.3.0.BETA-SNAPSHOT</version>
     </parent>
 
     <name>HornetQ REST Interface Implementation</name>

--- a/hornetq-server/pom.xml
+++ b/hornetq-server/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>hornetq-server</artifactId>

--- a/hornetq-service-sar/pom.xml
+++ b/hornetq-service-sar/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
     <artifactId>hornetq-service-sar</artifactId>

--- a/hornetq-spring-integration/pom.xml
+++ b/hornetq-spring-integration/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
     <artifactId>hornetq-spring-integration</artifactId>

--- a/hornetq-twitter-integration/pom.xml
+++ b/hornetq-twitter-integration/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
     <artifactId>hornetq-twitter-integration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>org.hornetq</groupId>
    <artifactId>hornetq-pom</artifactId>
    <packaging>pom</packaging>
-   <version>2.3.0.BETA1</version>
+   <version>2.3.0.BETA-SNAPSHOT</version>
 
    <name>HornetQ Parent</name>
    <url>http://hornetq.org</url>

--- a/tests/concurrent-tests/pom.xml
+++ b/tests/concurrent-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>concurrent-tests</artifactId>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>integration-tests</artifactId>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>jms-tests</artifactId>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>joram-tests</artifactId>

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>performance-tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <groupId>org.hornetq</groupId>
       <artifactId>hornetq-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
    <name>HornetQ Tests POM</name>
    <modelVersion>4.0.0</modelVersion>

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>soak-tests</artifactId>

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>stress-tests</artifactId>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -17,7 +17,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>timing-tests</artifactId>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.hornetq.tests</groupId>
       <artifactId>hornetq-tests-pom</artifactId>
-      <version>2.3.0.BETA1</version>
+      <version>2.3.0.BETA-SNAPSHOT</version>
    </parent>
 
    <artifactId>unit-tests</artifactId>


### PR DESCRIPTION
The core/client split and the changes in the location of our default values are breaking AS7 compilation
