### PR TITLE
Replace all "/* (non-Javadoc)\n* @see ETC */" with @Override:

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientMessageImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientMessageImpl.java
@@ -143,9 +143,7 @@ public class ClientMessageImpl extends MessageImpl implements ClientMessageInter
       return "ClientMessage[messageID=" + messageID + ", durable=" + durable + ", address=" + getAddress() + ",properties=" + properties.toString() + "]";
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.client.ClientMessage#saveToOutputStream(java.io.OutputStream)
-    */
+   @Override
    public void saveToOutputStream(final OutputStream out) throws HornetQException
    {
       try
@@ -161,25 +159,19 @@ public class ClientMessageImpl extends MessageImpl implements ClientMessageInter
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.client.ClientMessage#setOutputStream(java.io.OutputStream)
-    */
+   @Override
    public void setOutputStream(final OutputStream out) throws HornetQException
    {
       saveToOutputStream(out);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.client.ClientMessage#waitOutputStreamCompletion()
-    */
+   @Override
    public boolean waitOutputStreamCompletion(final long timeMilliseconds) throws HornetQException
    {
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.client.impl.ClientMessageInternal#discardLargeBody()
-    */
+   @Override
    public void discardBody()
    {
    }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/CompressedLargeMessageControllerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/CompressedLargeMessageControllerImpl.java
@@ -25,8 +25,8 @@ import org.hornetq.api.core.HornetQBuffer;
 import org.hornetq.api.core.HornetQBuffers;
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.SimpleString;
-import org.hornetq.core.protocol.core.impl.wireformat.SessionReceiveContinuationMessage;
 import org.hornetq.core.client.HornetQClientLogger;
+import org.hornetq.core.protocol.core.impl.wireformat.SessionReceiveContinuationMessage;
 import org.hornetq.utils.DataConstants;
 import org.hornetq.utils.HornetQBufferInputStream;
 import org.hornetq.utils.InflaterReader;
@@ -202,10 +202,7 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       return (short)(getByte(index) << 8 | getByte(index + 1) & 0xFF);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getUnsignedMedium(int)
-    */
-   public int getUnsignedMedium(final int index)
+   private int getUnsignedMedium(final int index)
    {
       positioningNotSupported();
       return 0;
@@ -217,98 +214,50 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setByte(int, byte)
-    */
+   @Override
    public void setByte(final int index, final byte value)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, org.hornetq.api.core.buffers.ChannelBuffer, int, int)
-    */
+   @Override
    public void setBytes(final int index, final HornetQBuffer src, final int srcIndex, final int length)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, byte[], int, int)
-    */
+   @Override
    public void setBytes(final int index, final byte[] src, final int srcIndex, final int length)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.nio.ByteBuffer)
-    */
+   @Override
    public void setBytes(final int index, final ByteBuffer src)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.io.InputStream, int)
