### PR TITLE
Spell check manual files

### DIFF
--- a/docs/user-manual/en/appserver-integration.xml
+++ b/docs/user-manual/en/appserver-integration.xml
@@ -168,7 +168,7 @@ public class MDB_BMPExample implements MessageListener
                     >Dups-ok-acknowledge</literal>. Please note that because the message delivery is outside
                 the scope of the transaction a failure within the MDB will not cause the message to
                 be redelivered.</para>
-            <para>A user would control the lifecycle of the transaction something like the
+            <para>A user would control the life-cycle of the transaction something like the
                 following:</para>
             <programlisting>
 @Resource
@@ -336,7 +336,7 @@ public class MyMDB implements MessageListener
    &lt;config-property>
       &lt;description>The transport configuration. These values must be in the form of key=val;key=val;,
          if multiple connectors are used then each set must be separated by a comma i.e. host=host1;port=5445,host=host2;port=5446.
-         Each set of params maps to the connector classname specified.&lt;/description>
+         Each set of parameters maps to the connector classname specified.&lt;/description>
       &lt;config-property-name>ConnectionParameters&lt;/config-property-name>
       &lt;config-property-type>java.lang.String&lt;/config-property-type>
       &lt;config-property-value>server-id=0&lt;/config-property-value>
@@ -451,7 +451,7 @@ public class MyMDB implements MessageListener
                             <entry>String</entry>
                             <entry>The transport configuration. These parameters must be in the form of
                                 <literal>key1=val1;key2=val2;</literal> and will be specific to the connector used. If
-                               multiple connectors are configured then params should be supplied for each connector
+                               multiple connectors are configured then parameters should be supplied for each connector
                                separated by a comma.
                             </entry>
                         </row>
@@ -479,7 +479,7 @@ public class MyMDB implements MessageListener
                             <entry>
                                <link linkend="configuration.discovery-group.group-address">DiscoveryAddress</link></entry>
                             <entry>String</entry>
-                            <entry>The discovery group address to use to autodetect a server</entry>
+                            <entry>The discovery group address to use to auto-detect a server</entry>
                         </row>
                         <row>
                             <entry>
@@ -616,7 +616,7 @@ public class MyMDB implements MessageListener
                                <link linkend="configuration.connection-factory.reconnect-attempts">ReconnectAttempts</link>
                             </entry>
                             <entry>Integer</entry>
-                            <entry>maximum number of retry attempts, default for the resource adpater is -1 (infinite attempts)</entry>
+                            <entry>maximum number of retry attempts, default for the resource adapter is -1 (infinite attempts)</entry>
                         </row>
                         <row>
                             <entry>
@@ -687,7 +687,7 @@ public class MyMDB implements MessageListener
                         <row>
                             <entry>SetupInterval</entry>
                             <entry>Long</entry>
-                            <entry>Interval in milliseconds between consecutive attemps to setup a JMS connection (default is 2000m). This applies only for inbound connections</entry>
+                            <entry>Interval in milliseconds between consecutive attempts to setup a JMS connection (default is 2000m). This applies only for inbound connections</entry>
                         </row>
                     </tbody>
                 </tgroup>
@@ -726,7 +726,7 @@ public class MyMDB implements MessageListener
 &lt;/tx-connection-factory></programlisting>
            <warning>
               <title>overriding connectors</title>
-              <para>If the connector class name is overridden the all params must also be supplied.</para>
+              <para>If the connector class name is overridden the all parameters must also be supplied.</para>
            </warning>
             <para>In this example the connection factory will be bound to JNDI with the name
                     <literal>RemoteJmsXA</literal> and can be looked up in the usual way using JNDI
@@ -890,7 +890,7 @@ private ConnectionFactory connectionFactory;</programlisting>
                    <literal>deploy/hornet-ra.rar/META-INF</literal>
                    and change the transport type to
                    use a netty connector (instead of the invm connector that is defined) and configure its transport
-                   params.
+                   parameters.
                    Heres an example of what this would look like:
                 </para>
                 <programlisting>
@@ -927,9 +927,9 @@ private ConnectionFactory connectionFactory;</programlisting>
    &lt;config-property-value>host=127.0.0.1;port=5446,host=127.0.0.2;port=5447&lt;/config-property-value>
 &lt;/config-property></programlisting>
                 <warning>
-                   <title>provide all params</title>
+                   <title>provide all parameters</title>
                    <para>
-                      Make sure you provide parameters for each connector configured. The position of the params in the
+                      Make sure you provide parameters for each connector configured. The position of the parameters in the
                       list maps to each connector provided.
                    </para>
                 </warning>
@@ -942,7 +942,7 @@ private ConnectionFactory connectionFactory;</programlisting>
                 <title>Configuring the outgoing adaptor</title>
                 <para>You will also need to configure the outbound connection by creating a <literal>hornetq-ds.xml</literal>
                    and placing it under any directory that will be deployed under the <literal>deploy</literal> directory.
-                   In a standard HornetQ jboss configuration this would be under <literal>horneq</literal> or <literal>hornetq.sar</literal>
+                   In a standard HornetQ jboss configuration this would be under <literal>hornetq</literal> or <literal>hornetq.sar</literal>
                    but you can place it where ever you like. Actually as long as it ends in <literal>-ds.xml</literal> you can
                    call it anything you like. You can again find a template for this file under the config directory of the
                    HornetQ distribution but called <literal>jms-ds.xml</literal> which is the jboss default.
