### PR TITLE
[HORNETQ-1140] Provide a jar with native libs uploaded to Maven repo

### DIFF
--- a/hornetq-native/pom.xml
+++ b/hornetq-native/pom.xml
@@ -15,9 +15,52 @@
    <build>
       <resources>
          <resource>
-            <directory>bin</directory>
+            <directory>${basedir}/target/output/</directory>
          </resource>
       </resources>
+      <plugins>
+         <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+               <execution>
+                  <id>copy-resources-32</id>
+                  <phase>validate</phase>
+                  <goals>
+                     <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                     <outputDirectory>${basedir}/target/output/lib/linux-i686/</outputDirectory>
+                     <resources>
+                        <resource>
+                           <directory>bin/</directory>
+                           <includes>
+                              <include>libHornetQAIO32.so</include>
+                           </includes>
+                        </resource>
+                     </resources>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>copy-resources-64</id>
+                  <phase>validate</phase>
+                  <goals>
+                     <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                     <outputDirectory>${basedir}/target/output/lib/linux-x86_64/</outputDirectory>
+                     <resources>
+                        <resource>
+                           <directory>bin/</directory>
+                           <includes>
+                              <include>libHornetQAIO64.so</include>
+                           </includes>
+                        </resource>
+                     </resources>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
    </build>
-
 </project>


### PR DESCRIPTION
- modify the layout inside the generate jars to have the library files
  in different directories depending on their architecture:
  
    $ jar tvf target/hornetq-native-2.3.0.BETA-SNAPSHOT.jar
    ...
    44272 Tue Feb 19 12:07:00 CET 2013 lib/linux-i686/libHornetQAIO32.so
    53350 Tue Feb 19 12:07:00 CET 2013 lib/linux-x86_64/libHornetQAIO64.so

With this layout, the jar content can be extracted as-is in AS7
org.hornetq module's directory
