### PR TITLE
HORNETQ-804 : compress large meassges to small messages if size allows

### DIFF
--- a/docs/user-manual/en/configuration-index.xml
+++ b/docs/user-manual/en/configuration-index.xml
@@ -1311,13 +1311,6 @@
                             <entry>100 * 1024</entry>
                         </row>
                         <row>
-                            <entry id="configuration.connection-factory.compress-large-messages">
-                               <link linkend="large.message.configuring">connection-factory.compress-large-messages</link></entry>
-                            <entry>Boolean</entry>
-                            <entry>If compress large messages when sending</entry>
-                            <entry>false</entry>
-                        </row>
-                        <row>
                             <entry id="configuration.connection-factory.avoid-large-messages">
                                <link linkend="large.message.configuring">connection-factory.avoid-large-messages</link></entry>
                             <entry>Boolean</entry>

--- a/docs/user-manual/en/large-messages.xml
+++ b/docs/user-manual/en/large-messages.xml
@@ -99,36 +99,24 @@ ClientSessionFactory factory = HornetQClient.createClientSessionFactory();</prog
         <section>
             <title>Compressed Large Messages</title>
             <para>
-				You can choose to send large messages in compressed form. There are two options that
-				controls how large messages are compressed and sent, i.e. <literal>
-				compress-large-messages</literal> and <literal>avoid-large-messages</literal>.
+				You can choose to send large messages in compressed form using <literal>
+				compress-large-messages</literal> attributes.
             </para>
             <section>
 				<title><literal>compress-large-messages</literal></title>
                 <para>If you specify the boolean property <literal>compress-large-messages</literal> on
-                the <literal>server locator</literal> or <literal>ConnectionFactory</literal> The
+                the <literal>server locator</literal> or <literal>ConnectionFactory</literal> as true, The
                 system will use the ZIP algorithm to compress the message body as the message is
                 transferred to the server's side. Notice that there's no special treatment at the
                 server's side, all the compressing and uncompressing is done at the client.</para>
-            </section>
-            <section>
-				<title><literal>avoid-large-messages</literal></title>
-                <para>If you specify the boolean property <literal>avoid-large-messages</literal> on
-                the <literal>server locator</literal> or <literal>ConnectionFactory</literal>, large
-                messages are compressed the same way as if <literal>compress-large-message</literal>
-                is set to true and, if the compressed size is below <literal>
-			    min-large-message-size</literal>, are sent to server as regular messages. This means
-			    that those compress large messages won't be written into the server's large-message
+                <para>If the compressed size of a large message is below <literal>
+                min-large-message-size</literal>, it is sent to server as regular messages. This means
+			    that the message won't be written into the server's large-message
 			    data directory, thus reducing the disk I/O.</para>
             </section>
             <section>
-				<para>Note that you only need to set one of the two above attributes that suits your needs.
-				Setting <literal>avoid-large-messages</literal> automatically makes 
-				<literal>compress-large-message</literal> true. Setting <literal>
-				compress-large-message</literal> to false automatically makes <literal>avoid-large-message</literal>
-				to be false.</para>
-				<para>If you use JMS, you can achieve large messages compression by configuring your 
-				connection factories. For example,</para>
+                <para>If you use JMS, you can achieve large messages compression by configuring your 
+                connection factories. For example,</para>
             <programlisting>...
 &lt;connection-factory name="ConnectionFactory">
    &lt;connectors>

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/HornetQClient.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/HornetQClient.java
@@ -42,8 +42,6 @@ public final class HornetQClient
 
    public static final boolean DEFAULT_COMPRESS_LARGE_MESSAGES = false;
 
-   public static final boolean DEFAULT_AVOID_LARGE_MESSAGES = false;
-
    public static final int DEFAULT_CONSUMER_WINDOW_SIZE = 1024 * 1024;
 
    public static final int DEFAULT_CONSUMER_MAX_RATE = -1;

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
@@ -706,13 +706,9 @@ public interface ServerLocator
 
    boolean isCompressLargeMessage();
 
