### PR TITLE
Bug 965093/HORNETQ-1206 : Thread leak test failure with IBM JRE

### DIFF
--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1224,6 +1224,7 @@ public abstract class UnitTestCase extends CoreUnitTestCase
       final String name = thread.getName();
       final ThreadGroup group = thread.getThreadGroup();
       final boolean isSystemThread = group != null && "system".equals(group.getName());
+      final String javaVendor = System.getProperty("java.vendor");
 
       if (name.contains("SunPKCS11"))
       {
@@ -1234,6 +1235,10 @@ public abstract class UnitTestCase extends CoreUnitTestCase
          return true;
       }
       else if (isSystemThread && name.equals("process reaper"))
+      {
+         return true;
+      }
+      else if (javaVendor.contains("IBM") && name.equals("MemoryPoolMXBean notification dispatcher"))
       {
          return true;
       }


### PR DESCRIPTION
With IBM jre, the hornetq server will cause a daemon thread called "MemoryPoolMXBean notification dispatcher" to be started by the VM because the hornetq server invoked the management service. This thread is not controlled by hornetq and should be put to the expected set. Otherwise tests will report false thread leak error.
