### PR TITLE
HORNETQ-1148 Bump the version to fail properly if server is older:

### DIFF
--- a/hornetq-core-client/src/main/resources/hornetq-version.properties
+++ b/hornetq-core-client/src/main/resources/hornetq-version.properties
@@ -6,4 +6,4 @@ hornetq.version.incrementingVersion=${hornetq.version.incrementingVersion}
 hornetq.version.versionSuffix=${hornetq.version.versionSuffix}
 hornetq.version.versionTag=${hornetq.version.versionTag}
 hornetq.netty.version=${netty.version.string}
-hornetq.version.compatibleVersionList=121,122
+hornetq.version.compatibleVersionList=121,122,123

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
       <hornetq.version.majorVersion>2</hornetq.version.majorVersion>
       <hornetq.version.minorVersion>3</hornetq.version.minorVersion>
       <hornetq.version.microVersion>0</hornetq.version.microVersion>
-      <hornetq.version.incrementingVersion>122</hornetq.version.incrementingVersion>
+      <hornetq.version.incrementingVersion>123</hornetq.version.incrementingVersion>
       <hornetq.version.versionSuffix>SNAPSHOT</hornetq.version.versionSuffix>
       <hornetq.version.versionTag>SNAPSHOT</hornetq.version.versionTag>
       <HornetQ-Version>


### PR DESCRIPTION
Connecting from a 2.3-client (now, version 123) to a 2.2 server will fail due
to serialization errors. Better a `version incompatibility` error.
