### PR TITLE
fix paging issue

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -396,6 +396,38 @@ public class PageCursorProviderImpl implements PageCursorProvider
 
             long minPage = checkMinPage(cursorList);
 
+            //if minPage is complete, forward
+            if (minPage != Long.MAX_VALUE)
+            {
+               boolean isPageCompleted = true;
+               for (PageSubscription cursor : cursorList)
+               {
+                  if (!cursor.isComplete(minPage))
+                  {
+                     isPageCompleted = false;
+                     break;
+                  }
+               }
+
+               if (isPageCompleted)
+               {
+                  if (minPage == pagingStore.getNumberOfPages())
+                  {
+                     pagingStore.forceAnotherPage();
+
+                     Page currentPage = pagingStore.getCurrentPage();
+
+                     storeBookmark(cursorList, currentPage);
+
+                     pagingStore.stopPaging();
+                  }
+                  else if (minPage < pagingStore.getNumberOfPages())
+                  {
+                     minPage++;
+                  }
+               }
+            }
+
             // if the current page is being written...
             // on that case we need to move to verify it in a different way
             if (minPage == pagingStore.getCurrentWritingPage() && pagingStore.getCurrentPage().getNumberOfMessages() > 0)

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -33,11 +33,11 @@ import org.hornetq.utils.UUID;
 
 public class BackupSyncJournalTest extends FailoverTestBase
 {
-   private static final int BACKUP_WAIT_TIME = 20;
+   protected static final int BACKUP_WAIT_TIME = 20;
    private ServerLocatorInternal locator;
    protected ClientSessionFactoryInternal sessionFactory;
    protected ClientSession session;
-   private ClientProducer producer;
+   protected ClientProducer producer;
    private BackupSyncDelay syncDelay;
    protected int n_msgs = 20;
 
@@ -119,7 +119,7 @@ public class BackupSyncJournalTest extends FailoverTestBase
       assertNoMoreMessages();
    }
 
-   private void assertNoMoreMessages() throws HornetQException
+   protected void assertNoMoreMessages() throws HornetQException
    {
       session.start();
       ClientConsumer consumer = session.createConsumer(FailoverTestBase.ADDRESS);
@@ -179,7 +179,7 @@ public class BackupSyncJournalTest extends FailoverTestBase
       }
    }
 
-   private void finishSyncAndFailover() throws Exception
+   protected void finishSyncAndFailover() throws Exception
    {
       syncDelay.deliverUpToDateMsg();
       waitForRemoteBackup(sessionFactory, BACKUP_WAIT_TIME, true, backupServer.getServer());

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/BackupSyncPagingTest.java
@@ -31,4 +31,33 @@ public class BackupSyncPagingTest extends BackupSyncJournalTest
       conf.put(ADDRESS.toString(), as);
       return createInVMFailoverServer(realFiles, configuration, PAGE_SIZE, PAGE_MAX, conf, nodeManager, id);
    }
+
+   public void testReplicationWithPageFileComplete() throws Exception
+   {
+      try
+      {
+         n_msgs = 10;
+         createProducerSendSomeMessages();
+         backupServer.start();
+         waitForRemoteBackup(sessionFactory, BACKUP_WAIT_TIME, false, backupServer.getServer());
+
+         sendMessages(session, producer, n_msgs);
+         session.commit();
+         
+         receiveMsgsInRange(0, n_msgs);
+         
+         finishSyncAndFailover();
+
+         receiveMsgsInRange(0, n_msgs);
+         assertNoMoreMessages();
+      }
+      catch (junit.framework.AssertionFailedError error)
+      {
+         printJournal(liveServer);
+         printJournal(backupServer);
+         // test failed
+         throw error;
+      }
+   }
+
 }


### PR DESCRIPTION
The issue could happen in the following case:

Say we have a live and a backup in replication mode. A client sends 20 messages (m0 to m19) to an address in two batches, each sending 10 messages. And the paging setup is such that it causes messages to be paged in the following detail:

1) first two (m0 and m1) are in the memory (not paged).
2) next 5 messages (m2 to m6) are paged into file 1.page.
3) next 3 messages (m7 to m9) are paged into file 2.page.
4) next 5 messages (m10 to m14) are paged into file 3.page.
5) next 5 messages (m15 to m19) are paged into file 4.page.

At backup server those page files (1-4.page) are replicated to the backup's paging dir. Now if we let the following happen:

1) create a client to receive and commit first 10 messages.
2) crash live server immediately after.
3) the client receives the next 10 messages after failover.

After above step 1), 1.page and 2.page will be cleaned up. Accordingly the 1.page and 2.page at backup's paging store should be cleaned up too. However if step 2) comes too fast, the backup won't get a chance to receive the signal from live server to clean them up. 

Now if 1.page and 2.page are left at backup and the backup starts failover, it will load the paging files (all 1, 2, 3, 4.page in order) and re-calculate a valid page file to set up proper paging store. Due to a miscalculation, only 1.page is dropped as used page but 2.page (whose messages are all consumed before failover) are taking as a valid page and loaded.

The result is that after failover the client will receive duplicated message (m7 to m9).
