### PR TITLE
maven: Remove duplicate version declaration of hornetq-maven-plugin

### DIFF
--- a/examples/jms/applet/pom.xml
+++ b/examples/jms/applet/pom.xml
@@ -33,7 +33,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/application-layer-failover/pom.xml
+++ b/examples/jms/application-layer-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/bridge/pom.xml
+++ b/examples/jms/bridge/pom.xml
@@ -34,7 +34,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/browser/pom.xml
+++ b/examples/jms/browser/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/client-kickoff/pom.xml
+++ b/examples/jms/client-kickoff/pom.xml
@@ -34,7 +34,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/client-side-failoverlistener/pom.xml
+++ b/examples/jms/client-side-failoverlistener/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/client-side-load-balancing/pom.xml
+++ b/examples/jms/client-side-load-balancing/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-durable-subscription/pom.xml
+++ b/examples/jms/clustered-durable-subscription/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-grouping/pom.xml
+++ b/examples/jms/clustered-grouping/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-jgroups/pom.xml
+++ b/examples/jms/clustered-jgroups/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-queue/pom.xml
+++ b/examples/jms/clustered-queue/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-standalone/pom.xml
+++ b/examples/jms/clustered-standalone/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-static-discovery/pom.xml
+++ b/examples/jms/clustered-static-discovery/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-static-oneway/pom.xml
+++ b/examples/jms/clustered-static-oneway/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/clustered-topic/pom.xml
+++ b/examples/jms/clustered-topic/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/consumer-rate-limit/pom.xml
+++ b/examples/jms/consumer-rate-limit/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/dead-letter/pom.xml
+++ b/examples/jms/dead-letter/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/delayed-redelivery/pom.xml
+++ b/examples/jms/delayed-redelivery/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/divert/pom.xml
+++ b/examples/jms/divert/pom.xml
@@ -34,7 +34,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/durable-subscription/pom.xml
+++ b/examples/jms/durable-subscription/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/embedded-simple/pom.xml
+++ b/examples/jms/embedded-simple/pom.xml
@@ -39,7 +39,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>runClient</id>

--- a/examples/jms/expiry/pom.xml
+++ b/examples/jms/expiry/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/http-transport/pom.xml
+++ b/examples/jms/http-transport/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/instantiate-connection-factory/pom.xml
+++ b/examples/jms/instantiate-connection-factory/pom.xml
@@ -39,7 +39,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/interceptor/pom.xml
+++ b/examples/jms/interceptor/pom.xml
@@ -34,7 +34,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/jms-bridge/pom.xml
+++ b/examples/jms/jms-bridge/pom.xml
@@ -47,7 +47,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/jmx/pom.xml
+++ b/examples/jms/jmx/pom.xml
@@ -39,7 +39,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/large-message/pom.xml
+++ b/examples/jms/large-message/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/last-value-queue/pom.xml
+++ b/examples/jms/last-value-queue/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/management-notifications/pom.xml
+++ b/examples/jms/management-notifications/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/management/pom.xml
+++ b/examples/jms/management/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/message-counters/pom.xml
+++ b/examples/jms/message-counters/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/message-group/pom.xml
+++ b/examples/jms/message-group/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/message-group2/pom.xml
+++ b/examples/jms/message-group2/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/message-priority/pom.xml
+++ b/examples/jms/message-priority/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/multiple-failover-failback/pom.xml
+++ b/examples/jms/multiple-failover-failback/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/multiple-failover/pom.xml
+++ b/examples/jms/multiple-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/no-consumer-buffering/pom.xml
+++ b/examples/jms/no-consumer-buffering/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/non-transaction-failover/pom.xml
+++ b/examples/jms/non-transaction-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/paging/pom.xml
+++ b/examples/jms/paging/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/perf/pom.xml
+++ b/examples/jms/perf/pom.xml
@@ -60,7 +60,6 @@
                <plugin>
                   <groupId>org.hornetq</groupId>
                   <artifactId>hornetq-maven-plugin</artifactId>
-                  <version>1.0.0</version>
                   <executions>
                      <execution>
                         <id>start</id>

--- a/examples/jms/pre-acknowledge/pom.xml
+++ b/examples/jms/pre-acknowledge/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/producer-rate-limit/pom.xml
+++ b/examples/jms/producer-rate-limit/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/queue-message-redistribution/pom.xml
+++ b/examples/jms/queue-message-redistribution/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/queue-requestor/pom.xml
+++ b/examples/jms/queue-requestor/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/queue-selector/pom.xml
+++ b/examples/jms/queue-selector/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/queue/pom.xml
+++ b/examples/jms/queue/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/reattach-node/pom.xml
+++ b/examples/jms/reattach-node/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/replicated-failback-static/pom.xml
+++ b/examples/jms/replicated-failback-static/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/replicated-failback/pom.xml
+++ b/examples/jms/replicated-failback/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/replicated-multiple-failover/pom.xml
+++ b/examples/jms/replicated-multiple-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/replicated-transaction-failover/pom.xml
+++ b/examples/jms/replicated-transaction-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/request-reply/pom.xml
+++ b/examples/jms/request-reply/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/scheduled-message/pom.xml
+++ b/examples/jms/scheduled-message/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/security/pom.xml
+++ b/examples/jms/security/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/send-acknowledgements/pom.xml
+++ b/examples/jms/send-acknowledgements/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/spring-integration/pom.xml
+++ b/examples/jms/spring-integration/pom.xml
@@ -38,7 +38,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>runClient</id>

--- a/examples/jms/ssl-enabled/pom.xml
+++ b/examples/jms/ssl-enabled/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/static-selector-jms/pom.xml
+++ b/examples/jms/static-selector-jms/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/static-selector/pom.xml
+++ b/examples/jms/static-selector/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/stomp-websockets/pom.xml
+++ b/examples/jms/stomp-websockets/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/stomp/pom.xml
+++ b/examples/jms/stomp/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/stomp1.1/pom.xml
+++ b/examples/jms/stomp1.1/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/stop-server-failover/pom.xml
+++ b/examples/jms/stop-server-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/symmetric-cluster/pom.xml
+++ b/examples/jms/symmetric-cluster/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/temp-queue/pom.xml
+++ b/examples/jms/temp-queue/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/topic-hierarchies/pom.xml
+++ b/examples/jms/topic-hierarchies/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/topic-selector-example1/pom.xml
+++ b/examples/jms/topic-selector-example1/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/topic-selector-example2/pom.xml
+++ b/examples/jms/topic-selector-example2/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/topic/pom.xml
+++ b/examples/jms/topic/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/transaction-failover/pom.xml
+++ b/examples/jms/transaction-failover/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start0</id>

--- a/examples/jms/transactional/pom.xml
+++ b/examples/jms/transactional/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/xa-heuristic/pom.xml
+++ b/examples/jms/xa-heuristic/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/xa-receive/pom.xml
+++ b/examples/jms/xa-receive/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/xa-send/pom.xml
+++ b/examples/jms/xa-send/pom.xml
@@ -29,7 +29,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>

--- a/examples/jms/xa-with-jta/pom.xml
+++ b/examples/jms/xa-with-jta/pom.xml
@@ -38,7 +38,6 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
                <execution>
                   <id>start</id>


### PR DESCRIPTION
I assume that these were reintroduced by mistake during the jms --> jms-client move