-   void setCompressLargeMessage(boolean compress);
+   void setCompressLargeMessage(boolean avoidLargeMessages);
 
    void addClusterTopologyListener(ClusterTopologyListener listener);
 
    void removeClusterTopologyListener(ClusterTopologyListener listener);
-
-   boolean isAvoidLargeMessage();
-
-   void setAvoidLargeMessage(boolean avoidLargeMessages);
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
@@ -39,13 +39,11 @@ public interface ClientConsumerInternal extends ClientConsumer
 
    boolean isBrowseOnly();
 
-   void handleMessage(ClientMessageInternal message) throws Exception;
+   void handleMessage(SessionReceiveMessage message) throws Exception;
 
    void handleLargeMessage(SessionReceiveLargeMessage largeMessageHeader) throws Exception;
 
    void handleLargeMessageContinuation(SessionReceiveContinuationMessage continuation) throws Exception;
-
-   void handleCompressedMessage(SessionReceiveMessage message) throws Exception;
 
    void flowControl(final int messageBytes, final boolean discountSlowConsumer) throws HornetQException;
 

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientProducerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientProducerImpl.java
@@ -354,9 +354,7 @@ public class ClientProducerImpl implements ClientProducerInternal
       {
          msgI.putBooleanProperty(Message.HDR_LARGE_COMPRESSED, true);
 
-         boolean avoidLarge = session.isAvoidLargeMessages();
-
-         if (avoidLarge && (!msgI.isServerMessage()))
+         if (!msgI.isServerMessage())
          {
             InputStream input = msgI.getBodyInputStream();
             if (input == null)

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -887,7 +887,6 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                                                                      serverLocator.isCacheLargeMessagesClient(),
                                                                      serverLocator.getMinLargeMessageSize(),
                                                                      serverLocator.isCompressLargeMessage(),
-                                                                     serverLocator.isAvoidLargeMessage(),
                                                                      serverLocator.getInitialMessagePacketSize(),
                                                                      serverLocator.getGroupID(),
                                                                      connection,

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -166,8 +166,6 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
 
    private final boolean compressLargeMessages;
 
-   private final boolean avoidLargeMessages;
-
    private volatile int initialMessagePacketSize;
 
    private final boolean cacheLargeMessageClient;
@@ -224,7 +222,6 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
                             final boolean cacheLargeMessageClient,
                             final int minLargeMessageSize,
                             final boolean compressLargeMessages,
-                            final boolean avoidLargeMessages,
                             final int initialMessagePacketSize,
                             final String groupID,
                             final CoreRemotingConnection remotingConnection,
@@ -282,8 +279,6 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
       this.minLargeMessageSize = minLargeMessageSize;
 
       this.compressLargeMessages = compressLargeMessages;
-
-      this.avoidLargeMessages = avoidLargeMessages;
 
       this.initialMessagePacketSize = initialMessagePacketSize;
 
@@ -765,11 +760,6 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
       return compressLargeMessages;
    }
 
-   public boolean isAvoidLargeMessages()
-   {
-      return avoidLargeMessages;
-   }
-
    /**
     * @return the cacheLargeMessageClient
     */
@@ -906,18 +896,8 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
 
          clMessage.setFlowControlSize(message.getPacketSize());
 
-         consumer.handleMessage(clMessage);
+         consumer.handleMessage(message);
       }
-   }
-
-   public void handleReceiveCompressedMessage(long consumerID, SessionReceiveMessage message) throws Exception
-   {
-      ClientConsumerInternal consumer = getConsumer(consumerID);
-
-      if (consumer != null)
-      {
-         consumer.handleCompressedMessage(message);
-      }      
    }
 
    public void handleReceiveLargeMessage(final long consumerID, final SessionReceiveLargeMessage message) throws Exception

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionInternal.java
@@ -43,8 +43,6 @@ public interface ClientSessionInternal extends ClientSession
 
    boolean isCompressLargeMessages();
 
-   boolean isAvoidLargeMessages();
-
    void expire(long consumerID, long messageID) throws HornetQException;
 
    void addConsumer(ClientConsumerInternal consumer);