@@ -991,7 +991,7 @@ private ConnectionFactory connectionFactory;</programlisting>
                             <row>
                                 <entry>hornetq-ra.jar</entry>
                                 <entry>The HornetQ resource adaptor classes</entry>
-                                <entry>deploy/hornetq-ra.rar or equivelant</entry>
+                                <entry>deploy/hornetq-ra.rar or equivalent</entry>
                             </row>
                             <row>
                                 <entry>hornetq-core-client.jar</entry>
@@ -1023,7 +1023,7 @@ private ConnectionFactory connectionFactory;</programlisting>
         <section>
             <title>Configuring Jboss 5</title>
             <para>Firstly download and install JBoss AS 5 as per the JBoss installation guide and HornetQ as per the
-                HornetQ installation guide. After thatt he following steps are required</para>
+                HornetQ installation guide. After that the following steps are required</para>
             <itemizedlist>
                 <listitem>
                     <para>Copy the following jars from the HornetQ distribution to the <literal>lib</literal> directory of

--- a/docs/user-manual/en/architecture.xml
+++ b/docs/user-manual/en/architecture.xml
@@ -27,7 +27,7 @@
     <section>
         <title>Core Architecture</title>
         <para>HornetQ core is designed simply as set of Plain Old Java Objects (POJOs) - we hope you
-            like it's clean-cut design.</para>
+            like its clean-cut design.</para>
         <para>We've also designed it to have as few dependencies on external jars as possible. In
             fact, HornetQ core has only one jar dependency, netty.jar,
             other than the standard JDK classes! This is because we use some of the netty buffer classes
@@ -56,7 +56,7 @@
         </para>
         <para>JMS semantics are implemented by a thin JMS facade layer on the client side.</para>
         <para>The HornetQ server does not speak JMS and in fact does not know anything about JMS,
-            it's a protocol agnostic messaging server designed to be used with multiple different
+            it is a protocol agnostic messaging server designed to be used with multiple different
             protocols.</para>
         <para>When a user uses the JMS API on the client side, all JMS interactions are translated
             into operations on the HornetQ core client API before being transferred over the wire

--- a/docs/user-manual/en/client-classpath.xml
+++ b/docs/user-manual/en/client-classpath.xml
@@ -55,7 +55,7 @@
     <section>
         <title>JMS Client with JNDI</title>
         <para>If you are looking up JMS resources from the JNDI server co-located with the HornetQ
-            standalone server, you wil also need the jar <literal>jnp-client.jar</literal> jar on
+            standalone server, you will also need the jar <literal>jnp-client.jar</literal> jar on
             your client classpath as well as any other jars mentioned previously.</para>
     </section>
 </chapter>

--- a/docs/user-manual/en/client-reconnection.xml
+++ b/docs/user-manual/en/client-reconnection.xml
@@ -29,7 +29,7 @@
         <title>100% Transparent session re-attachment</title>
         <para>If the failure was due to some transient failure such as a temporary network failure,
             and the target server was not restarted, then the sessions will still be existent on the
-            server, asssuming the client hasn't been disconnected for more than connection-ttl <xref
+            server, assuming the client hasn't been disconnected for more than connection-ttl <xref
                 linkend="connection-ttl"/>.</para>
         <para>In this scenario, HornetQ will automatically re-attach the client sessions to the
             server sessions when the connection reconnects. This is done 100% transparently and the

--- a/docs/user-manual/en/clusters.xml
+++ b/docs/user-manual/en/clusters.xml
@@ -137,7 +137,7 @@
                         <para><literal>local-bind-port</literal>. If you want to specify a local port to
                             which the datagram socket is bound you can specify it here. Normally you
                             would just use the default value of <literal>-1</literal> which signifies
-                            that an anonymous port should be used. This parameter is alawys specified in conjunction with
+                            that an anonymous port should be used. This parameter is always specified in conjunction with
                             <literal>local-bind-address</literal>. This is a UDP specific attribute.</para>
                     </listitem>
                     <listitem>
@@ -320,7 +320,7 @@
                             address with this parameter. This parameter is optional. This is a UDP specific attribute.</para>
                     </listitem>
                     <listitem>
-                        <para><literal>group-address</literal>. This is the multicast ip address of the
+                        <para><literal>group-address</literal>. This is the multicast IP address of the
                             group to listen on. It should match the <literal>group-address</literal> in
                             the broadcast group that you wish to listen from. This parameter is
                             mandatory.  This is a UDP specific attribute.</para>

--- a/docs/user-manual/en/configuration-index.xml
+++ b/docs/user-manual/en/configuration-index.xml
@@ -945,7 +945,7 @@
                             <entry><link linkend="security.settings.roles"
                                     >security-settings.permission</link></entry>
                             <entry>Security Permission</entry>
-                            <entry>a permision to add to the address</entry>
+                            <entry>a permission to add to the address</entry>
                             <entry/>
                         </row>
                         <row>
@@ -1417,7 +1417,7 @@
 
         <section>
            <title>Using Masked Passwords in Configuration Files</title>
