### PR TITLE
bug 971839/HORNETQ-1223 JGroups Channel not closed after the channel is cleaned up

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/JGroupsBroadcastGroupConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/JGroupsBroadcastGroupConfiguration.java
@@ -404,6 +404,7 @@ public final class JGroupsBroadcastGroupConfiguration implements BroadcastEndpoi
          {
             channel.setReceiver(null);
             channel.disconnect();
+            channel.close();
             JChannelWrapper<?> wrapper = channels.remove(key);
             if (wrapper == null)
             {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/discovery/DiscoveryTest.java
@@ -140,9 +140,6 @@ public class DiscoveryTest extends UnitTestCase
    @Test
    public void testSimpleBroadcastJGropus() throws Exception
    {
-      // There are some executors on JGroups that won't be stopped right away, and they do not represent leakages
-      disableCheckThread();
-
       final String nodeID = RandomUtil.randomString();
 
       bg = new BroadcastGroupImpl(new FakeNodeManager(nodeID), "broadcast", 100, null,
@@ -173,9 +170,6 @@ public class DiscoveryTest extends UnitTestCase
    @Test
    public void testJGropusChannelReferenceCounting() throws Exception
    {
-      // There are some executors on JGroups that won't be stopped right away, and they do not represent leakages
-      disableCheckThread();
-
       JGroupsBroadcastGroupConfiguration jgroupsConfig =
                new JGroupsBroadcastGroupConfiguration(TEST_JGROUPS_CONF_FILE, "tst");
       BroadcastEndpointFactory factory = jgroupsConfig.createBroadcastEndpointFactory();
@@ -238,9 +232,6 @@ public class DiscoveryTest extends UnitTestCase
    @Test
    public void testJGropusChannelReferenceCounting1() throws Exception
    {
-      // There are some executors on JGroups that won't be stopped right away, and they do not represent leakages
-      disableCheckThread();
-
       JGroupsBroadcastGroupConfiguration jgroupsConfig =
                new JGroupsBroadcastGroupConfiguration(TEST_JGROUPS_CONF_FILE, "tst");
       BroadcastEndpointFactory factory = jgroupsConfig.createBroadcastEndpointFactory();
@@ -312,9 +303,6 @@ public class DiscoveryTest extends UnitTestCase
    @Test
    public void testJGropusChannelReferenceCounting2() throws Exception
    {
-      // There are some executors on JGroups that won't be stopped right away, and they do not represent leakages
-      disableCheckThread();
-
       JGroupsBroadcastGroupConfiguration jgroupsConfig =
                new JGroupsBroadcastGroupConfiguration(TEST_JGROUPS_CONF_FILE, "tst");
       BroadcastEndpointFactory factory = jgroupsConfig.createBroadcastEndpointFactory();
@@ -392,9 +380,6 @@ public class DiscoveryTest extends UnitTestCase
    @Test
    public void testStraightSendReceiveJGroups() throws Exception
    {
-      // There are some executors on JGroups that won't be stopped right away, and they do not represent leakages
-      disableCheckThread();
-
       BroadcastEndpoint broadcaster = null;
       BroadcastEndpoint client = null;
       try


### PR DESCRIPTION
JGroups Channel not closed after the channel is cleaned up
