### PR TITLE
Turn off failureCheckAndFlushThread when freezing the connections.

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
@@ -278,6 +278,10 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
 
    public synchronized void freeze(final CoreRemotingConnection connectionToKeepOpen)
    {
+      if (!started)
+         return;
+      failureCheckAndFlushThread.close(false);
+
       for (Acceptor acceptor : acceptors)
       {
          try
@@ -316,11 +320,6 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
 
    public void stop(final boolean criticalError) throws Exception
    {
-      if (!started)
-      {
-         return;
-      }
-
       if (!started)
       {
          return;


### PR DESCRIPTION
Also remove a duplicate check on "started" at stop().
