### PR TITLE
fix the dead-lock bugzilla

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -828,7 +828,7 @@ final class PageSubscriptionImpl implements PageSubscription
       getPageInfo(pageNr, true);
    }
 
-   private synchronized PageCursorInfo getPageInfo(final PagePosition pos)
+   private PageCursorInfo getPageInfo(final PagePosition pos)
    {
       return getPageInfo(pos.getPageNr(), true);
    }

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PageTransactionInfoImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PageTransactionInfoImpl.java
@@ -37,7 +37,7 @@ import org.hornetq.utils.DataConstants;
  * @author <a href="mailto:clebert.suconic@jboss.com">Clebert Suconic</a>
  *
  */
-public class PageTransactionInfoImpl implements PageTransactionInfo
+public final class PageTransactionInfoImpl implements PageTransactionInfo
 {
    // Constants -----------------------------------------------------
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=927236
Reasoning is as follows:
- the method just forwards the call to `getPageInfo(boolean, long)` which
  is **not** synchronized on `PageSubscriptionImpl` but which synchronizes
  on `consumedPages`.
- for all I can tell, at `PageSubscriptionImpl.getPageInfo(*)` we really
  only need to synchronize on `consumedPages`.
