### PR TITLE
Depend only on released plugin for this release candidate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
          <plugin>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-maven-plugin</artifactId>
-            <version>1.1.1-SNAPSHOT</version>
+            <version>1.1.0</version>
          </plugin>
          </plugins>
       </pluginManagement>


### PR DESCRIPTION
When testing the CR I noticed that all samples fail, this is due to the external dependency on `hornetq-maven-plugin`. Since this is not part of the project, the SNAPSHOT version will not be readily available. Eighter use the latest released version or use the next release of that plugin when doing integration tests for the next release.
