### PR TITLE
https://bugzilla.redhat.com/show_bug.cgi?id=958776 Move connection.signa...

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -32,7 +32,6 @@ import org.hornetq.api.core.HornetQBuffer;
 import org.hornetq.api.core.HornetQBuffers;
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.HornetQExceptionType;
-import org.hornetq.api.core.HornetQTransactionOutcomeUnknownException;
 import org.hornetq.api.core.Message;
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientConsumer;

--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnection.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnection.java
@@ -206,7 +206,6 @@ public final class HornetQRAManagedConnection implements ManagedConnection, Exce
 
          if (connection != null)
          {
-            connection.signalStopToAllSessions();
             connection.stop();
          }
       }
@@ -248,6 +247,10 @@ public final class HornetQRAManagedConnection implements ManagedConnection, Exce
       catch (JMSException e)
       {
          HornetQRALogger.LOGGER.debug("Error unsetting the exception listener " + this, e);
+      }
+      if (connection != null)
+      {
+         connection.signalStopToAllSessions();
       }
 
       destroyHandles();


### PR DESCRIPTION
...lStopToAllSessions() to destroy()

it was placed inside destroyAllHandles() which is also called from within cleanup()
