### PR TITLE
[HORNETQ-1103] Upgrade Netty to fix SSL race. Also maximal wait 30 secon...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@ Copyright 2009 Red Hat, Inc.
       <dependency>
          <groupId>org.jboss.netty</groupId>
          <artifactId>netty</artifactId>
-         <version>3.2.6.Final</version>
+         <version>3.2.7.Final</version>
       </dependency>
       <!--needed to compile the logging jar-->
       <dependency>


### PR DESCRIPTION
...ds for the handshake to complete

For this I released Netty 3.2.8.Final which should be on maven central soon. All tests still pass :)
