### PR TITLE
fix typo: HDR_DUPLICATE_DETECTION_ID is a field of the Message interface

### DIFF
--- a/docs/user-manual/en/duplicate-detection.xml
+++ b/docs/user-manual/en/duplicate-detection.xml
@@ -69,7 +69,7 @@
             set it once in the transaction. If the server detects a duplicate message for any
             message in the transaction, then it will ignore the entire transaction.</para>
         <para>The name of the property that you set is given by the value of <literal
-                >org.hornetq.api.core.HDR_DUPLICATE_DETECTION_ID</literal>, which
+                >org.hornetq.api.core.Message.HDR_DUPLICATE_DETECTION_ID</literal>, which
             is <literal>_HQ_DUPL_ID</literal></para>
         <para>The value of the property can be of type <literal>byte[]</literal> or <literal
                 >SimpleString</literal> if you're using the core API. If you're using JMS it must be


### PR DESCRIPTION
The original version says the duplicate detection id string is `org.hornetq.api.core.HDR_DUPLICATE_DETECTION_ID`, which doesn't exist.
