### PR TITLE
Delete TMP dir at the end of each test.

### DIFF
--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -672,6 +672,12 @@ public abstract class UnitTestCase extends CoreUnitTestCase
       clearData(getTestDir());
    }
 
+   private final void deleteTmpDir()
+   {
+      File file = new File(getTestDir());
+      deleteDirectory(file);
+   }
+
    protected void clearData(final String testDir1)
    {
       // Need to delete the root
@@ -1105,7 +1111,7 @@ public abstract class UnitTestCase extends CoreUnitTestCase
       checkFilesUsage();
          // System.out.println("SLEEP!");
          // Thread.sleep(60000);
-      clearData();
+         deleteTmpDir();
       super.tearDown();
    }
    }


### PR DESCRIPTION
Otherwise we would leave ///loads/// of empty dirs at each test run
