### PR TITLE
JBPAPP6-1393 Fix backup bridge deployment: deploy&start bridges on clust...

### DIFF
--- a/src/main/org/hornetq/core/server/cluster/ClusterManager.java
+++ b/src/main/org/hornetq/core/server/cluster/ClusterManager.java
@@ -44,7 +44,11 @@ public interface ClusterManager extends HornetQComponent
 
    Set<BroadcastGroup> getBroadcastGroups();
 
-   void activate();
+   /**
+    * Starts several cluster services. Used by shared-store backup for failover.
+    * @throws Exception 
+    */
+   void activate() throws Exception;
 
    void flushExecutor();
 
@@ -52,7 +56,7 @@ public interface ClusterManager extends HornetQComponent
 
    void deploy() throws Exception;
 
-   void deployBridge(BridgeConfiguration config, boolean start) throws Exception;
+   void deployBridge(BridgeConfiguration config) throws Exception;
 
    void destroyBridge(String name) throws Exception;
 

--- a/src/main/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/src/main/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -1258,7 +1258,7 @@ public class HornetQServerImpl implements HornetQServer
    {
       if (clusterManager != null)
       {
-         clusterManager.deployBridge(config, true);
+         clusterManager.deployBridge(config);
       }
    }
 


### PR DESCRIPTION
...erManager.activate()

Worth noting that activate now "throws Exception" because our code throws exceptions
from constructors. One must never throw exceptions from inside a constructor,
as it an anti-pattern for leaking resources.

https://bugzilla.redhat.com/show_bug.cgi?id=900764