-           <para>By default all passwords in HornetQ server's configuration files are in plaintext form. This usually poses no security issues as those 
+           <para>By default all passwords in HornetQ server's configuration files are in plain text form. This usually poses no security issues as those 
            files should be well protected from unauthorized accessing. However, in some circumstances a user doesn't want to expose its passwords to more 
            eyes than necessary. </para>
 
@@ -1459,7 +1459,7 @@
                  as needed and any other implementations will have access to these to use if they so wish.</para>
                  </section>
 
-                 <section> <title>Passwords in Core Bridge cofigurations</title>
+                 <section> <title>Passwords in Core Bridge configurations</title>
 
                  <para>Core Bridges are configured in the server configuration file and so the masking of its 'password' properties 
                  follows the same rules as that of 'cluster-password'.</para>
@@ -1516,7 +1516,7 @@
 <programlisting>
 &lt;cluster-password>bbc&lt;/cluster-password></programlisting>
 
-<para>This indicates the cluster password is a plaintext value ("bbc").</para>
+<para>This indicates the cluster password is a plain text value ("bbc").</para>
 
 <para>example 2</para>
 
@@ -1524,7 +1524,7 @@
 &lt;mask-password>true&lt;/mask-password>
 &lt;cluster-password>80cf731af62c290&lt;/cluster-password></programlisting>
 
-              <para>This indicates the cluster password is a masked value and HorentQ will use its built-in decoder to decode it. All other
+              <para>This indicates the cluster password is a masked value and HornetQ will use its built-in decoder to decode it. All other
               passwords in the configuration file, Connectors, Acceptors and Bridges, will also use masked passwords.</para>
               </section>
            </section>
@@ -1551,7 +1551,7 @@
 
            </section>
 
-           <section> <title>Masking passwords in HorentQ ResourceAdapters and MDB activation configurations</title>
+           <section> <title>Masking passwords in HornetQ ResourceAdapters and MDB activation configurations</title>
 
            <para>Both ra.xml and MDB activation configuration have a 'password' property that can be masked. They are controlled by the following two 
            optional Resource Adapter properties in ra.xml:</para>
@@ -1599,7 +1599,7 @@
            <section> <title>Choosing a decoder for password masking</title>
 
            <para>As described in the previous sections, all password masking requires a decoder. A decoder uses an algorithm to 
-           convert a masked password into its original cleartext form in order to be used in various security operations. The algorithm 
+           convert a masked password into its original clear text form in order to be used in various security operations. The algorithm 
            used for decoding must match that for encoding. Otherwise the decoding may not be successful.</para>
 
            <para>For user's convenience HornetQ provides a default built-in Decoder. However a user can if they so wish implement their own.</para>
@@ -1646,7 +1646,7 @@ Encoded password: 80cf731af62c290</programlisting>
               It also process all passwords using the new defined decoder.</para>
               </section>
 
-              <section><title>Implementing your own ocdecs</title>
+              <section><title>Implementing your own codecs</title>
 
               <para>To use a different decoder than the built-in one, you either pick one from existing libraries or you implement it yourself.
               All decoders must implement the <literal>org.hornetq.utils.SensitiveDataCodec&lt;T></literal> interface:</para>
