### PR TITLE
change test temp dir cleanup: do not return false when a file is not deleted. Keep on deleting all the rest.

### DIFF
--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1359,9 +1359,10 @@ public abstract class UnitTestCase extends CoreUnitTestCase
 
          for (int j = 0; j < files.length; j++)
          {
-            if (!deleteDirectory(new File(directory, files[j])))
+            File f = new File(directory, files[j]);
+            if (!deleteDirectory(f))
             {
-               return false;
+               log.warn("Failed to clean up file: " + f.getAbsolutePath());
             }
          }
       }


### PR DESCRIPTION
change test temp dir cleanup: do not return false when a file is not deleted. Keep on deleting all the rest.
