### PR TITLE
Make deprecation of clustered option work and document HQ221038

### DIFF
--- a/docs/user-manual/en/clusters.xml
+++ b/docs/user-manual/en/clusters.xml
@@ -29,8 +29,9 @@
             share message processing load. Each active node in the cluster is an active HornetQ
             server which manages its own messages and handles its own connections. </para>
         <note id="clustered-deprecation">
-            <para> The <emphasis>clustered</emphasis> parameter is deprecated and no longer needed for
-            setting up a cluster.</para>
+            <para>The <emphasis>clustered</emphasis> parameter is deprecated and no longer needed for
+            setting up a cluster. If your configuration contains this parameter it will be ignored and
+            a message with the ID <literal>HQ221038</literal> will be logged.</para>
         </note>
         <para>The cluster is formed by each node declaring <emphasis>cluster connections</emphasis>
             to other nodes in the core configuration file <literal

--- a/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
@@ -175,7 +175,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
       config.setName(getString(e, "name", config.getName(), Validators.NO_CHECK));
 
       NodeList elems = e.getElementsByTagName("clustered");
-      if (elems != null && elems.getLength() > -1)
+      if (elems != null && elems.getLength() > 0)
       {
          HornetQServerLogger.LOGGER.deprecatedConfigurationOption("clustered");
 

--- a/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
+++ b/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
@@ -17,8 +17,8 @@
                      minOccurs="0">
           <xsd:annotation hq:linkend="clusters">
             <xsd:documentation>DEPRECATED. This option is deprecated and its value will be
-            ignored. A HornetQ server will be "clustered" when its configuration contain a
-            cluster-configuration.
+            ignored (HQ221038). A HornetQ server will be "clustered" when its configuration
+            contain a cluster-configuration.
             </xsd:documentation>
           </xsd:annotation>
         </xsd:element>


### PR DESCRIPTION
This is the promised update to Pull#997 (removed duplicate prefix).

Currently HornetQ always prints the deprecation message, with this fix it will only be printed when the option is actually present. This fix also adds the log message ID to two places in the documentation to make it easier to find.

Further improvements would be to remove the default value for the element in the configuration schema and possibly make the deprecation message a warning.