@@ -1667,7 +1667,7 @@ public class MyNewDecoder implements SensitiveDataCodec&lt;String>
 {
    public String decode(Object mask) throws Exception
    {
-      //decode the mask into cleartext passord
+      //decode the mask into clear text password
       return "the password";
    }
 

--- a/docs/user-manual/en/configuring-transports.xml
+++ b/docs/user-manual/en/configuring-transports.xml
@@ -219,9 +219,9 @@ etc</programlisting>
                         specifying the host for a connector; a connector makes a connection to one
                         specific address.</para>
                     <note>
-                        <para>Don't forget to specify a host name or ip address! If you want your
+                        <para>Don't forget to specify a host name or IP address! If you want your
                             server able to accept connections from other nodes you must specify a
-                            hostname or ip address at which the acceptor will bind and listen for
+                            hostname or IP address at which the acceptor will bind and listen for
                             incoming connections. The default is localhost which of course is not
                             accessible from remote nodes!</para>
                     </note>
@@ -329,7 +329,7 @@ buffer_size = bandwidth * RTT.</programlisting>
         <section>
             <title>Configuring Netty HTTP</title>
             <para>Netty HTTP tunnels packets over the HTTP protocol. It can be useful in scenarios
-                where firewalls only allow HTTP traffice to pass.</para>
+                where firewalls only allow HTTP traffic to pass.</para>
             <para>Please see the examples for a full working example of using Netty HTTP.</para>
             <para>Netty HTTP uses the same properties as Netty TCP but adds the following additional
                 properties:</para>
@@ -458,8 +458,8 @@ buffer_size = bandwidth * RTT.</programlisting>
    &lt;param key="use-servlet" value="true"/>
    &lt;param key="servlet-path" value="/messaging/HornetQServlet"/>
    &lt;param key="ssl-enabled" value="true"/>
-   &lt;param key="key-store-path" value="path to a keystoree"/>
-   &lt;param key="key-store-password" value="keystore password"/>
+   &lt;param key="key-store-path" value="path to a key-store"/>
+   &lt;param key="key-store-password" value="key-store password"/>
 &lt;/connector></programlisting>
             <para>You will also have to configure the Application server to use a KeyStore. Edit the
                     <literal>server.xml</literal> file that can be found under <literal

--- a/docs/user-manual/en/embedding-hornetq.xml
+++ b/docs/user-manual/en/embedding-hornetq.xml
@@ -140,7 +140,7 @@ Destination destination = jms.lookup("/example/queue");
 
     <para>Create the configuration object - this contains configuration
     information for a HornetQ instance. The setter methods of this class allow
-    you to programmitcally set configuration options as describe in the <xref
+    you to programmatically set configuration options as describe in the <xref
     linkend="server.configuration" /> section.</para>
 
     <para>The acceptors are configured through
@@ -226,7 +226,7 @@ jmsServer.start();</programlisting>
     <trademark>JBoss Micro Container</trademark> or <trademark>Spring
     Framework</trademark>. See <xref linkend="spring.integration" /> for more
     details on Spring and HornetQ, but here's how you would do things with the
-    JBoss Micro Contaier.</para>
+    JBoss Micro Container.</para>
 
     <para>HornetQ standalone uses JBoss Micro Container as the injection
     framework. <literal>HornetQBootstrapServer</literal> and

--- a/docs/user-manual/en/examples.xml
+++ b/docs/user-manual/en/examples.xml
@@ -220,7 +220,7 @@
         </section>
         <section id="examples.hornetq-ra-rar">
             <title>HornetQ Resource Adapter example</title>
-            <para>This examples shows how to build the hornetq resource adapteras a rar for deployment in other Application
+            <para>This examples shows how to build the hornetq resource adapters a rar for deployment in other Application
             Server's</para>
         </section>
         <section>

--- a/docs/user-manual/en/interoperability.xml
+++ b/docs/user-manual/en/interoperability.xml
@@ -105,7 +105,7 @@
       </section>
       
         <section>
-          <title>Stomp and JMS interoperabilty</title>
+          <title>Stomp and JMS interoperability</title>
           <section>
             <title>Using JMS destinations</title>
             <para>As explained in <xref linkend="jms-core-mapping" />, JMS destinations are also mapped to HornetQ addresses and queues.

--- a/docs/user-manual/en/jms-bridge.xml
+++ b/docs/user-manual/en/jms-bridge.xml
@@ -416,7 +416,7 @@
               If this occurs then the bridge will try <literal>Max Retries</literal> to reconnect every
               <literal>Failure Retry Interval</literal> milliseconds as specified in the JMS Bridge definition.</para>
               <para>However since a third party JNDI is used, in this case the JBoss naming server, it is possible for the
-              JNDI lookup to hang if the network were to disappear during the JNDI lookup. To stop this occuring the JNDI
+              JNDI lookup to hang if the network were to disappear during the JNDI lookup. To stop this from occurring the JNDI
               definition can be configured to time out if this occurs. To do this set the <literal>jnp.timeout</literal>
                and the <literal>jnp.sotimeout</literal> on the Initial Context definition. The first sets the connection
               timeout for the initial connection and the second the read timeout for the socket.</para>

--- a/docs/user-manual/en/large-messages.xml
+++ b/docs/user-manual/en/large-messages.xml
@@ -101,7 +101,7 @@ ClientSessionFactory factory = HornetQClient.createClientSessionFactory();</prog
             <para>If you specify the boolean property <literal>compress-large-message</literal> on
                 the <literal>server locator</literal> or <literal>ConnectionFactory</literal> The
                 system will use the ZIP algorithm to compress the message body as the message is
-                transfered to the server's side. Notice that there's no special treatment at the
+                transferred to the server's side. Notice that there's no special treatment at the
                 server's side, all the compressing and uncompressing is done at the client.</para>
         </section>
     </section>

--- a/docs/user-manual/en/libaio.xml
+++ b/docs/user-manual/en/libaio.xml
@@ -23,9 +23,9 @@
 ]>
 <chapter id="libaio">
     <title>Libaio Native Libraries</title>
-    <para>HornetQ distributes a native library, used as a bridge between HornetQ and linux
+    <para>HornetQ distributes a native library, used as a bridge between HornetQ and Linux
         libaio.</para>
-    <para><literal>libaio</literal> is a library, developed as part of the linux kernel project.
+    <para><literal>libaio</literal> is a library, developed as part of the Linux kernel project.
         With <literal>libaio</literal> we submit writes to the operating system where they are
         processed asynchronously. Some time later the OS will call our code back when they have been
         processed.</para>
@@ -89,11 +89,11 @@
             <para>To perform this installation on RHEL or Fedora, you can simply type this at a
                 command line:</para>
             <programlisting>sudo yum install automake libtool autoconf gcc-c++ gcc libaio libaio-devel make</programlisting>
-            <para>Or on debian systems:</para>
+            <para>Or on Debian systems:</para>
             <programlisting>sudo apt-get install automake libtool autoconf gcc-g++ gcc libaio libaio-dev make</programlisting>
             <note>
                 <para>You could find a slight variation of the package names depending on the
