### PR TITLE
Fix for issue HORNETQ-1158

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -794,6 +794,7 @@ public class NettyConnector extends AbstractConnector
             }
 
             HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, url);
+            httpRequest.addHeader(HttpHeaders.Names.HOST, NettyConnector.this.host);
             if (cookie != null)
             {
                httpRequest.addHeader(HttpHeaders.Names.COOKIE, cookie);
@@ -827,6 +828,7 @@ public class NettyConnector extends AbstractConnector
             if (!waitingGet && System.currentTimeMillis() > lastSendTime + httpMaxClientIdleTime)
             {
                HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url);
+               httpRequest.addHeader(HttpHeaders.Names.HOST, NettyConnector.this.host);
                waitingGet = true;
                channel.write(httpRequest);
             }


### PR DESCRIPTION
Hi!,

These two lines should fix the issue https://issues.jboss.org/browse/HORNETQ-1158
Host header is missing. Host is known in the class so it is easy to set it.
This makes it possible to access hornetQ using netty HTTP, in combination with a reverse proxy.

regards,

Maarten van Hulsentop
