### PR TITLE
fix occasional test failure

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -49,6 +49,7 @@ public class BackupSyncJournalTest extends FailoverTestBase
       locator = getServerLocator();
       locator.setBlockOnNonDurableSend(true);
       locator.setBlockOnDurableSend(true);
+      locator.setBlockOnAcknowledge(true);
       locator.setReconnectAttempts(-1);
       sessionFactory = createSessionFactoryAndWaitForTopology(locator, 1);
       syncDelay = new BackupSyncDelay(backupServer, liveServer);


### PR DESCRIPTION
blockOnAcknowledge should be true to avoid unacked messages being resent after live server crashes.

Default this attribute is false. Meaning it's possible when server crashes the messages haven't been acknowledged on server. So after fail over those unacked messages are re-delivered to client, making the test (like testReplicationDuringSync) fail.