-                    version and linux distribution. (for example gcc-c++ on Fedora versus g++ on
+                    version and Linux distribution. (for example gcc-c++ on Fedora versus g++ on
                     Debian systems)</para>
             </note>
         </section>

--- a/docs/user-manual/en/logging.xml
+++ b/docs/user-manual/en/logging.xml
@@ -25,7 +25,7 @@
     <title>Logging</title>
     <para>HornetQ uses the JBoss Logging framework to do its logging and is configurable via the <literal>logging.properties</literal>
        file found in the configuration directories. This is configured by Default to log to both the console and to a file.</para>
-   <para>There are 6 loggers availabe which are as follows:</para>
+   <para>There are 6 loggers available which are as follows:</para>
     <table frame="topbot" border="2">
        <title>Global Configuration Properties</title>
        <tgroup cols="2">

--- a/docs/user-manual/en/management.xml
+++ b/docs/user-manual/en/management.xml
@@ -1078,18 +1078,18 @@ messageCounter.getDepthDelta());</programlisting>
          <para>The name and JNDI name cant be changed, if you want to change these recreate the queue with the appropriate
          settings. The rest of the configuration options, apart from security roles, relate to address settings for a particular
          address. The default address settings are picked up from the servers configuration, if you change any of these
-         settings or create a queue via the console a new Address Settings enrty will be added. For a full explanation on
+         settings or create a queue via the console a new Address Settings entry will be added. For a full explanation on
          Address Settings see <xref linkend="queue-attributes.address-settings"/></para>
          <para>To delete a queue simply click on the delete button beside the queue name in the main JMS Queues screen.
          This will also delete any address settings or security settings previously created for the queues address</para>
          <para>The last part of the configuration options are security roles. If non are provided on creation then the
-            servers default security settings will be shown. If these are changed or updated then new securty settings are
-         created for the address of this queue. For more information on securuty setting see <xref linkend="security"/> </para>
+            servers default security settings will be shown. If these are changed or updated then new security settings are
+         created for the address of this queue. For more information on security setting see <xref linkend="security"/> </para>
          <para>It is also possible via the metrics tab to view statistics for this queue. This will show statistics such
             as message count, consumer count etc.</para>
          <para>Operations can be performed on a queue via the control tab. This will allow you to start and stop the queue,
          list,move,expire and delete messages from the queue and other useful operations. To invoke an operation click on
-         the button for the operation you want, this will take you to a screen where you can parameters for the opertion can be set.
+         the button for the operation you want, this will take you to a screen where you can parameters for the operation can be set.
          Once set clicking the ok button will invoke the operation, results appear at the bottom of the screen.</para>
       </section>
       <section>

--- a/docs/user-manual/en/message-grouping.xml
+++ b/docs/user-manual/en/message-grouping.xml
@@ -118,7 +118,7 @@
          decide between them which route the message should take.</para>
       <para>There are 2 types of handlers; Local and Remote. Each cluster should choose 1 node to
          have a local grouping handler and all the other nodes should have remote handlers- it's the
-         local handler that actually makes the decsion as to what route should be used, all the
+         local handler that actually makes the decision as to what route should be used, all the
          other remote handlers converse with this. Here is a sample config for both types of
          handler, this should be configured in the <emphasis role="italic"
             >hornetq-configuration.xml</emphasis>
@@ -136,7 +136,7 @@
 &lt;/grouping-handler></programlisting></para>
       <para>The <emphasis role="italic">address</emphasis> attribute refers to a cluster connection
          and the address it uses, refer to the clustering section on how to configure clusters. The
-            <emphasis role="italic">timeout</emphasis> attribute referes to how long to wait for a
+            <emphasis role="italic">timeout</emphasis> attribute referees to how long to wait for a
          decision to be made, an exception will be thrown during the send if this timeout is
          reached, this ensures that strict ordering is kept.</para>
       <para>The decision as to where a message should be routed to is initially proposed by the node
@@ -172,7 +172,7 @@
                      it. This can be avoided by making sure that the queue is deleted by the session
                      that is sending the messages. This means that when the next message is sent it
                      is sent to the node where the queue was deleted meaning a new proposal can
-                     succesfully take place. Alternatively you could just start using a different
+                     successfully take place. Alternatively you could just start using a different
                      group id.</para>
                </listitem>
                <listitem>

--- a/docs/user-manual/en/messaging-concepts.xml
+++ b/docs/user-manual/en/messaging-concepts.xml
@@ -34,7 +34,7 @@
         you can skip this chapter.</para>
     <section>
         <title>Messaging Concepts</title>
-        <para>Messaging systems allow you to loosely couple heteregenous systems together, whilst
+        <para>Messaging systems allow you to loosely couple heterogeneous systems together, whilst
             typically providing reliability, transactions and many other features.</para>
         <para>Unlike systems based on a <ulink
                 url="http://en.wikipedia.org/wiki/Remote_procedure_call">Remote Procedure
@@ -194,7 +194,7 @@
                 recently.</para>
             <para>It seems plausible that API standards for cloud computing may converge on a REST
                 style set of interfaces and consequently a REST messaging approach is a very strong
-                contender for becoming the defacto method for messaging interoperability.</para>
+                contender for becoming the de-facto method for messaging interoperability.</para>
             <para>With a REST approach messaging resources are manipulated as resources defined by a
                 URI and typically using a simple set of operations on those resources, e.g. PUT,
                 POST, GET etc. REST approaches to messaging often use HTTP as their underlying

