### PR TITLE
HORNETQ-1094 missing dep on hornetq-jms-server for RA

### DIFF
--- a/examples/jms/hornetq-ra-rar/pom.xml
+++ b/examples/jms/hornetq-ra-rar/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
         <dependency>
             <groupId>org.hornetq</groupId>
+            <artifactId>hornetq-jms-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hornetq</groupId>
             <artifactId>hornetq-core-client</artifactId>
             <version>${project.version}</version>
             <exclusions>


### PR DESCRIPTION
- add org.hornetq:hornetq-jms-server to HornetQ RA dependencies
