### PR TITLE
Add XML schema for HornetQ REST configuration

### DIFF
--- a/hornetq-rest/src/main/resources/schema/hornetq-rest.xsd
+++ b/hornetq-rest/src/main/resources/schema/hornetq-rest.xsd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="urn:hornetq" version="1.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:hornetq">
+
+    <xsd:element name="rest-messaging">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element name="server-in-vm-id" type="xsd:string" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            The HornetQ REST implementation uses the IN-VM transport to communicate
+                            with HornetQ. It uses the default server id, which is "0".
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="use-link-headers" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            By default, all links (URLs) are published using custom headers.
+                            You can instead have the HornetQ REST implementation publish links
+                            using the Link Header specification instead if you desire.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="default-durable-send" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Whether a posted message should be persisted by default if the user
+                            does not specify a durable query parameter.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="dups-ok" type="xsd:boolean" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                             If this is true, no duplicate detection protocol will be enforced for
+                             message posting.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="topic-push-store-dir" type="xsd:string" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            This must be a relative or absolute file system path. This is a
+                            directory where push registrations for topics are stored.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="queue-push-store-dir" type="xsd:string" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                             This must be a relative or absolute file system path. This is a
+                             directory where push registrations for queues are stored.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="producer-session-pool-size" type="xsd:int" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            The REST implementation pools HornetQ sessions for sending messages.
+                            This is the size of the pool. That number of sessions will be created
+                            at startup time.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="producer-time-to-live" type="xsd:long" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Default time to live for posted messages. Default is no ttl.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="session-timeout-task-interval" type="xsd:int" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Pull consumers and pull subscriptions can time out. This is the
+                            interval the thread that checks for timed-out sessions will run at. A
+                            value of 1 means it will run every 1 second.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="consumer-session-timeout-seconds" type="xsd:int" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Timeout in seconds for pull consumers/subscriptions that remain idle
+                            for that amount of time.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="consumer-window-size" type="xsd:int" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            For consumers, this config option is the same as the HornetQ one of the
+                            same name. It will be used by sessions created by the HornetQ REST
+                            implementation.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>
+


### PR DESCRIPTION
Simple XML schema for HornetQ REST configuration.

Skeleton generated with schemagen. Documentation filled in from official documentation.