--- a/docs/user-manual/en/persistence.xml
+++ b/docs/user-manual/en/persistence.xml
@@ -74,7 +74,7 @@
                 install libaio please see <xref linkend="installing-aio"/>.</para>
             <para>Also, please note that AIO will only work with the following file systems: ext2,
                 ext3, ext4, jfs, xfs. With other file systems, e.g. NFS it may appear to work, but
-                it will fall back to a slower sychronous behaviour. Don't put the journal on a NFS
+                it will fall back to a slower synchronous behaviour. Don't put the journal on a NFS
                 share!</para>
             <para>For more information on libaio please see <xref linkend="libaio"/>.</para>
             <para>libaio is part of the kernel project.</para>
@@ -206,7 +206,7 @@
                         >journal-min-files</literal> number of files.</para>
                 <para>Creating journal files and filling them with padding is a fairly expensive
                     operation and we want to minimise doing this at run-time as files get filled. By
-                    precreating files, as one is filled the journal can immediately resume with the
+                    pre-creating files, as one is filled the journal can immediately resume with the
                     next one without pausing to create it.</para>
                 <para>Depending on how much data you expect your queues to contain at steady state
                     you should tune this number of files to match that total amount of data.</para>
@@ -220,7 +220,7 @@
                 <para>When using NIO, this value should always be equal to <literal
                     >1</literal></para>
                 <para>When using AIO, the default should be <literal>500</literal>.</para>
-                <para>The system maintains different defaults for this parameter depening on whether
+                <para>The system maintains different defaults for this parameter depending on whether
                     it's NIO or AIO (default for NIO is 1, default for AIO is 500)</para>
                 <para>There is a limit and the total max AIO can't be higher than what is configured
                     at the OS level (/proc/sys/fs/aio-max-nr) usually at 65536.</para>