-    */
-   public int setBytes(final int index, final InputStream in, final int length) throws IOException
-   {
-      throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.nio.channels.ScatteringByteChannel, int)
-    */
-   public int setBytes(final int index, final ScatteringByteChannel in, final int length) throws IOException
-   {
-      throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setInt(int, int)
-    */
+   @Override
    public void setInt(final int index, final int value)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setLong(int, long)
-    */
+   @Override
    public void setLong(final int index, final long value)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setMedium(int, int)
-    */
-   public void setMedium(final int index, final int value)
-   {
-      throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setShort(int, short)
-    */
+   @Override
    public void setShort(final int index, final short value)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#toByteBuffer(int, int)
-    */
+   @Override
    public ByteBuffer toByteBuffer(final int index, final int length)
-   {
-      throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#toString(int, int, java.lang.String)
-    */
-   public String toString(final int index, final int length, final String charsetName)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
@@ -724,17 +673,13 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       return this;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readBoolean()
-    */
+   @Override
    public boolean readBoolean()
    {
       return readByte() != 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readChar()
-    */
+   @Override
    public char readChar()
    {
       return (char)readShort();
@@ -762,25 +707,19 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       return HornetQBuffers.wrappedBuffer(bytesToGet);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readDouble()
-    */
+   @Override
    public double readDouble()
    {
       return Double.longBitsToDouble(readLong());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readFloat()
-    */
+   @Override
    public float readFloat()
    {
       return Float.intBitsToFloat(readInt());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readNullableSimpleString()
-    */
+   @Override
    public SimpleString readNullableSimpleString()
    {
       int b = readByte();
@@ -794,9 +733,7 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readNullableString()
-    */
+   @Override
    public String readNullableString()
    {
       int b = readByte();
@@ -810,9 +747,7 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readSimpleString()
-    */
+   @Override
    public SimpleString readSimpleString()
    {
       int len = readInt();
@@ -821,9 +756,7 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       return new SimpleString(data);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readString()
-    */
+   @Override
    public String readString()
    {
       int len = readInt();
@@ -847,83 +780,63 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readUTF()
-    */
+   @Override
    public String readUTF()
    {
       return UTF8Util.readUTF(this);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeBoolean(boolean)
-    */
+   @Override
    public void writeBoolean(final boolean val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeChar(char)
-    */
+   @Override
    public void writeChar(final char val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeDouble(double)
-    */
+   @Override
    public void writeDouble(final double val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeFloat(float)
-    */
+   @Override
    public void writeFloat(final float val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeNullableSimpleString(org.hornetq.util.SimpleString)
-    */
+   @Override
    public void writeNullableSimpleString(final SimpleString val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeNullableString(java.lang.String)
-    */
+   @Override
    public void writeNullableString(final String val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeSimpleString(org.hornetq.util.SimpleString)
-    */
+   @Override
    public void writeSimpleString(final SimpleString val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeString(java.lang.String)
-    */
+   @Override
    public void writeString(final String val)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeUTF(java.lang.String)
-    */
+   @Override
    public void writeUTF(final String utf)
    {
       throw new IllegalAccessError(OPERATION_NOT_SUPPORTED);

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/LargeMessageControllerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/LargeMessageControllerImpl.java
@@ -32,10 +32,10 @@ import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.HornetQExceptionType;
 import org.hornetq.api.core.HornetQInterruptedException;
 import org.hornetq.api.core.SimpleString;
-import org.hornetq.core.protocol.core.Packet;
-import org.hornetq.core.protocol.core.impl.wireformat.SessionReceiveContinuationMessage;
 import org.hornetq.core.client.HornetQClientLogger;
 import org.hornetq.core.client.HornetQClientMessageBundle;
+import org.hornetq.core.protocol.core.Packet;
+import org.hornetq.core.protocol.core.impl.wireformat.SessionReceiveContinuationMessage;
 import org.hornetq.utils.DataConstants;
 import org.hornetq.utils.UTF8Util;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -397,17 +397,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
 
    // Channel Buffer Implementation ---------------------------------
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#array()
-    */
-   public byte[] array()
-   {
-      throw new IllegalAccessError("array not supported on LargeMessageBufferImpl");
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#capacity()
-    */
+   @Override
    public int capacity()
    {
       return -1;
@@ -418,9 +408,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return getByte(readerIndex++);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getByte(int)
-    */
+   @Override
    public byte getByte(final int index)
    {
       return getByte((long)index);
@@ -440,9 +428,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getBytes(int, org.hornetq.api.core.buffers.ChannelBuffer, int, int)
-    */
+   @Override
    public void getBytes(final int index, final HornetQBuffer dst, final int dstIndex, final int length)
    {
       byte[] destBytes = new byte[length];
@@ -450,19 +436,14 @@ public class LargeMessageControllerImpl implements LargeMessageController
       dst.setBytes(dstIndex, destBytes);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getBytes(int, org.hornetq.api.core.buffers.ChannelBuffer, int, int)
-    */
-   public void getBytes(final long index, final HornetQBuffer dst, final int dstIndex, final int length)
+   private void getBytes(final long index, final HornetQBuffer dst, final int dstIndex, final int length)
    {
       byte[] destBytes = new byte[length];
       getBytes(index, destBytes);
       dst.setBytes(dstIndex, destBytes);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getBytes(int, byte[], int, int)
-    */
+   @Override
    public void getBytes(final int index, final byte[] dst, final int dstIndex, final int length)
    {
       byte bytesToGet[] = new byte[length];
@@ -481,9 +462,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       System.arraycopy(bytesToGet, 0, dst, dstIndex, length);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getBytes(int, java.nio.ByteBuffer)
-    */
+   @Override
    public void getBytes(final int index, final ByteBuffer dst)
    {
       byte bytesToGet[] = new byte[dst.remaining()];
@@ -533,9 +512,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
              (getByte(index + 3) & 0xff) << 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getLong(int)
-    */
+   @Override
    public long getLong(final int index)
    {
       return ((long)getByte(index) & 0xff) << 56 | ((long)getByte(index + 1) & 0xff) << 48 |
@@ -558,9 +535,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
              ((long)getByte(index + 7) & 0xff) << 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getShort(int)
-    */
+   @Override
    public short getShort(final int index)
    {
       return (short)(getByte(index) << 8 | getByte(index + 1) & 0xFF);
@@ -571,10 +546,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return (short)(getByte(index) << 8 | getByte(index + 1) & 0xFF);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#getUnsignedMedium(int)
-    */
-   public int getUnsignedMedium(final int index)
+   private int getUnsignedMedium(final int index)
    {
       return (getByte(index) & 0xff) << 16 | (getByte(index + 1) & 0xff) << 8 | (getByte(index + 2) & 0xff) << 0;
    }
@@ -584,98 +556,50 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return (getByte(index) & 0xff) << 16 | (getByte(index + 1) & 0xff) << 8 | (getByte(index + 2) & 0xff) << 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setByte(int, byte)
-    */
+   @Override
    public void setByte(final int index, final byte value)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, org.hornetq.api.core.buffers.ChannelBuffer, int, int)
-    */
+   @Override
    public void setBytes(final int index, final HornetQBuffer src, final int srcIndex, final int length)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, byte[], int, int)
-    */
+   @Override
    public void setBytes(final int index, final byte[] src, final int srcIndex, final int length)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.nio.ByteBuffer)
-    */
+   @Override
    public void setBytes(final int index, final ByteBuffer src)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.io.InputStream, int)
-    */
-   public int setBytes(final int index, final InputStream in, final int length) throws IOException
-   {
-      throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setBytes(int, java.nio.channels.ScatteringByteChannel, int)
-    */
-   public int setBytes(final int index, final ScatteringByteChannel in, final int length) throws IOException
-   {
-      throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setInt(int, int)
-    */
+   @Override
    public void setInt(final int index, final int value)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setLong(int, long)
-    */
+   @Override
    public void setLong(final int index, final long value)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setMedium(int, int)
-    */
-   public void setMedium(final int index, final int value)
-   {
-      throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#setShort(int, short)
-    */
+   @Override
    public void setShort(final int index, final short value)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#toByteBuffer(int, int)
-    */
+   @Override
    public ByteBuffer toByteBuffer(final int index, final int length)
-   {
-      throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#toString(int, int, java.lang.String)
-    */
-   public String toString(final int index, final int length, final String charsetName)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
@@ -1081,17 +1005,13 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return this;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readBoolean()
-    */
+   @Override
    public boolean readBoolean()
    {
       return readByte() != 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readChar()
-    */
+   @Override
    public char readChar()
    {
       return (char)readShort();
@@ -1120,25 +1040,19 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return HornetQBuffers.wrappedBuffer(bytesToGet);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readDouble()
-    */
+   @Override
    public double readDouble()
    {
       return Double.longBitsToDouble(readLong());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readFloat()
-    */
+   @Override
    public float readFloat()
    {
       return Float.intBitsToFloat(readInt());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readNullableSimpleString()
-    */
+   @Override
    public SimpleString readNullableSimpleString()
    {
       int b = readByte();
@@ -1152,9 +1066,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readNullableString()
-    */
+   @Override
    public String readNullableString()
    {
       int b = readByte();
@@ -1168,9 +1080,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readSimpleString()
-    */
+   @Override
    public SimpleString readSimpleString()
    {
       int len = readInt();
@@ -1179,9 +1089,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
       return new SimpleString(data);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readString()
-    */
+   @Override
    public String readString()
    {
       int len = readInt();
@@ -1205,94 +1113,66 @@ public class LargeMessageControllerImpl implements LargeMessageController
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#readUTF()
-    */
+   @Override
    public String readUTF()
    {
       return UTF8Util.readUTF(this);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeBoolean(boolean)
-    */
+   @Override
    public void writeBoolean(final boolean val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeChar(char)
-    */
+   @Override
    public void writeChar(final char val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeDouble(double)
-    */
+   @Override
    public void writeDouble(final double val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeFloat(float)
-    */
+   @Override
    public void writeFloat(final float val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeNullableSimpleString(org.hornetq.util.SimpleString)
-    */
+   @Override
    public void writeNullableSimpleString(final SimpleString val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeNullableString(java.lang.String)
-    */
+   @Override
    public void writeNullableString(final String val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeSimpleString(org.hornetq.util.SimpleString)
-    */
+   @Override
    public void writeSimpleString(final SimpleString val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeString(java.lang.String)
-    */
+   @Override
    public void writeString(final String val)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.HornetQBuffer#writeUTF(java.lang.String)
-    */
+   @Override
    public void writeUTF(final String utf)
    {
       throw new IllegalAccessError(LargeMessageControllerImpl.READ_ONLY_ERROR_MESSAGE);
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.buffers.ChannelBuffer#compareTo(org.hornetq.api.core.buffers.ChannelBuffer)
-    */
-   public int compareTo(final HornetQBuffer buffer)
-   {
-      return -1;
    }
 
    public HornetQBuffer copy()
@@ -1304,12 +1184,6 @@ public class LargeMessageControllerImpl implements LargeMessageController
    {
       throw new UnsupportedOperationException();
    }
-
-   // Package protected ---------------------------------------------
-
-   // Protected -----------------------------------------------------
-
-   // Private -------------------------------------------------------
 
    /**
     * @param output

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
@@ -158,9 +158,7 @@ public class JMSQueueControlImpl extends StandardMBean implements JMSQueueContro
       coreQueueControl.setExpiryAddress(expiryAddres);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.JMSQueueControl#addJNDI(java.lang.String)
-    */
+   @Override
    public void addJNDI(String jndi) throws Exception
    {
       jmsServerManager.addQueueToJndi(managedQueue.getName(), jndi);

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSServerControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSServerControlImpl.java
@@ -208,9 +208,7 @@ public class JMSServerControlImpl extends AbstractControl implements JMSServerCo
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.JMSServerControl#createConnectionFactory(java.lang.String, boolean, boolean, int, java.lang.String, java.lang.String, java.lang.String, long, long, long, int, boolean, int, int, int, int, int, boolean, boolean, boolean, boolean, boolean, java.lang.String, int, int, boolean, int, int, long, double, long, int, boolean, java.lang.String)
-    */
+   @Override
    public void createConnectionFactory(String name,
                                        boolean ha,
                                        boolean useDiscovery,
@@ -284,9 +282,7 @@ public class JMSServerControlImpl extends AbstractControl implements JMSServerCo
                               groupId);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.JMSServerControl#createConnectionFactory(java.lang.String, boolean, boolean, int, java.lang.String[], java.lang.String[], java.lang.String, long, long, long, int, boolean, int, int, int, int, int, boolean, boolean, boolean, boolean, boolean, java.lang.String, int, int, boolean, int, int, long, double, long, int, boolean, java.lang.String)
-    */
+   @Override
    public void createConnectionFactory(String name,
                                        boolean ha,
                                        boolean useDiscovery,
@@ -418,9 +414,7 @@ public class JMSServerControlImpl extends AbstractControl implements JMSServerCo
       return createQueue(name, jndiBindings, null, true);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.JMSServerControl#createQueue(java.lang.String, java.lang.String, java.lang.String)
-    */
+   @Override
    public boolean createQueue(String name, String jndiBindings, String selector) throws Exception
    {
       return createQueue(name, jndiBindings, selector, true);

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSTopicControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSTopicControlImpl.java
@@ -22,6 +22,7 @@ import javax.management.MBeanInfo;
 import javax.management.StandardMBean;
 
 import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.Pair;
 import org.hornetq.api.core.management.AddressControl;
 import org.hornetq.api.core.management.HornetQServerControl;
 import org.hornetq.api.core.management.QueueControl;
@@ -33,7 +34,6 @@ import org.hornetq.jms.client.HornetQDestination;
 import org.hornetq.jms.client.HornetQMessage;
 import org.hornetq.jms.client.SelectorTranslator;
 import org.hornetq.jms.server.JMSServerManager;
-import org.hornetq.api.core.Pair;
 import org.hornetq.utils.json.JSONArray;
 import org.hornetq.utils.json.JSONObject;
 
@@ -76,23 +76,11 @@ public class JMSTopicControlImpl extends StandardMBean implements TopicControl
 
    // TopicControlMBean implementation ------------------------------
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.JMSQueueControl#addJNDI(java.lang.String)
-    */
+   @Override
    public void addJNDI(String jndi) throws Exception
    {
       jmsServerManager.addTopicToJndi(managedTopic.getName(), jndi);
    }
-
-
-   /* (non-Javadoc)
-    * @see org.hornetq.api.jms.management.TopicControl#removeJNDI(java.lang.String)
-    */
-   public void removeJNDI(String jndi) throws Exception
-   {
-      jmsServerManager.removeTopicFromJNDI(managedTopic.getName(), jndi);
-   }
-
 
    public String[] getJNDIBindings()
    {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedConnectionFactory.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedConnectionFactory.java
@@ -82,26 +82,20 @@ public class PersistedConnectionFactory implements EncodingSupport
       return config;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(final HornetQBuffer buffer)
    {
       config = new ConnectionFactoryConfigurationImpl();
       config.decode(buffer);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       config.encode(buffer);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
       return config.getEncodeSize();

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedJNDI.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedJNDI.java
@@ -63,9 +63,7 @@ public class PersistedJNDI implements EncodingSupport
    }
 
    // Public --------------------------------------------------------
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(HornetQBuffer buffer)
    {
       type = PersistedType.getType(buffer.readByte());
@@ -79,9 +77,7 @@ public class PersistedJNDI implements EncodingSupport
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(HornetQBuffer buffer)
    {
       buffer.writeByte(type.getType());
@@ -93,9 +89,7 @@ public class PersistedJNDI implements EncodingSupport
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
       return DataConstants.SIZE_BYTE +

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
@@ -122,9 +122,7 @@ public class JMSJournalStorageManagerImpl implements JMSStorageManager
 
 
    // Public --------------------------------------------------------
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#recoverConnectionFactories()
-    */
+   @Override
    public List<PersistedConnectionFactory> recoverConnectionFactories()
    {
       List<PersistedConnectionFactory> cfs = new ArrayList<PersistedConnectionFactory>(mapFactories.size());
@@ -132,9 +130,7 @@ public class JMSJournalStorageManagerImpl implements JMSStorageManager
       return cfs;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#storeConnectionFactory(org.hornetq.jms.persistence.PersistedConnectionFactory)
-    */
+   @Override
    public void storeConnectionFactory(final PersistedConnectionFactory connectionFactory) throws Exception
    {
       deleteConnectionFactory(connectionFactory.getName());
@@ -153,9 +149,7 @@ public class JMSJournalStorageManagerImpl implements JMSStorageManager
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#recoverDestinations()
-    */
+   @Override
    public List<PersistedDestination> recoverDestinations()
    {
       List<PersistedDestination> destinations = new ArrayList<PersistedDestination>(this.destinations.size());
@@ -163,9 +157,7 @@ public class JMSJournalStorageManagerImpl implements JMSStorageManager
       return destinations;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#storeDestination(org.hornetq.jms.persistence.PersistedDestination)
-    */
+   @Override
    public void storeDestination(final PersistedDestination destination) throws Exception
    {
       deleteDestination(destination.getType(), destination.getName());

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/nullpm/NullJMSStorageManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/nullpm/NullJMSStorageManagerImpl.java
@@ -16,7 +16,6 @@ package org.hornetq.jms.persistence.impl.nullpm;
 import java.util.Collections;
 import java.util.List;
 
-import org.hornetq.core.replication.ReplicationEndpoint;
 import org.hornetq.jms.persistence.JMSStorageManager;
 import org.hornetq.jms.persistence.config.PersistedConnectionFactory;
 import org.hornetq.jms.persistence.config.PersistedDestination;
@@ -33,140 +32,78 @@ import org.hornetq.jms.persistence.config.PersistedType;
 public class NullJMSStorageManagerImpl implements JMSStorageManager
 {
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#deleteConnectionFactory(java.lang.String)
-    */
+   @Override
    public void deleteConnectionFactory(String connectionFactory) throws Exception
    {
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#recoverConnectionFactories()
-    */
+   @Override
    public List<PersistedConnectionFactory> recoverConnectionFactories()
    {
       return Collections.emptyList();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#recoverDestinations()
-    */
+   @Override
    public List<PersistedDestination> recoverDestinations()
    {
       return Collections.emptyList();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#storeConnectionFactory(org.hornetq.jms.persistence.PersistedConnectionFactory)
-    */
+   @Override
    public void storeConnectionFactory(PersistedConnectionFactory connectionFactory) throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#storeDestination(org.hornetq.jms.persistence.PersistedDestination)
-    */
+   @Override
    public void storeDestination(PersistedDestination destination)
    {
    }
 
-    /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#deleteDestination (org.hornetq.jms.persistence.PersistedDestination)
-    */
-   public void deleteDestination(String name) throws Exception
-   {
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#isStarted()
-    */
+   @Override
    public boolean isStarted()
    {
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#start()
-    */
+   @Override
    public void start() throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#stop()
-    */
+   @Override
    public void stop() throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#addJNDI(org.hornetq.jms.persistence.PersistedType, java.lang.String, java.lang.String)
-    */
+   @Override
    public void addJNDI(PersistedType type, String name, String ... address) throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#deleteJNDI(org.hornetq.jms.persistence.PersistedType, java.lang.String, java.lang.String)
-    */
+   @Override
    public void deleteJNDI(PersistedType type, String name, String address) throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#deleteDestination(org.hornetq.jms.persistence.PersistedType, java.lang.String)
-    */
+   @Override
    public void deleteDestination(PersistedType type, String name) throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#deleteJNDI(org.hornetq.jms.persistence.PersistedType, java.lang.String)
-    */
+   @Override
    public void deleteJNDI(PersistedType type, String name) throws Exception
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#recoverPersistedJNDI()
-    */
+   @Override
    public List<PersistedJNDI> recoverPersistedJNDI() throws Exception
    {
       return Collections.emptyList();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#installReplication(org.hornetq.core.replication.ReplicationEndpoint)
-    */
-   public void installReplication(ReplicationEndpoint replicationEndpoint) throws Exception
-   {
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.persistence.JMSStorageManager#load()
-    */
+   @Override
    public void load() throws Exception
    {
    }
-
-   // Constants -----------------------------------------------------
-
-   // Attributes ----------------------------------------------------
-
-   // Static --------------------------------------------------------
-
-   // Constructors --------------------------------------------------
-
-   // Public --------------------------------------------------------
-
-   // Package protected ---------------------------------------------
-
-   // Protected -----------------------------------------------------
-
-   // Private -------------------------------------------------------
-
-   // Inner classes -------------------------------------------------
-
 }

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
@@ -513,9 +513,7 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
 
    // Encoding Support Implementation --------------------------------------------------------------
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(final HornetQBuffer buffer)
    {
       persisted = true;
@@ -603,9 +601,7 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
       factoryType = JMSFactoryType.valueOf(buffer.readInt());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       persisted = true;
@@ -693,9 +689,7 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
       buffer.writeInt(factoryType.intValue());
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
       int size = BufferHelper.sizeOfSimpleString(name) +

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -752,10 +752,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       return added;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.server.JMSServerManager#removeQueueFromJNDI(java.lang.String, java.lang.String)
-    */
-
+   @Override
    public boolean removeQueueFromJNDI(String name, String jndi) throws Exception
    {
       checkInitialised();
@@ -770,9 +767,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       return removed;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.server.JMSServerManager#removeQueueFromJNDI(java.lang.String, java.lang.String)
-    */
+   @Override
    public boolean removeQueueFromJNDI(final String name) throws Exception
    {
       final AtomicBoolean valueReturn = new AtomicBoolean(false);
@@ -802,10 +797,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       return valueReturn.get();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.server.JMSServerManager#removeTopicFromJNDI(java.lang.String, java.lang.String)
-    */
-
+   @Override
    public boolean removeTopicFromJNDI(String name, String jndi) throws Exception
    {
       checkInitialised();
@@ -853,10 +845,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       return valueReturn.get();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.server.JMSServerManager#removeConnectionFactoryFromJNDI(java.lang.String, java.lang.String)
-    */
-
+   @Override
    public boolean removeConnectionFactoryFromJNDI(String name, String jndi) throws Exception
    {
       checkInitialised();
@@ -868,10 +857,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.jms.server.JMSServerManager#removeConnectionFactoryFromJNDI(java.lang.String, java.lang.String)
-    */
-
+   @Override
    public boolean removeConnectionFactoryFromJNDI(String name) throws Exception
    {
       checkInitialised();

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/RecoveryDiscovery.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/RecoveryDiscovery.java
@@ -173,9 +173,7 @@ public class RecoveryDiscovery implements SessionFailureListener
    }
 
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.remoting.FailureListener#connectionFailed(org.hornetq.api.core.HornetQException, boolean)
-    */
+   @Override
    public void connectionFailed(HornetQException exception, boolean failedOver)
    {
       if (exception.getType() == HornetQExceptionType.DISCONNECTED)
@@ -191,9 +189,7 @@ public class RecoveryDiscovery implements SessionFailureListener
       HornetQRecoveryRegistry.getInstance().failedDiscovery(this);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.client.SessionFailureListener#beforeReconnect(org.hornetq.api.core.HornetQException)
-    */
+   @Override
    public void beforeReconnect(HornetQException exception)
    {
    }

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/AIOSequentialFile.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/AIOSequentialFile.java
@@ -116,9 +116,7 @@ public class AIOSequentialFile extends AbstractSequentialFile implements IOExcep
       notifyAll();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFile#waitForClose()
-    */
+   @Override
    public synchronized void waitForClose() throws Exception
    {
       while (isOpen())
@@ -258,9 +256,7 @@ public class AIOSequentialFile extends AbstractSequentialFile implements IOExcep
    // Public methods
    // -----------------------------------------------------------------------------------------------------
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.asyncio.IOExceptionListener#onException(int, java.lang.String)
-    */
+   @Override
    public void onIOException(Exception code, String message)
    {
       factory.onIOError(code, message, this);

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/AbstractSequentialFileFactory.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/AbstractSequentialFileFactory.java
@@ -131,9 +131,7 @@ abstract class AbstractSequentialFileFactory implements SequentialFileFactory
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#onIOError(java.lang.Exception, java.lang.String, org.hornetq.core.journal.SequentialFile)
-    */
+   @Override
    public void onIOError(Exception exception, String message, SequentialFile file)
    {
       if (critialErrorListener != null)
@@ -142,9 +140,7 @@ abstract class AbstractSequentialFileFactory implements SequentialFileFactory
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#activate(org.hornetq.core.journal.SequentialFile)
-    */
+   @Override
    public void activateBuffer(final SequentialFile file)
    {
       if (timedBuffer != null)

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/DummyCallback.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/DummyCallback.java
@@ -45,9 +45,7 @@ class DummyCallback extends SyncIOCompletion
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.IOCompletion#linedUp()
-    */
+   @Override
    public void storeLineUp()
    {
    }

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalCompactor.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalCompactor.java
@@ -625,17 +625,13 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.impl.JournalRecordsProvider#getCompactor()
-    */
+   @Override
    public JournalCompactor getCompactor()
    {
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.impl.JournalRecordsProvider#getRecords()
-    */
+   @Override
    public Map<Long, JournalRecord> getRecords()
    {
       return newRecords;

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalFileImpl.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalFileImpl.java
@@ -199,25 +199,19 @@ public class JournalFileImpl implements JournalFile
       return count;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.impl.JournalFile#addSize(int)
-    */
+   @Override
    public void addSize(final int bytes)
    {
       liveBytes.addAndGet(bytes);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.impl.JournalFile#decSize(int)
-    */
+   @Override
    public void decSize(final int bytes)
    {
       liveBytes.addAndGet(-bytes);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.impl.JournalFile#getSize()
-    */
+   @Override
    public int getLiveSize()
    {
       return liveBytes.get();

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalImpl.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/JournalImpl.java
@@ -1153,9 +1153,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.Journal#lineUpContex(org.hornetq.core.journal.IOCompletion)
-    */
+   @Override
    public void lineUpContex(IOCompletion callback)
    {
       callback.storeLineUp();

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/SimpleWaitIOCallback.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/SimpleWaitIOCallback.java
@@ -85,9 +85,7 @@ public class SimpleWaitIOCallback extends SyncIOCompletion
       return retValue;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.IOCompletion#linedUp()
-    */
+   @Override
    public void storeLineUp()
    {
    }

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalAddRecord.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalAddRecord.java
@@ -51,9 +51,7 @@ public class JournalAddRecord extends JournalInternalRecord
       this.add = add;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.buffers.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       if (add)

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalDeleteRecordTX.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalDeleteRecordTX.java
@@ -47,9 +47,7 @@ public class JournalDeleteRecordTX extends JournalInternalRecord
       this.record = record;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.buffers.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       buffer.writeByte(JournalImpl.DELETE_RECORD_TX);

--- a/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalRollbackRecordTX.java
+++ b/hornetq-journal/src/main/java/org/hornetq/core/journal/impl/dataformat/JournalRollbackRecordTX.java
@@ -32,9 +32,7 @@ public class JournalRollbackRecordTX extends JournalInternalRecord
       this.txID = txID;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.buffers.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       buffer.writeByte(JournalImpl.ROLLBACK_RECORD);

--- a/hornetq-server/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
@@ -498,17 +498,13 @@ public class ConfigurationImpl implements Configuration
    }
 
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#getPageMaxConcurrentIO()
-    */
+   @Override
    public int getPageMaxConcurrentIO()
    {
       return maxConcurrentPageIO;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#setPageMaxConcurrentIO(int)
-    */
+   @Override
    public void setPageMaxConcurrentIO(int maxIO)
    {
       this.maxConcurrentPageIO = maxIO;
@@ -1200,33 +1196,25 @@ public class ConfigurationImpl implements Configuration
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#getAddressesSettings()
-    */
+   @Override
    public Map<String, AddressSettings> getAddressesSettings()
    {
       return addressesSettings;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#setAddressesSettings(java.util.Map)
-    */
+   @Override
    public void setAddressesSettings(final Map<String, AddressSettings> addressesSettings)
    {
       this.addressesSettings = addressesSettings;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#getSecurityRoles()
-    */
+   @Override
    public Map<String, Set<Role>> getSecurityRoles()
    {
       return securitySettings;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#setSecuritySettings(java.util.Map)
-    */
+   @Override
    public void setSecurityRoles(final Map<String, Set<Role>> securitySettings)
    {
       this.securitySettings = securitySettings;
@@ -1262,17 +1250,13 @@ public class ConfigurationImpl implements Configuration
       this.connectorServiceConfigurations = configs;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#getName()
-    */
+   @Override
    public String getName()
    {
       return name;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.config.Configuration#setName(java.lang.String)
-    */
+   @Override
    public void setName(String name)
    {
       this.name = name;

--- a/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
@@ -884,9 +884,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.api.core.management.QueueControl#listConsumersAsJSON()
-    */
+   @Override
    public String listConsumersAsJSON() throws Exception
    {
       checkStarted();

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/PagedReferenceImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/PagedReferenceImpl.java
@@ -110,9 +110,7 @@ public class PagedReferenceImpl implements PagedReference
    }
 
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#getMessageMemoryEstimate()
-    */
+   @Override
    public int getMessageMemoryEstimate()
    {
       if (messageEstimate < 0)
@@ -123,17 +121,13 @@ public class PagedReferenceImpl implements PagedReference
    }
 
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#copy(org.hornetq.core.server.Queue)
-    */
+   @Override
    public MessageReference copy(final Queue queue)
    {
       return new PagedReferenceImpl(this.position, this.getPagedMessage(), this.subscription);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#getScheduledDeliveryTime()
-    */
+   @Override
    public long getScheduledDeliveryTime()
    {
       if (deliveryTime == null)
@@ -151,33 +145,25 @@ public class PagedReferenceImpl implements PagedReference
       return deliveryTime;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#setScheduledDeliveryTime(long)
-    */
+   @Override
    public void setScheduledDeliveryTime(final long scheduledDeliveryTime)
    {
       deliveryTime = scheduledDeliveryTime;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#getDeliveryCount()
-    */
+   @Override
    public int getDeliveryCount()
    {
       return deliveryCount.get();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#setDeliveryCount(int)
-    */
+   @Override
    public void setDeliveryCount(final int deliveryCount)
    {
       this.deliveryCount.set(deliveryCount);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#incrementDeliveryCount()
-    */
+   @Override
    public void incrementDeliveryCount()
    {
       deliveryCount.incrementAndGet();
@@ -188,9 +174,7 @@ public class PagedReferenceImpl implements PagedReference
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#decrementDeliveryCount()
-    */
+   @Override
    public void decrementDeliveryCount()
    {
       deliveryCount.decrementAndGet();
@@ -200,33 +184,25 @@ public class PagedReferenceImpl implements PagedReference
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#getQueue()
-    */
+   @Override
    public Queue getQueue()
    {
       return subscription.getQueue();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#handled()
-    */
+   @Override
    public void handled()
    {
       getQueue().referenceHandled();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#acknowledge()
-    */
+   @Override
    public void acknowledge() throws Exception
    {
       subscription.ack(this);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.MessageReference#acknowledge(org.hornetq.core.transaction.Transaction)
-    */
+   @Override
    public void acknowledge(final Transaction tx) throws Exception
    {
       subscription.ackTx(tx, this);

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PagePositionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PagePositionImpl.java
@@ -84,9 +84,7 @@ public class PagePositionImpl implements PagePosition
       return messageNr;
    }
 
-   /* (non-Javadoc)
-    * @see java.lang.Comparable#compareTo(java.lang.Object)
-    */
+   @Override
    public int compareTo(PagePosition o)
    {
       if (pageNr > o.getPageNr())

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -482,9 +482,7 @@ class PageSubscriptionImpl implements PageSubscription
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.cursor.PageCursor#confirm(org.hornetq.core.paging.cursor.PagePosition)
-    */
+   @Override
    public void ack(final PagedReference reference) throws Exception
    {
       // Need to do the ACK and counter atomically (inside a TX) or the counter could get out of sync
@@ -526,9 +524,7 @@ class PageSubscriptionImpl implements PageSubscription
       });
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.cursor.PageCursor#getFirstPage()
-    */
+   @Override
    public long getFirstPage()
    {
       synchronized (consumedPages)
@@ -604,18 +600,14 @@ class PageSubscriptionImpl implements PageSubscription
       recoveredACK.add(position);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.cursor.PageCursor#recoverPreparedACK(org.hornetq.core.paging.cursor.PagePosition)
-    */
+   @Override
    public void reloadPreparedACK(final Transaction tx, final PagePosition position)
    {
       deliveredCount.incrementAndGet();
       installTXCallback(tx, position);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.cursor.PageCursor#positionIgnored(org.hornetq.core.paging.cursor.PagePosition)
-    */
+   @Override
    public void positionIgnored(final PagePosition position)
    {
       processACK(position);
@@ -702,9 +694,7 @@ class PageSubscriptionImpl implements PageSubscription
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.cursor.PageCursor#getId()
-    */
+   @Override
    public long getId()
    {
       return cursorId;

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PageTransactionInfoImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PageTransactionInfoImpl.java
@@ -271,9 +271,7 @@ public class PageTransactionInfoImpl implements PageTransactionInfo
              ")";
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.paging.PageTransactionInfo#deliverAfterCommit(org.hornetq.core.paging.cursor.PageCursor, org.hornetq.core.paging.cursor.PagePosition)
-    */
+   @Override
    public synchronized boolean deliverAfterCommit(PageSubscription cursor, PagePosition cursorPos)
    {
       if (committed && useRedelivery)

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/config/PersistedAddressSetting.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/config/PersistedAddressSetting.java
@@ -97,9 +97,7 @@ public class PersistedAddressSetting implements EncodingSupport
       return setting;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(HornetQBuffer buffer)
    {
       addressMatch = buffer.readSimpleString();
@@ -108,9 +106,7 @@ public class PersistedAddressSetting implements EncodingSupport
       setting.decode(buffer);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(HornetQBuffer buffer)
    {
       buffer.writeSimpleString(addressMatch);
@@ -118,9 +114,7 @@ public class PersistedAddressSetting implements EncodingSupport
       setting.encode(buffer);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
       return addressMatch.sizeof() + setting.getEncodeSize();

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/config/PersistedRoles.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/config/PersistedRoles.java
@@ -164,9 +164,7 @@ public class PersistedRoles implements EncodingSupport
       return manageRoles.toString();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(final HornetQBuffer buffer)
    {
       buffer.writeSimpleString(addressMatch);
@@ -179,9 +177,7 @@ public class PersistedRoles implements EncodingSupport
       buffer.writeNullableSimpleString(manageRoles);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
       return addressMatch.sizeof() + SimpleString.sizeofNullableString(sendRoles) +
@@ -194,9 +190,7 @@ public class PersistedRoles implements EncodingSupport
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(final HornetQBuffer buffer)
    {
       addressMatch = buffer.readSimpleString();

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/JournalStorageManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/JournalStorageManager.java
@@ -2253,17 +2253,13 @@ public class JournalStorageManager implements StorageManager
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.persistence.StorageManager#allocateDirectBuffer(long)
-    */
+   @Override
    public ByteBuffer allocateDirectBuffer(int size)
    {
       return journalFF.allocateDirectBuffer(size);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.persistence.StorageManager#freeDirectuffer(java.nio.ByteBuffer)
-    */
+   @Override
    public void freeDirectBuffer(ByteBuffer buffer)
    {
       journalFF.releaseBuffer(buffer);

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
@@ -45,16 +45,12 @@ public class NullStorageLargeServerMessage extends ServerMessageImpl implements 
       super();
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#release()
-    */
+   @Override
    public void releaseResources()
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#addBytes(byte[])
-    */
+   @Override
    public synchronized void addBytes(final byte[] bytes)
    {
       if (buffer == null)
@@ -66,21 +62,10 @@ public class NullStorageLargeServerMessage extends ServerMessageImpl implements 
       buffer.writeBytes(bytes);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#deleteFile()
-    */
+   @Override
    public void deleteFile() throws Exception
    {
       // nothing to be done here.. we don really have a file on this Storage
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#complete()
-    */
-   public void complete() throws Exception
-   {
-      // nothing to be done here.. we don really have a file on this Storage
-
    }
 
    @Override
@@ -89,35 +74,14 @@ public class NullStorageLargeServerMessage extends ServerMessageImpl implements 
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#isComplete()
-    */
-   public boolean isComplete()
-   {
-      // nothing to be done on null persistence
-      return true;
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#setComplete(boolean)
-    */
-   public void setComplete(final boolean isComplete)
-   {
-      // nothing to be done on null persistence
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#isFileExists()
-    */
+   @Override
    public boolean isFileExists() throws Exception
    {
       // There are no real files on null persistence
       return true;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#decrementDelayDeletionCount()
-    */
+   @Override
    public void decrementDelayDeletionCount()
    {
 
@@ -151,9 +115,7 @@ public class NullStorageLargeServerMessage extends ServerMessageImpl implements 
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.LargeServerMessage#getPendingRecordID()
-    */
+   @Override
    public long getPendingRecordID()
    {
       return -1;

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
@@ -662,10 +662,8 @@ public class NettyAcceptor implements Acceptor
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.remoting.Acceptor#getClusterConnection()
-    */
-    public ClusterConnection getClusterConnection()
+   @Override
+   public ClusterConnection getClusterConnection()
    {
       return clusterConnection;
    }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
@@ -314,9 +314,7 @@ public class ServerMessageImpl extends MessageImpl implements ServerMessage
       buffer.setLong(buffer.getInt(MessageImpl.BUFFER_HEADER_SPACE) + DataConstants.SIZE_INT, messageID);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.ServerMessage#getDuplicateIDBytes()
-    */
+   @Override
    public byte[] getDuplicateIDBytes()
    {
       Object duplicateID = getDuplicateProperty();

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
@@ -1416,9 +1416,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener
       return this.creationTime;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.ServerSession#getProducersInfoJSON()
-    */
+   @Override
    public void describeProducersInfo(JSONArray array) throws Exception
    {
       Map<SimpleString, Pair<UUID, AtomicLong>> targetCopy = cloneTargetAddresses();

--- a/hornetq-server/src/main/java/org/hornetq/core/settings/impl/AddressSettings.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/settings/impl/AddressSettings.java
@@ -311,9 +311,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       }
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#decode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void decode(HornetQBuffer buffer)
    {
       SimpleString policyStr = buffer.readNullableSimpleString();
@@ -358,9 +356,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       sendToDLAOnNoRoute = BufferHelper.readNullableBoolean(buffer);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#getEncodeSize()
-    */
+   @Override
    public int getEncodeSize()
    {
 
@@ -382,9 +378,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
              BufferHelper.sizeOfNullableBoolean(sendToDLAOnNoRoute);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.EncodingSupport#encode(org.hornetq.api.core.HornetQBuffer)
-    */
+   @Override
    public void encode(HornetQBuffer buffer)
    {
       buffer.writeNullableSimpleString(addressFullMessagePolicy != null ? new SimpleString(addressFullMessagePolicy.toString())

--- a/integration/hornetq-spring-integration/src/main/java/org/hornetq/integration/spring/SpringBindingRegistry.java
+++ b/integration/hornetq-spring-integration/src/main/java/org/hornetq/integration/spring/SpringBindingRegistry.java
@@ -45,17 +45,13 @@ public class SpringBindingRegistry implements BindingRegistry
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.naming.BindingRegistry#getContext()
-    */
+   @Override
    public Object getContext()
    {
       return this.factory;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.spi.core.naming.BindingRegistry#setContext(java.lang.Object)
-    */
+   @Override
    public void setContext(Object ctx)
    {
       this.factory = (ConfigurableBeanFactory) ctx;

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
@@ -674,103 +674,59 @@ public class FakeSequentialFileFactory implements SequentialFileFactory
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#createDirs()
-    */
+   @Override
    public void createDirs() throws Exception
    {
       // nothing to be done on the fake Sequential file
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#releaseBuffer(java.nio.ByteBuffer)
-    */
+   @Override
    public void releaseBuffer(final ByteBuffer buffer)
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#getBufferCallback()
-    */
-   public BufferCallback getBufferCallback()
-   {
-      return null;
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#setBufferCallback(org.hornetq.core.journal.BufferCallback)
-    */
-   public void setBufferCallback(final BufferCallback bufferCallback)
-   {
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#controlBuffersLifeCycle(boolean)
-    */
-   public void controlBuffersLifeCycle(final boolean value)
-   {
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#stop()
-    */
+   @Override
    public void stop()
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#activate(org.hornetq.core.journal.SequentialFile)
-    */
+   @Override
    public void activateBuffer(final SequentialFile file)
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#start()
-    */
+   @Override
    public void start()
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#deactivate(org.hornetq.core.journal.SequentialFile)
-    */
+   @Override
    public void deactivateBuffer()
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#testFlush()
-    */
+   @Override
    public void flush()
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#onIOError(java.lang.Exception, java.lang.String, org.hornetq.core.journal.SequentialFile)
-    */
+   @Override
    public void onIOError(Exception exception, String message, SequentialFile file)
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#newDirectBuffer(int)
-    */
+   @Override
    public ByteBuffer allocateDirectBuffer(int size)
    {
       return ByteBuffer.allocateDirect(size);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#releaseDirectBuffer(java.nio.ByteBuffer)
-    */
+   @Override
    public void releaseDirectBuffer(ByteBuffer buffer)
    {
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.journal.SequentialFileFactory#getDirectory()
-    */
+   @Override
    public String getDirectory()
    {
       // TODO Auto-generated method stub

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -39,18 +39,14 @@ import org.hornetq.utils.LinkedListIterator;
 public class FakeQueue implements Queue
 {
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#isInternalQueue()
-    */
+   @Override
    public boolean isInternalQueue()
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#setInternalQueue(boolean)
-    */
+   @Override
    public void setInternalQueue(boolean internalQueue)
    {
       // no-op
@@ -133,252 +129,175 @@ public class FakeQueue implements Queue
       this.id = id;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#acknowledge(org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void acknowledge(final MessageReference ref) throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#acknowledge(org.hornetq.core.transaction.Transaction, org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void acknowledge(final Transaction tx, final MessageReference ref) throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#addConsumer(org.hornetq.core.server.Consumer)
-    */
+   @Override
    public void addConsumer(final Consumer consumer) throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#addFirst(org.hornetq.core.server.MessageReference)
-    */
-   public void addFirst(final MessageReference ref)
-   {
-      // no-op
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#addLast(org.hornetq.core.server.MessageReference)
-    */
-   public void addLast(final MessageReference ref)
-   {
-      // no-op
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#addRedistributor(long)
-    */
+   @Override
    public void addRedistributor(final long delay)
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#cancel(org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void cancel(final MessageReference reference, final long timeBase) throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#cancel(org.hornetq.core.transaction.Transaction, org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void cancel(final Transaction tx, final MessageReference ref)
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#cancelRedistributor()
-    */
+   @Override
    public void cancelRedistributor() throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#changeReferencePriority(long, byte)
-    */
+   @Override
    public boolean changeReferencePriority(final long messageID, final byte newPriority) throws Exception
    {
       // no-op
       return false;
    }
 
-/* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#changeReferencesPriority(org.hornetq.core.filter.Filter, byte)
-    */
+@Override
    public int changeReferencesPriority(Filter filter, byte newPriority) throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#checkDLQ(org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public boolean checkRedelivery(final MessageReference ref, final long timeBase) throws Exception
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#deleteAllReferences()
-    */
+   @Override
    public int deleteAllReferences() throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#deleteMatchingReferences(org.hornetq.core.filter.Filter)
-    */
+   @Override
    public int deleteMatchingReferences(final Filter filter) throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#deleteReference(long)
-    */
+   @Override
    public boolean deleteReference(final long messageID) throws Exception
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#deliverAsync()
-    */
+   @Override
    public void deliverAsync()
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#deliverNow()
-    */
-   public void deliverNow()
-   {
-      // no-op
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#expire(org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void expire(final MessageReference ref) throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#expireReference(long)
-    */
+   @Override
    public boolean expireReference(final long messageID) throws Exception
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#expireReferences()
-    */
+   @Override
    public void expireReferences() throws Exception
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#expireReferences(org.hornetq.core.filter.Filter)
-    */
+   @Override
    public int expireReferences(final Filter filter) throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getConsumerCount()
-    */
+   @Override
    public int getConsumerCount()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getConsumers()
-    */
+   @Override
    public Set<Consumer> getConsumers()
    {
       // no-op
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getDeliveringCount()
-    */
+   @Override
    public int getDeliveringCount()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getFilter()
-    */
+   @Override
    public Filter getFilter()
    {
       // no-op
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getMessageCount()
-    */
+   @Override
    public long getMessageCount()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getMessagesAdded()
-    */
+   @Override
    public long getMessagesAdded()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getName()
-    */
+   @Override
    public SimpleString getName()
    {
       return name;
@@ -390,125 +309,83 @@ public class FakeQueue implements Queue
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getID()
-    */
+   @Override
    public long getID()
    {
       return id;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getReference(long)
-    */
-   public MessageReference getReference(final long id)
+   @Override
+   public MessageReference getReference(final long id1)
    {
       // no-op
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getScheduledCount()
-    */
+   @Override
    public int getScheduledCount()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getScheduledMessages()
-    */
+   @Override
    public List<MessageReference> getScheduledMessages()
    {
       // no-op
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#isDurable()
-    */
+   @Override
    public boolean isDurable()
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#isPaused()
-    */
+   @Override
    public boolean isPaused()
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#isTemporary()
-    */
+   @Override
    public boolean isTemporary()
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#iterator()
-    */
+   @Override
    public LinkedListIterator<MessageReference> iterator()
    {
       // no-op
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#list(org.hornetq.core.filter.Filter)
-    */
-   public List<MessageReference> list(final Filter filter)
-   {
-      // no-op
-      return null;
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#lockDelivery()
-    */
-   public void lockDelivery()
-   {
-      // no-op
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#moveReference(long, org.hornetq.utils.SimpleString)
-    */
+   @Override
    public boolean moveReference(final long messageID, final SimpleString toAddress) throws Exception
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#moveReferences(org.hornetq.core.filter.Filter, org.hornetq.utils.SimpleString)
-    */
+   @Override
    public int moveReferences(final Filter filter, final SimpleString toAddress) throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#pause()
-    */
+   @Override
    public void pause()
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#reacknowledge(org.hornetq.core.transaction.Transaction, org.hornetq.core.server.MessageReference)
-    */
+   @Override
    public void reacknowledge(final Transaction tx, final MessageReference ref) throws Exception
    {
       // no-op
@@ -525,13 +402,13 @@ public class FakeQueue implements Queue
    {
    }
 
-   public MessageReference removeFirstReference(final long id) throws Exception
+   public MessageReference removeFirstReference(final long id1) throws Exception
    {
       // no-op
       return null;
    }
 
-   public MessageReference removeReferenceWithID(final long id) throws Exception
+   public MessageReference removeReferenceWithID(final long id1) throws Exception
    {
       // no-op
       return null;
@@ -555,29 +432,14 @@ public class FakeQueue implements Queue
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#setExpiryAddress(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public void setExpiryAddress(final SimpleString expiryAddress)
    {
       // no-op
 
    }
 
-   // no-op
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#unlockDelivery()
-    */
-   public void unlockDelivery()
-   {
-      // no-op
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Bindable#route(org.hornetq.core.server.ServerMessage, org.hornetq.core.server.RoutingContext)
-    */
+   @Override
    public void route(final ServerMessage message, final RoutingContext context) throws Exception
    {
       // no-op
@@ -585,15 +447,6 @@ public class FakeQueue implements Queue
    }
 
    public boolean hasMatchingConsumer(final ServerMessage message)
-   {
-      // no-op
-      return false;
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#checkDLQ(org.hornetq.core.server.MessageReference, java.util.concurrent.Executor)
-    */
-   public boolean checkDLQ(final MessageReference ref, final Executor ioExecutor) throws Exception
    {
       // no-op
       return false;
@@ -611,9 +464,7 @@ public class FakeQueue implements Queue
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getPageSubscription()
-    */
+   @Override
    public PageSubscription getPageSubscription()
    {
       return subs;
@@ -624,45 +475,35 @@ public class FakeQueue implements Queue
       this.subs = sub;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#moveReference(long, org.hornetq.api.core.SimpleString, boolean)
-    */
+   @Override
    public boolean moveReference(long messageID, SimpleString toAddress, boolean rejectDuplicates) throws Exception
    {
       // no-op
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#moveReferences(org.hornetq.core.filter.Filter, org.hornetq.api.core.SimpleString, boolean)
-    */
+   @Override
    public int moveReferences(Filter filter, SimpleString toAddress, boolean rejectDuplicates) throws Exception
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#forceDelivery()
-    */
+   @Override
    public void forceDelivery()
    {
       // no-op
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getInstantMessageCount()
-    */
+   @Override
    public long getInstantMessageCount()
    {
       // no-op
       return 0;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.Queue#getInstantMessagesAdded()
-    */
+   @Override
    public long getInstantMessagesAdded()
    {
       // no-op

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -13,6 +13,7 @@
 
 package org.hornetq.tests.unit.core.server.impl.fakes;
 
+import org.hornetq.api.core.Pair;
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.core.paging.PagingManager;
 import org.hornetq.core.persistence.impl.nullpm.NullStorageManager;
@@ -27,59 +28,46 @@ import org.hornetq.core.server.RoutingContext;
 import org.hornetq.core.server.ServerMessage;
 import org.hornetq.core.server.impl.MessageReferenceImpl;
 import org.hornetq.core.transaction.Transaction;
-import org.hornetq.api.core.Pair;
 
 public class FakePostOffice implements PostOffice
 {
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#isStarted()
-    */
+   @Override
    public boolean isStarted()
    {
 
       return false;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#start()
-    */
+   @Override
    public void start() throws Exception
    {
 
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.server.HornetQComponent#stop()
-    */
+   @Override
    public void stop() throws Exception
    {
 
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#addBinding(org.hornetq.core.postoffice.Binding)
-    */
+   @Override
    public void addBinding(final Binding binding) throws Exception
    {
 
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getBinding(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public Binding getBinding(final SimpleString uniqueName)
    {
 
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getBindingsForAddress(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public Bindings getBindingsForAddress(final SimpleString address) throws Exception
    {
 
@@ -92,72 +80,42 @@ public class FakePostOffice implements PostOffice
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getDuplicateIDCache(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public DuplicateIDCache getDuplicateIDCache(final SimpleString address)
    {
       return new DuplicateIDCacheImpl(address, 2000, new NullStorageManager(), false);
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getMatchingBindings(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public Bindings getMatchingBindings(final SimpleString address)
    {
 
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getNotificationLock()
-    */
+   @Override
    public Object getNotificationLock()
    {
 
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#getPagingManager()
-    */
+   @Override
    public PagingManager getPagingManager()
    {
 
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#redistribute(org.hornetq.core.server.ServerMessage, org.hornetq.core.server.Queue, org.hornetq.core.server.RoutingContext)
-    */
-   public boolean redistribute(final ServerMessage message, final Queue originatingQueue, final RoutingContext context) throws Exception
-   {
-
-      return false;
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#removeBinding(org.hornetq.utils.SimpleString)
-    */
+   @Override
    public Binding removeBinding(final SimpleString uniqueName) throws Exception
    {
 
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#sendQueueInfoToQueue(org.hornetq.utils.SimpleString, org.hornetq.utils.SimpleString)
-    */
+   @Override
    public void sendQueueInfoToQueue(final SimpleString queueName, final SimpleString address) throws Exception
-   {
-
-
-   }
-
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#route(org.hornetq.core.server.ServerMessage)
-    */
-   public void route(final ServerMessage message) throws Exception
    {
 
 
@@ -204,27 +162,21 @@ public class FakePostOffice implements PostOffice
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#route(org.hornetq.core.server.ServerMessage, org.hornetq.core.server.RoutingContext, boolean, boolean)
-    */
+   @Override
    public void route(ServerMessage message, RoutingContext context, boolean direct, boolean rejectDuplicates) throws Exception
    {
 
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#route(org.hornetq.core.server.ServerMessage, org.hornetq.core.transaction.Transaction, boolean, boolean)
-    */
+   @Override
    public void route(ServerMessage message, Transaction tx, boolean direct, boolean rejectDuplicates) throws Exception
    {
 
 
    }
 
-   /* (non-Javadoc)
-    * @see org.hornetq.core.postoffice.PostOffice#processRoute(org.hornetq.core.server.ServerMessage, org.hornetq.core.server.RoutingContext, boolean)
-    */
+   @Override
    public void processRoute(ServerMessage message, RoutingContext context, boolean direct) throws Exception
    {
 

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/MessageEndpointFactory.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/MessageEndpointFactory.java
@@ -8,17 +8,13 @@ import java.lang.reflect.Method;
 public class MessageEndpointFactory implements javax.resource.spi.endpoint.MessageEndpointFactory
 {
 
-   /* (non-Javadoc)
-    * @see javax.resource.spi.endpoint.MessageEndpointFactory#createEndpoint(javax.transaction.xa.XAResource)
-    */
+   @Override
    public MessageEndpoint createEndpoint(final XAResource arg0) throws UnavailableException
    {
       return null;
    }
 
-   /* (non-Javadoc)
-    * @see javax.resource.spi.endpoint.MessageEndpointFactory#isDeliveryTransacted(java.lang.reflect.Method)
-    */
+   @Override
    public boolean isDeliveryTransacted(final Method arg0) throws NoSuchMethodException
    {
       return false;


### PR DESCRIPTION
- Delete all unused methods not overriding anything;
- Reduce visibility when possible

FYI, regular expression used was:
/* (non-Javadoc)\R    * @see [\p{Alpha}\p{Digit}\p{Punct}\p{Blank}]_\R    \_/\R[\s\t]*public
REPLACED WITH
@Override\R   public