@@ -60,14 +58,6 @@ public interface ClientSessionInternal extends ClientSession
    void handleReceiveLargeMessage(long consumerID, SessionReceiveLargeMessage message) throws Exception;
 
    void handleReceiveContinuation(long consumerID, SessionReceiveContinuationMessage continuation) throws Exception;
-
-   /**
-    * This method deals with messages arrived as regular message but its contents are compressed.
-    * Such messages come from message senders who are configured to compress large messages, and
-    * if some of the messages are compressed below the min-large-message-size limit, they are sent
-    * as regular messages (see avoid-large-messages option).
-    */
-   void handleReceiveCompressedMessage(long consumerID, SessionReceiveMessage message) throws Exception;
 
    void preHandleFailover(CoreRemotingConnection connection);
 

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionPacketHandler.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionPacketHandler.java
@@ -18,7 +18,6 @@ import static org.hornetq.core.protocol.core.impl.PacketImpl.SESS_RECEIVE_CONTIN
 import static org.hornetq.core.protocol.core.impl.PacketImpl.SESS_RECEIVE_LARGE_MSG;
 import static org.hornetq.core.protocol.core.impl.PacketImpl.SESS_RECEIVE_MSG;
 
-import org.hornetq.api.core.Message;
 import org.hornetq.core.protocol.core.Channel;
 import org.hornetq.core.protocol.core.ChannelHandler;
 import org.hornetq.core.protocol.core.Packet;
@@ -70,15 +69,8 @@ final class ClientSessionPacketHandler implements ChannelHandler
             case SESS_RECEIVE_MSG:
             {
                SessionReceiveMessage message = (SessionReceiveMessage)packet;
-               
-               if (message.getMessage().getBooleanProperty(Message.HDR_LARGE_COMPRESSED))
-               {
-                  clientSession.handleReceiveCompressedMessage(message.getConsumerID(), message);
-               }
-               else
-               {
-                  clientSession.handleReceiveMessage(message.getConsumerID(), message);
-               }
+
+               clientSession.handleReceiveMessage(message.getConsumerID(), message);
 
                break;
             }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
@@ -399,11 +399,6 @@ public class DelegatingSession implements ClientSessionInternal
       session.handleReceiveMessage(consumerID, message);
    }
 
