### PR TITLE
Hornetq 756

### DIFF
--- a/hornetq-rest/src/test/java/org/hornetq/rest/test/CreateDestinationTest.java
+++ b/hornetq-rest/src/test/java/org/hornetq/rest/test/CreateDestinationTest.java
@@ -22,6 +22,7 @@ public class CreateDestinationTest extends MessageTestBase
       server.getJaxrsServer().getDeployment().getProviderFactory().registerProvider(org.jboss.resteasy.plugins.providers.DocumentProvider.class);
    }
 
+   @Test
    public void testCreateQueue() throws Exception
    {
       String queueConfig = "<queue name=\"testQueue\"><durable>true</durable></queue>";
@@ -76,6 +77,7 @@ public class CreateDestinationTest extends MessageTestBase
       Assert.assertEquals(204, res.getStatus());
    }
 
+   @Test
    public void testCreateTopic() throws Exception
    {
       String queueConfig = "<topic name=\"testTopic\"></topic>";
@@ -161,6 +163,7 @@ public class CreateDestinationTest extends MessageTestBase
       Assert.assertEquals(415, cRes.getStatus());
    }
 
+   @Test
    public void testCreateTopicWithBadContentType() throws Exception
    {
       String queueConfig = "<topic name=\"testTopic\"></topic>";


### PR DESCRIPTION
I was investigating https://issues.jboss.org/browse/HORNETQ-756 and it seems that this is already resolved.

I suspect that this was some old behaviour of Rest Easy as I could not see anything in the history of QueueDestinationsResource that had changed to set the content type.

This pull request contains two new tests for creating a queue and topic that checks for a 415 if the content type does not match. These tests are probably unnecessary as it is really testing the behaviour of Rest Easy.