--- a/docs/user-manual/en/pre-acknowledge.xml
+++ b/docs/user-manual/en/pre-acknowledge.xml
@@ -82,8 +82,8 @@ Session session = connection.createSession(false, HornetQJMSConstants.PRE_ACKNOW
     </section>
     <section id="individual-ack">
         <title>Individual Acknowledge</title>
-        <para>A valid usecase for individual acknowledgement would be when you need to have your own scheduling and you don't know when your message processing will be finished. You should prefer having one consumer per thread worker
-            but this is not possible in some circunstances depending on how complex is your processing. For that you can use the individual Acknowledgement. </para>
+        <para>A valid use-case for individual acknowledgement would be when you need to have your own scheduling and you don't know when your message processing will be finished. You should prefer having one consumer per thread worker
+            but this is not possible in some circumstances depending on how complex is your processing. For that you can use the individual Acknowledgement. </para>
         <para>You basically setup Individual ACK by creating a session with the acknowledge mode with <literal>HornetQJMSConstants.INDIVIDUAL_ACKNOWLEDGE</literal>. Individual ACK inherits all the semantics from Client Acknowledge,
             with the exception the message is individually acked.</para>
         <note>

--- a/docs/user-manual/en/preface.xml
+++ b/docs/user-manual/en/preface.xml
@@ -43,7 +43,7 @@
     <para>Why use HornetQ? Here are just a few of the reasons:</para>
     <itemizedlist>
         <listitem>
-            <para>100% open source software. HornetQ is licenced using the Apache Software License v
+            <para>100% open source software. HornetQ is licensed using the Apache Software License v
                 2.0 to minimise barriers to adoption.</para>
         </listitem>
         <listitem>

--- a/docs/user-manual/en/project-info.xml
+++ b/docs/user-manual/en/project-info.xml
@@ -64,7 +64,7 @@
                      >https://github.com/hornetq/hornetq</ulink></para>
             </listitem>
             <listitem>
-               <para>All release tags are availble from <ulink
+               <para>All release tags are available from <ulink
                      url="https://github.com/hornetq/hornetq/tags"
                      >https://github.com/hornetq/hornetq/tags</ulink></para>
             </listitem>

--- a/docs/user-manual/en/queue-attributes.xml
+++ b/docs/user-manual/en/queue-attributes.xml
@@ -112,7 +112,7 @@
    &lt;/address-setting>
 &lt;/address-settings></programlisting>
         <para>The idea with address settings, is you can provide a block of settings which will be
-            applied against any adresses that match the string in the <literal>match</literal> attribute. In the
+            applied against any addresses that match the string in the <literal>match</literal> attribute. In the
             above example the settings would only be applied to any addresses which exactly match
             the address <literal>jms.queue.exampleQueue</literal>, but you can also use wildcards to apply sets of
             configuration against many addresses. The wildcard syntax used is described <link linkend="wildcard-syntax">here</link>.</para>

--- a/docs/user-manual/en/rest.xml
+++ b/docs/user-manual/en/rest.xml
@@ -215,7 +215,7 @@ Content-Type: application/xml
             </note>
 
             <para>
-                It's worth noting that when deploying a WAR in a Java EE application server
+                It is worth noting that when deploying a WAR in a Java EE application server
                 like AS7 the URL for the resulting application will include the name of the
                 WAR by default.  For example, if you've constructed a WAR as described above
                 named "hornetq-rest.war" then clients will access it at, e.g.
@@ -566,7 +566,7 @@ curl --head http://example.com/queues/jms.queue.bar</programlisting>
         </section>
 
         <section>
-            <title>Topic Resource Respones Headers</title>
+            <title>Topic Resource Response Headers</title>
 
             <para>Below is a list of response headers you should expect when
                 interacting with a Topic resource.
@@ -850,7 +850,7 @@ ServerMessage[messageID=20,priority=4, bodySize=1500,expiration=0, durable=true,
             <para>An alternative to this approach is to use the <literal>msg-create-with-id</literal>
                 header. This is not an invokable URL, but a URL template. The idea is that
                 the client provides the <literal>DUPLICATE_DETECTION_ID</literal> and creates
-                it's own <literal>create-next</literal> URL. The <literal>msg-create-with-id</literal>
+                its own <literal>create-next</literal> URL. The <literal>msg-create-with-id</literal>
                 header looks like this (you've see it in previous examples, but we haven't used it):
             </para>
 
@@ -941,13 +941,13 @@ Content-Type: application/xml
 
         <para>You create consumer resources by doing a simple POST to the URL
             published by the <literal>msg-pull-consumers</literal>
-            response header if you're interacting with a queue, the
+            response header if you are interacting with a queue, the
             <literal>msg-pull-subscribers</literal> response header if you're
             interacting with a topic. These headers are provided by the main queue or
             topic resource discussed in <link linkend="basics">HornetQ REST Interface
             Basics</link>. Doing an empty POST to one of these
             URLs will create a consumer resource that follows an auto-acknowledge
-            protocol and, if you're interacting with a topic, creates a temporty
+            protocol and, if you are interacting with a topic, creates a temporarily 
             subscription to the topic. If you want to use the acknowledgement protocol
             and/or create a durable subscription (topics only), then you must use the
             form parameters (<literal>application/x-www-form-urlencoded</literal>)
@@ -981,7 +981,7 @@ Content-Type: application/xml
                 <para><literal>selector</literal>. This is an optional JMS selector
                     string. The HornetQ REST interface adds HTTP headers to the
                     JMS message for REST produced messages. HTTP headers are
-                    prefixed with "http_" and every '-' charactor is converted
+                    prefixed with "http_" and every '-' character is converted
                     to a '$'.
                 </para>
             </listitem>
@@ -1214,7 +1214,7 @@ msg-consume-next: http://example.com/queues/jms.queue.bar/pull-consumers/333/con
                             a 503 response back. As per the HTTP 1.1 spec, a 503 response may
                             return a Retry-After head specifying the time in seconds that you
                             should retry a post. Also notice, that another new
-                            msg-consume-next URL is present. Although it probabley is the same
+                            msg-consume-next URL is present. Although it probably is the same
                             URL you used last post, get in the habit of using URLs returned in
                             response headers as future versions of HornetQ REST might be
                             redirecting you or adding additional data to the URL after
@@ -1296,7 +1296,7 @@ msg-consume-next: http://example.com/queues/jms.queue.bar/pull-consumers/333/con
             <para>The manual acknowledgement protocol is similar to the auto-ack
                 protocol except there is an additional round trip to the server to tell
                 it that you have received the message and that the server can internally
-                ack the message. Here is a list of the respone headers you will be
+                ack the message. Here is a list of the response headers you will be
                 interested in.
             </para>
 
@@ -1904,7 +1904,7 @@ Location: http://example.com/topics/jms.topic.bar/push-subscriptions/1-333-1212<
                 element, you must define a unique id attribute. You must also define a
                 destination element to specify the queue you should register a consumer
                 with. For a topic, the destination element is the name of the
-                subscription that will be reated. For a topic, you must also specify the
+                subscription that will be created. For a topic, you must also specify the
                 topic name within the topic element.
             </para>
 
@@ -2122,7 +2122,7 @@ Location: http://example.com/topics/jms.topic.testTopic</programlisting>
     <section>
         <title>Mixing JMS and REST</title>
 
-        <para>The HornetQ REST interface supports mixing JMS and REST producres
+        <para>The HornetQ REST interface supports mixing JMS and REST producers
             and consumers. You can send an ObjectMessage through a JMS Producer, and
             have a REST client consume it. You can have a REST client POST a message
             to a topic and have a JMS Consumer receive it. Some simple transformations

--- a/docs/user-manual/en/security.xml
+++ b/docs/user-manual/en/security.xml
@@ -262,8 +262,8 @@
           <para>JBoss can be configured to allow client login, basically this is when a JEE component such as a Servlet
              or EJB sets security credentials on the current security context  and these are used throughout the call.
              If you would like these credentials to be used by HornetQ when sending or consuming messages then
-          set <literal>allowClientLogin</literal> to true. This will bypass HornetQ authentication and propgate the
-          provided Security Context. If you would like HornetQ to authenticate using the propogated security then set the
+          set <literal>allowClientLogin</literal> to true. This will bypass HornetQ authentication and propagate the
+          provided Security Context. If you would like HornetQ to authenticate using the propagated security then set the
           <literal>authoriseOnClientLogin</literal> to true also.</para>
           <para>There is more info on using the JBoss client login module <ulink
                 url="http://community.jboss.org/wiki/ClientLoginModule">here</ulink> </para>

--- a/docs/user-manual/en/using-jms.xml
+++ b/docs/user-manual/en/using-jms.xml
@@ -38,7 +38,7 @@
         to use JMS with HornetQ without using any JNDI.</para>
     <section>
         <title>A simple ordering system</title>
-        <para>For this chapter we're going to use a very simple ordering system as our example. It's
+        <para>For this chapter we're going to use a very simple ordering system as our example. It is
             a somewhat contrived example because of its extreme simplicity, but it serves to
             demonstrate the very basics of setting up and using JMS.</para>
         <para>We will have a single JMS Queue called <literal>OrderQueue</literal>, and we will have
@@ -46,8 +46,8 @@
             single <literal>MessageConsumer</literal> consuming the order message from the
             queue.</para>
         <para>The queue will be a <literal>durable</literal> queue, i.e. it will survive a server
-            restart or crash. We also want to predeploy the queue, i.e. specify the queue in the
-            server JMS configuration so it's created automatically without us having to explicitly
+            restart or crash. We also want to pre-deploy the queue, i.e. specify the queue in the
+            server JMS configuration so it is created automatically without us having to explicitly
             create it from the client.</para>
     </section>
     <section id="using-jms.server.configuration">
@@ -200,7 +200,7 @@ java.naming.factory.url.pkgs=org.jboss.naming:org.jnp.interfaces</programlisting
 &lt;/bean></programlisting>
         <note>
             <para>If you want your JNDI server to be available to non local clients make sure you
-                change it's bind address to something other than <literal
+                change its bind address to something other than <literal
                 >localhost</literal>!</para>
         </note>
         <note>
@@ -236,12 +236,12 @@ producer.send(message);</programlisting>
         <para>And we consume the message:</para>
         <programlisting>TextMessage receivedMessage = (TextMessage)consumer.receive();
 System.out.println("Got order: " + receivedMessage.getText());</programlisting>
-        <para>It's as simple as that. For a wide range of working JMS examples please see the
+        <para>It is as simple as that. For a wide range of working JMS examples please see the
             examples directory in the distribution.</para>
         <warning>
             <para>Please note that JMS connections, sessions, producers and consumers are
                     <emphasis>designed to be re-used</emphasis>.</para>
-            <para>It's an anti-pattern to create new connections, sessions, producers and consumers
+            <para>It is an anti-pattern to create new connections, sessions, producers and consumers
                 for each message you produce or consume. If you do this, your application will
                 perform very poorly. This is discussed further in the section on performance tuning
                     <xref linkend="perf-tuning"/>.</para>
@@ -249,7 +249,7 @@ System.out.println("Got order: " + receivedMessage.getText());</programlisting>
     </section>
     <section>
         <title>Directly instantiating JMS Resources without using JNDI</title>
-        <para>Although it's a very common JMS usage pattern to lookup JMS <emphasis>Administered
+        <para>Although it is a very common JMS usage pattern to lookup JMS <emphasis>Administered
                 Objects</emphasis> (that's JMS Queue, Topic and ConnectionFactory instances) from
             JNDI, in some cases a JNDI server is not available and you still want to use JMS, or you
             just think "Why do I need JNDI? Why can't I just instantiate these objects

--- a/docs/user-manual/en/using-server.xml
+++ b/docs/user-manual/en/using-server.xml
@@ -34,7 +34,7 @@
     <section>
         <title>Starting and Stopping the standalone server</title>
         <para>In the distribution you will find a directory called <literal>bin</literal>.</para>
-        <para><literal>cd</literal> into that directory and you'll find a unix/linux script called
+        <para><literal>cd</literal> into that directory and you will find a Unix/Linux script called
                 <literal>run.sh</literal> and a windows batch file called <literal
             >run.bat</literal></para>
         <para>To run on Unix/Linux type <literal>./run.sh</literal></para>
@@ -42,7 +42,7 @@
         <para>These scripts are very simple and basically just set-up the classpath and some JVM
             parameters and start the JBoss Microcontainer. The Microcontainer is a light weight
             container used to deploy the HornetQ POJO's</para>
-        <para>To stop the server you'll also find a unix/linux script <literal>stop.sh</literal> and
+        <para>To stop the server you will also find a Unix/Linux script <literal>stop.sh</literal> and
             a windows batch file <literal>stop.bat</literal></para>
         <para>To run on Unix/Linux type <literal>./stop.sh</literal></para>
         <para>To run on Windows type <literal>stop.bat</literal></para>
@@ -314,7 +314,7 @@
     <section id="server.microkernel.configuration">
         <title>JBoss AS4 MBean Service.</title>
         <note>
-            <para>The section is only to configure HornetQ on JBoss AS4. The service funtionality is
+            <para>The section is only to configure HornetQ on JBoss AS4. The service functionality is
                 similar to Microcontainer Beans</para>
         </note>
         <para>
@@ -348,7 +348,7 @@
 &lt;/server></programlisting>
         </para>
         <para>This jboss-service.xml configuration file is included inside the hornetq-service.sar
-            on AS4 with embebbed HornetQ. As you can see, on this configuration file we are starting
+            on AS4 with embedded HornetQ. As you can see, on this configuration file we are starting
             various services:</para>
         <itemizedlist>
             <listitem>


### PR DESCRIPTION
tip: use 'git diff --color-words' to view this diff.

Note (although I did not change these systematically), a formal
text should not contain contractions. Use "should not" instead of "shouldn't".