-   public void handleReceiveCompressedMessage(long consumerID, SessionReceiveMessage message) throws Exception
-   {
-      session.handleReceiveCompressedMessage(consumerID, message);
-   }
-
    public boolean isAutoCommitAcks()
    {
       return session.isAutoCommitAcks();
@@ -592,11 +587,6 @@ public class DelegatingSession implements ClientSessionInternal
    public boolean isCompressLargeMessages()
    {
       return session.isCompressLargeMessages();
-   }
-
-   public boolean isAvoidLargeMessages()
-   {
-      return session.isAvoidLargeMessages();
    }
 
    @Override

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -205,8 +205,6 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
 
    private TransportConfiguration clusterTransportConfiguration;
 
-   private boolean avoidLargeMessage;
-
    /*
    * *************WARNING***************
    * remember that when adding any new classes that we have to support serialization with previous clients.
@@ -480,8 +478,6 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       cacheLargeMessagesClient = HornetQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT;
 
       compressLargeMessage = HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES;
-
-      avoidLargeMessage = HornetQClient.DEFAULT_AVOID_LARGE_MESSAGES;
 
       clusterConnection = false;
    }
@@ -1268,21 +1264,9 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return compressLargeMessage;
    }
 
-   public void setCompressLargeMessage(boolean compress)
+   public void setCompressLargeMessage(boolean avoid)
    {
-      this.compressLargeMessage = compress;
-      if (!compress) this.avoidLargeMessage = false;
-   }
-
-   public boolean isAvoidLargeMessage()
-   {
-      return avoidLargeMessage;
-   }
-
-   public void setAvoidLargeMessage(boolean avoid)
-   {
-      this.avoidLargeMessage = avoid;
-      if (avoid) this.compressLargeMessage = true;
+      this.compressLargeMessage = avoid;
    }
 
    private void checkWrite()

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnectionFactory.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnectionFactory.java
@@ -543,19 +543,9 @@ public class HornetQConnectionFactory implements Serializable, Referenceable
       return serverLocator.isCompressLargeMessage();
    }
 
-   public void setCompressLargeMessage(boolean compress)
+   public void setCompressLargeMessage(boolean avoidLargeMessages)
    {
-      serverLocator.setCompressLargeMessage(compress);
-   }
-
-   public boolean isAvoidLargeMessage()
-   {
-      return serverLocator.isAvoidLargeMessage();
-   }
-
-   public void setAvoidLargeMessage(boolean avoidLargeMessages)
-   {
-      serverLocator.setAvoidLargeMessage(avoidLargeMessages);
+      serverLocator.setCompressLargeMessage(avoidLargeMessages);
    }
 
    public void close()

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSConnectionFactoryControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSConnectionFactoryControlImpl.java
@@ -81,17 +81,6 @@ public class JMSConnectionFactoryControlImpl extends StandardMBean implements Co
       recreateCF();
    }
 
-   public boolean isAvoidLargeMessages()
-   {
-      return cf.isAvoidLargeMessage();
-   }
-
-   public void setAvoidLargeMessages(final boolean compress)
-   {
-      cfConfig.setAvoidLargeMessages(compress);
-      recreateCF();
-   }
-
    public boolean isHA()
    {
       return cfConfig.isHA();

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/HornetQJMSServerBundle.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/HornetQJMSServerBundle.java
@@ -47,7 +47,4 @@ public interface HornetQJMSServerBundle
 
    @Message(id = 129007, value = "Error decoding password using codec instance", format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException errorDecodingPassword(@Cause Exception e);
-
-   @Message(id = 129009, value = "Either '{0}' or '{1}' can be presented in the configuration, not both", format = Message.Format.MESSAGE_FORMAT)
-   HornetQInternalErrorException oneOfViolationParsingCF(String param1, String param2);
 }

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/ConnectionFactoryConfiguration.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/ConnectionFactoryConfiguration.java
@@ -78,7 +78,7 @@ public interface ConnectionFactoryConfiguration extends EncodingSupport
 
    boolean isCompressLargeMessages();
 
-   void setCompressLargeMessages(boolean compress);
+   void setCompressLargeMessages(boolean avoidLargeMessages);
 
    int getConsumerWindowSize();
 
@@ -171,8 +171,4 @@ public interface ConnectionFactoryConfiguration extends EncodingSupport
    void setFactoryType(JMSFactoryType factType);
 
    JMSFactoryType getFactoryType();
-
-   void setAvoidLargeMessages(boolean avoidLargeMessages);
-   
-   boolean isAvoidLargeMessages();
 }

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
@@ -66,10 +66,8 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
    private boolean cacheLargeMessagesClient = HornetQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT;
 
    private int minLargeMessageSize = HornetQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE;
-
-   private boolean compressLargeMessage = HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES;
    
-   private boolean avoidLargeMessages = HornetQClient.DEFAULT_AVOID_LARGE_MESSAGES;
+   private boolean compressLargeMessage = HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES;
 
    private int consumerWindowSize = HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
 
@@ -271,17 +269,6 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
    public void setMinLargeMessageSize(final int minLargeMessageSize)
    {
       this.minLargeMessageSize = minLargeMessageSize;
-   }
-
-   public boolean isCompressLargeMessages()
-   {
-      return compressLargeMessage;
-   }
-
-   public void setCompressLargeMessages(final boolean compress)
-   {
-      this.compressLargeMessage = compress;
-      if (!compress) this.avoidLargeMessages = false;
    }
 
    public int getConsumerWindowSize()
@@ -815,16 +802,15 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
    }
 
    @Override
-   public void setAvoidLargeMessages(boolean avoidLargeMessages)
+   public void setCompressLargeMessages(boolean compressLargeMessage)
    {
-      this.avoidLargeMessages = avoidLargeMessages;
-      if (avoidLargeMessages) this.compressLargeMessage = true;
+      this.compressLargeMessage = compressLargeMessage;
    }
 
    @Override
-   public boolean isAvoidLargeMessages()
+   public boolean isCompressLargeMessages()
    {
-      return this.avoidLargeMessages;
+      return this.compressLargeMessage;
    }
 
    // Public --------------------------------------------------------

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerConfigParserImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerConfigParserImpl.java
@@ -273,31 +273,9 @@ public class JMSServerConfigParserImpl implements JMSServerConfigParser
                                                                 HornetQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE,
                                                                 Validators.GT_ZERO);
 
-      Boolean compressLargeMessages = XMLConfigurationUtil.getNullableBoolean(e,
+      boolean compressLargeMessages = XMLConfigurationUtil.getBoolean(e,
                                                                 "compress-large-messages",
-                                                                null);
-
-      Boolean avoidLargeMessages = XMLConfigurationUtil.getNullableBoolean(e,
-                                                                "avoid-large-messages",
-                                                                null);
-
-      if (compressLargeMessages != null)
-      {
-         if (avoidLargeMessages != null)
-         {
-            throw HornetQJMSServerBundle.BUNDLE.oneOfViolationParsingCF("compress-large-messages", "avoid-large-messages");         
-         }
-         avoidLargeMessages = false;
-      }
-      else if (avoidLargeMessages != null)
-      {
-         compressLargeMessages = avoidLargeMessages;
-      }
-      else
-      {
-         compressLargeMessages = false;
-         avoidLargeMessages = false;
-      }
+                                                                HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES);
 
       boolean blockOnAcknowledge = XMLConfigurationUtil.getBoolean(e,
                                                                    "block-on-acknowledge",
@@ -425,7 +403,6 @@ public class JMSServerConfigParserImpl implements JMSServerConfigParser
       cfConfig.setCacheLargeMessagesClient(cacheLargeMessagesClient);
       cfConfig.setMinLargeMessageSize(minLargeMessageSize);
       cfConfig.setCompressLargeMessages(compressLargeMessages);
-      cfConfig.setAvoidLargeMessages(avoidLargeMessages);
       cfConfig.setConsumerWindowSize(consumerWindowSize);
       cfConfig.setConsumerMaxRate(consumerMaxRate);
       cfConfig.setConfirmationWindowSize(confirmationWindowSize);

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -987,7 +987,6 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
          configuration.setCallFailoverTimeout(callFailoverTimeout);
          configuration.setCacheLargeMessagesClient(cacheLargeMessagesClient);
          configuration.setMinLargeMessageSize(minLargeMessageSize);
-         configuration.setCompressLargeMessages(compressLargeMessage);
          configuration.setConsumerWindowSize(consumerWindowSize);
          configuration.setConsumerMaxRate(consumerMaxRate);
          configuration.setConfirmationWindowSize(confirmationWindowSize);
@@ -1388,7 +1387,6 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
       cf.setReconnectAttempts(cfConfig.getReconnectAttempts());
       cf.setFailoverOnInitialConnection(cfConfig.isFailoverOnInitialConnection());
       cf.setCompressLargeMessage(cfConfig.isCompressLargeMessages());
-      cf.setAvoidLargeMessage(cfConfig.isAvoidLargeMessages());
       cf.setGroupID(cfConfig.getGroupID());
       return cf;
    }

--- a/hornetq-jms-server/src/main/resources/schema/hornetq-jms.xsd
+++ b/hornetq-jms-server/src/main/resources/schema/hornetq-jms.xsd
@@ -85,9 +85,6 @@
             <xsd:element name="compress-large-messages" type="xsd:boolean"
                 maxOccurs="1" minOccurs="0">
             </xsd:element>
-            <xsd:element name="avoid-large-messages" type="xsd:boolean"
-                maxOccurs="1" minOccurs="0">
-            </xsd:element>
             <xsd:element name="client-id" type="xsd:string"
                 maxOccurs="1" minOccurs="0">
             </xsd:element>            

--- a/hornetq-ra/src/main/java/org/hornetq/ra/ConnectionFactoryProperties.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/ConnectionFactoryProperties.java
@@ -74,8 +74,6 @@ public class ConnectionFactoryProperties
 
    private Boolean compressLargeMessage;
 
-   private Boolean avoidLargeMessage;
-
    private Integer consumerWindowSize;
 
    private Integer producerWindowSize;
@@ -172,21 +170,10 @@ public class ConnectionFactoryProperties
       return compressLargeMessage;
    }
 
-   public Boolean isAvoidLargeMessage()
-   {
-      return avoidLargeMessage;
-   }
-
    public void setCompressLargeMessage(Boolean compressLargeMessage)
    {
       hasBeenUpdated = true;
       this.compressLargeMessage = compressLargeMessage;
-   }
-
-   public void setAvoidLargeMessage(Boolean avoidLargeMessage)
-   {
-      hasBeenUpdated = true;
-      this.avoidLargeMessage = avoidLargeMessage;
    }
 
    public String getConnectionLoadBalancingPolicyClassName()

--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
@@ -628,21 +628,6 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
    }
 
    /**
-    * Get avoidLargeMessage
-    *
-    * @return The value
-    */
-   public Boolean isAvoidLargeMessage()
-   {
-      if (HornetQResourceAdapter.trace)
-      {
-         HornetQRALogger.LOGGER.trace("isAvoidLargeMessage()");
-      }
-
-      return raProperties.isAvoidLargeMessage();
-   }
-
-   /**
     * Set failoverOnInitialConnection
     *
     * @param failoverOnInitialConnection The value
@@ -685,21 +670,6 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
       }
 
       raProperties.setCompressLargeMessage(compressLargeMessage);
-   }
-
-   /**
-    * Set avoidLargeMessage
-    *
-    * @param avoidLargeMessage The value
-    */
-   public void setAvoidLargeMessage(final Boolean avoidLargeMessage)
-   {
-      if (HornetQResourceAdapter.trace)
-      {
-         HornetQRALogger.LOGGER.trace("setAvoidLargeMessage(" + avoidLargeMessage + ")");
-      }
-
-      raProperties.setCompressLargeMessage(avoidLargeMessage);
    }
 
    /**
@@ -2211,13 +2181,6 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
       if (val != null)
       {
          cf.setCompressLargeMessage(val);
-      }
-
-      val = overrideProperties.isAvoidLargeMessage() != null ? overrideProperties.isAvoidLargeMessage()
-                                                                    : raProperties.isAvoidLargeMessage();
-      if (val != null)
-      {
-         cf.setAvoidLargeMessage(val);
       }
 
       val = overrideProperties.isFailoverOnInitialConnection() != null ? overrideProperties.isFailoverOnInitialConnection()

--- a/hornetq-server/src/main/java/org/hornetq/utils/XMLConfigurationUtil.java
+++ b/hornetq-server/src/main/java/org/hornetq/utils/XMLConfigurationUtil.java
@@ -113,20 +113,6 @@ public class XMLConfigurationUtil
       }
    }
 
-   //with this method we can know if this property is absent in config or not by passing a null default
-   public static Boolean getNullableBoolean(final Element e, final String name, final Boolean def)
-   {
-      NodeList nl = e.getElementsByTagName(name);
-      if (nl.getLength() > 0)
-      {
-         return org.hornetq.utils.XMLUtil.parseBoolean(nl.item(0));
-      }
-      else
-      {
-         return def;
-      }
-   }
-
    // Constants -----------------------------------------------------
 
    // Attributes ----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageAvoidLargeMessagesTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageAvoidLargeMessagesTest.java
@@ -41,6 +41,11 @@ import org.hornetq.utils.DeflaterReader;
 public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
 {
 
+   public LargeMessageAvoidLargeMessagesTest()
+   {
+      isCompressedTest = true;
+   }
+
    @Override
    protected boolean isNetty()
    {
@@ -52,7 +57,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
    {
       ServerLocator locator1 = super.createFactory(isNetty);
       locator1.setMinLargeMessageSize(10240);
-      locator1.setAvoidLargeMessage(true);
+      locator1.setCompressLargeMessage(true);
       return locator1;
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageCompressTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageCompressTest.java
@@ -43,6 +43,10 @@ import org.hornetq.tests.util.UnitTestCase;
 public class LargeMessageCompressTest extends LargeMessageTest
 {
    // Constructors --------------------------------------------------
+   public LargeMessageCompressTest()
+   {
+      isCompressedTest = true;
+   }
 
    @Override
    protected boolean isNetty()

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageTest.java
@@ -72,6 +72,8 @@ public class LargeMessageTest extends LargeMessageTestBase
    private final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
    protected ServerLocator locator;
+   
+   protected boolean isCompressedTest = false;
 
    // Constructors --------------------------------------------------
 
@@ -407,7 +409,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          session.commit();
 
-         validateNoFilesOnLargeDir(1);
+         validateNoFilesOnLargeDir(isCompressedTest ? 0 : 1);
 
          consumer = session.createConsumer(LargeMessageTest.ADDRESS.concat("-2"));
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/config/JMSServerConfigParserTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/config/JMSServerConfigParserTest.java
@@ -75,7 +75,6 @@ public class JMSServerConfigParserTest extends ServiceTestBase
       assertEquals(789, cfConfig.getProducerMaxRate());
       assertEquals(12, cfConfig.getMinLargeMessageSize());
       assertEquals(true, cfConfig.isCompressLargeMessages());
-      assertEquals(false, cfConfig.isAvoidLargeMessages());
       assertEquals("TestClientID", cfConfig.getClientID());
       assertEquals(3456, cfConfig.getDupsOKBatchSize());
       assertEquals(4567, cfConfig.getTransactionBatchSize());

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
@@ -35,7 +35,6 @@ import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.MessageHandler;
 import org.hornetq.core.client.impl.ClientConsumerInternal;
-import org.hornetq.core.client.impl.ClientMessageInternal;
 import org.hornetq.core.client.impl.ClientSessionInternal;
 import org.hornetq.core.client.impl.LargeMessageControllerImpl;
 import org.hornetq.core.protocol.core.impl.wireformat.SessionQueueQueryResponseMessage;
@@ -879,7 +878,7 @@ public class LargeMessageBufferTest extends UnitTestCase
 
       }
 
-      public void handleMessage(final ClientMessageInternal message) throws Exception
+      public void handleMessage(final SessionReceiveMessage message) throws Exception
       {
 
 
@@ -927,13 +926,6 @@ public class LargeMessageBufferTest extends UnitTestCase
       public void interruptHandlers() throws HornetQException
       {
       }
-
-      @Override
-      public void handleCompressedMessage(SessionReceiveMessage message)
-            throws Exception
-      {
-      }
-
    }
 
 }

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/HornetQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/HornetQResourceAdapterConfigTest.java
@@ -340,14 +340,8 @@ public class HornetQResourceAdapterConfigTest extends UnitTestCase
          "         <config-property-value>false</config-property-value>\n" +
          "      </config-property>\n" +
          "      <config-property>\n" +
-         "         <description>Whether the resource adapter must compress large messages</description>\n" +
-         "         <config-property-name>CompressLargeMessage</config-property-name>\n" +
-         "         <config-property-type>boolean</config-property-type>\n" +
-         "         <config-property-value>false</config-property-value>\n" +
-         "      </config-property>\n" +
-         "      <config-property>\n" +
          "         <description>Whether the resource adapter compress large messages and send them as regular when possible</description>" +
-         "         <config-property-name>AvoidLargeMessage</config-property-name>" +
+         "         <config-property-name>CompressLargeMessage</config-property-name>" +
          "         <config-property-type>boolean</config-property-type>" +
          "         <config-property-value>false</config-property-value>" +
          "      </config-property>\n"+


### PR DESCRIPTION
Hi Clebert,

This is what we discussed yesterday.

1) remove avoid-large-messages option
2) move handle compress messages from the packet handler to client consumer.
