### PR TITLE
HORNETQ-720 Sort out the live.stop() order

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/StorageManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/StorageManager.java
@@ -46,10 +46,8 @@ import org.hornetq.core.server.Queue;
 import org.hornetq.core.server.RouteContextList;
 import org.hornetq.core.server.ServerMessage;
 import org.hornetq.core.server.group.impl.GroupBinding;
-import org.hornetq.core.server.impl.HornetQServerImpl;
 import org.hornetq.core.transaction.ResourceManager;
 import org.hornetq.core.transaction.Transaction;
-import org.hornetq.utils.IDGenerator;
 
 /**
  *
@@ -345,12 +343,4 @@ public interface StorageManager extends HornetQComponent
     * @see StorageManager#readLock()
     */
    void readUnLock();
-
-   /**
-    * Closes the {@link IDGenerator} persisting the current record ID.
-    * <p>
-    * Effectively a "pre-stop" method. Necessary due to the "stop"-order at
-    * {@link HornetQServerImpl}
-    */
-   void closeIdGenerator();
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/JournalStorageManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/JournalStorageManager.java
@@ -2222,16 +2222,6 @@ public class JournalStorageManager implements StorageManager
       stop(false);
    }
 
-   @Override
-   public synchronized void closeIdGenerator()
-   {
-      if (journalLoaded && idGenerator != null)
-      {
-         // Must call close to make sure last id is persisted
-         idGenerator.close();
-      }
-   }
-
    public synchronized void stop(boolean ioCriticalError) throws Exception
    {
       if (!started)
@@ -2246,7 +2236,10 @@ public class JournalStorageManager implements StorageManager
       }
 
       if (replicator != null)
+      {
+         replicator.sendLiveIsStopping();
          replicator.stop();
+      }
 
       bindingsJournal.stop();
 

--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/nullpm/NullStorageManager.java
@@ -615,10 +615,4 @@ public class NullStorageManager implements StorageManager
    {
       // no-op
    }
-
-   @Override
-   public void closeIdGenerator()
-   {
-      // no-op
-   }
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/replication/ReplicationManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/replication/ReplicationManager.java
@@ -285,6 +285,7 @@ public class ReplicationManager implements HornetQComponent
          enabled = false;
          clearReplicationTokens();
       }
+
       if (replicatingChannel != null)
       {
          replicatingChannel.close();


### PR DESCRIPTION
1. live.stop()
2. freeze all connections
   - if replicating keep that channel open
3. close all server sessions
4. close pagingManager
5. close storageManager

Now, the replicationManager is still open when the storagemanager closes, so
- it gets the "persist ID" value
- storageManager.stop() will send "LIVE_IS_STOPPING" msg
