### PR TITLE
Remove old code that is not needed anymore with newer Netty versions.

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
@@ -624,18 +624,6 @@ public class NettyAcceptor implements Acceptor
             }
          }
       }
-      // TODO remove workaround when integrating Netty 3.2.x
-      // https://jira.jboss.org/jira/browse/NETTY-256
-      bossExecutor.shutdown();
-      try
-      {
-         bossExecutor.awaitTermination(30, TimeUnit.SECONDS);
-      }
-      catch (InterruptedException e)
-      {
-         throw new HornetQInterruptedException(e);
-      }
-
       paused = true;
    }
 


### PR DESCRIPTION
This code also produced a deadlock with 3.6.0.Final and later as the
VirtualExecutorService.awaitTermination(..) has a bug which is triggered
by the new shutdown logic which was introduced with 3.6.0.Final.
