### PR TITLE
HORNETQ-1184 : Leak on failed RecoveryDiscovery

### DIFF
--- a/src/main/org/hornetq/jms/server/recovery/RecoveryDiscovery.java
+++ b/src/main/org/hornetq/jms/server/recovery/RecoveryDiscovery.java
@@ -196,4 +196,22 @@ public class RecoveryDiscovery implements SessionFailureListener
       return "RecoveryDiscovery [config=" + config + ", started=" + started + "]";
    }
 
+   @Override
+   public int hashCode()
+   {
+      return config.hashCode();
+   }
+   
+   @Override
+   public boolean equals(Object o)
+   {
+      if (o == null || (! (o instanceof RecoveryDiscovery)))
+      {
+         return false;
+      }
+      RecoveryDiscovery discovery = (RecoveryDiscovery)o;
+      
+      return config.equals(discovery.config);
+   }
+
 }

--- a/tests/src/org/hornetq/tests/integration/ra/ResourceAdapterTest.java
+++ b/tests/src/org/hornetq/tests/integration/ra/ResourceAdapterTest.java
@@ -15,6 +15,7 @@ package org.hornetq.tests.integration.ra;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -23,28 +24,23 @@ import javax.jms.Connection;
 import javax.resource.ResourceException;
 import javax.resource.spi.endpoint.MessageEndpoint;
 
+import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.api.core.client.ClientSession;
 import org.hornetq.api.core.client.ClientSessionFactory;
 import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.api.jms.HornetQJMSClient;
 import org.hornetq.core.client.impl.ClientSessionFactoryInternal;
 import org.hornetq.core.client.impl.ServerLocatorImpl;
-import org.hornetq.core.server.HornetQServer;
 import org.hornetq.jms.client.HornetQConnectionFactory;
 import org.hornetq.jms.client.HornetQDestination;
+import org.hornetq.jms.server.recovery.RecoveryDiscovery;
+import org.hornetq.jms.server.recovery.XARecoveryConfig;
 import org.hornetq.ra.HornetQResourceAdapter;
 import org.hornetq.ra.inflow.HornetQActivation;
 import org.hornetq.ra.inflow.HornetQActivationSpec;
 import org.hornetq.tests.unit.ra.MessageEndpointFactory;
 import org.hornetq.tests.util.UnitTestCase;
 import org.hornetq.utils.DefaultSensitiveStringCodec;
-
-import javax.resource.ResourceException;
-import javax.resource.spi.endpoint.MessageEndpoint;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
@@ -664,6 +660,22 @@ public class ResourceAdapterTest extends HornetQRATestBase
 
       qResourceAdapter.stop();
       assertTrue(endpoint.released);
+   }
+
+   public void testRecoveryDiscoveryAsKey() throws Exception
+   {
+      Set<RecoveryDiscovery> discoverySet = new HashSet<RecoveryDiscovery>();
+      String factClass = "org.hornetq.core.remoting.impl.netty.NettyConnectorFactory";
+      TransportConfiguration transportConfig = new TransportConfiguration(factClass, null, "netty");
+      XARecoveryConfig config = new XARecoveryConfig(false, new TransportConfiguration[] {transportConfig},
+                                                     null, null);
+      
+      RecoveryDiscovery discovery1 = new RecoveryDiscovery(config);
+      RecoveryDiscovery discovery2 = new RecoveryDiscovery(config);
+      assertTrue(discoverySet.add(discovery1));
+      assertFalse(discoverySet.add(discovery2));
+      assertEquals("should have only one in the set", 1, discoverySet.size());
+
    }
 
    @Override


### PR DESCRIPTION
The RecoveryDiscovery should override hashCode and equals methods
