### PR TITLE
fix jgroups test failures 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <skipRestTests>true</skipRestTests>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <hornetq-surefire-argline>-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=${user.dir}/tests/config/logging.properties -Djava.library.path=${user.dir}/distribution/hornetq/src/main/resources/bin/ -Djgroups.bind_addr=::1</hornetq-surefire-argline>
+      <hornetq-surefire-argline>-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dlogging.configuration=${user.dir}/tests/config/logging.properties -Djava.library.path=${user.dir}/distribution/hornetq/src/main/resources/bin/ -Djgroups.bind_addr=localhost -Djava.net.preferIPv4Stack=true</hornetq-surefire-argline>
    </properties>
 
    <scm>

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
@@ -58,6 +58,14 @@ import org.hornetq.utils.UUIDGenerator;
  * <p>
  * Or ultimately you may also turn off IPV6: {@literal -Djava.net.preferIPv4Stack=true}
  * <p>
+ * Note when you are not sure about your IP settings of your test machine, you should make sure
+ * that the jgroups.bind_addr and java.net.preferXXStack by defining them explicitly, for example
+ * if you would like to use IPV6, set BOTH properties to your JVM like the following:
+ * -Djgroups.bind_addr=::1 -Djava.net.preferIPv6Addresses=true
+ * <p>
+ * or if you prefer IPV4:
+ * -Djgroups.bind_addr=localhost -Djava.net.preferIPv4Stack=true
+ * <p>
  * Also: Make sure you add integration-tests/src/tests/resources to your project path on the
  * tests/integration-tests
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>


### PR DESCRIPTION
force jgroups use consistent ip stacks by explicitly setting the system properties.
