### PR TITLE
Removing exportJournal (this is not a export-test, and these steps were ...

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/journal/NIOJournalCompactTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/journal/NIOJournalCompactTest.java
@@ -1395,13 +1395,7 @@ public class NIOJournalCompactTest extends JournalImplTestBase
 
       journal.forceMoveNextFile();
 
-      ExportJournal.exportJournal(getTestDir(), filePrefix, fileExtension, 2, this.fileSize, "/tmp/out1.dmp");
-
-      ExportJournal.exportJournal(getTestDir(), filePrefix, fileExtension, 2, this.fileSize, "/tmp/out2.dmp");
-
       rollback(tx);
-
-      ExportJournal.exportJournal(getTestDir(), filePrefix, fileExtension, 2, this.fileSize, "/tmp/out3.dmp");
 
       journal.forceMoveNextFile();
       journal.checkReclaimStatus();


### PR DESCRIPTION
...added by mistake), and that was causing failures on our hudson due to using /tmp hardcoded
