### PR TITLE
HORNETQ-1184 second fix: don't register recovery if failed to make connection

### DIFF
--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnectionFactory.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnectionFactory.java
@@ -128,12 +128,6 @@ public final class HornetQRAManagedConnectionFactory implements ManagedConnectio
                                                      ", using connection manager: " +
                                                      cm);
       }
-
-      if (recoveryConnectionFactory == null)
-      {
-         recoveryConnectionFactory = ra.createRecoveryHornetQConnectionFactory(mcfProperties);
-         resourceRecovery = ra.getRecoveryManager().register(recoveryConnectionFactory, null, null);
-      }
       return cf;
    }
 
@@ -172,7 +166,23 @@ public final class HornetQRAManagedConnectionFactory implements ManagedConnectio
          HornetQRALogger.LOGGER.trace("created new managed connection: " + mc);
       }
 
+      registerRecovery();
+
       return mc;
+   }
+
+   private synchronized void registerRecovery()
+   {
+      if (recoveryConnectionFactory == null)
+      {
+         recoveryConnectionFactory = ra.createRecoveryHornetQConnectionFactory(mcfProperties);
+         resourceRecovery = ra.getRecoveryManager().register(recoveryConnectionFactory, null, null);
+      }
+   }
+   
+   public XARecoveryConfig getResourceRecovery()
+   {
+      return resourceRecovery;
    }
 
    /**

--- a/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivation.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivation.java
@@ -327,6 +327,8 @@ public class HornetQActivation
          }
       }
 
+      resourceRecovery = ra.getRecoveryManager().register(factory, spec.getUser(), spec.getPassword());
+
       HornetQRALogger.LOGGER.debug("Setup complete " + this);
    }
 
@@ -412,7 +414,6 @@ public class HornetQActivation
       if (spec.isHasBeenUpdated())
       {
          factory = ra.createHornetQConnectionFactory(spec);
-         resourceRecovery = ra.getRecoveryManager().register(factory, spec.getUser(), spec.getPassword());
       }
       else
       {

--- a/hornetq-ra/src/main/java/org/hornetq/ra/recovery/RecoveryManager.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/recovery/RecoveryManager.java
@@ -153,4 +153,9 @@ public final class RecoveryManager
          }
       });
    }
+
+   public Set<XARecoveryConfig> getResources()
+   {
+      return resources;
+   }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/ResourceAdapterTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/ResourceAdapterTest.java
@@ -93,6 +93,8 @@ public class ResourceAdapterTest extends HornetQRATestBase
 
       Field f = Class.forName(ServerLocatorImpl.class.getName()).getDeclaredField("factories");
 
+      Set<XARecoveryConfig> resources = ra.getRecoveryManager().getResources();
+
       f.setAccessible(true);
 
       Set<ClientSessionFactoryInternal> factories = (Set<ClientSessionFactoryInternal>)f.get(serverLocator);
@@ -103,12 +105,14 @@ public class ResourceAdapterTest extends HornetQRATestBase
          assertEquals(factories.size(), 0);
          activation.start();
          assertEquals(factories.size(), 15);
+         assertEquals(1, resources.size());
          activation.stop();
          assertEquals(factories.size(), 0);
       }
 
       System.out.println("before RA stop => " + factories.size());
       ra.stop();
+      assertEquals(0, resources.size());
       System.out.println("after RA stop => " + factories.size());
       assertEquals(factories.size(), 0);
       locator.close();
@@ -362,8 +366,38 @@ public class ResourceAdapterTest extends HornetQRATestBase
       DummyMessageEndpoint endpoint = new DummyMessageEndpoint(new CountDownLatch(1));
       DummyMessageEndpointFactory endpointFactory = new DummyMessageEndpointFactory(endpoint, false);
       qResourceAdapter.endpointActivation(endpointFactory, spec);
+      //make sure 2 recovery resources, one is default, one is in activation.
+      assertEquals(2, qResourceAdapter.getRecoveryManager().getResources().size());
       qResourceAdapter.stop();
       assertTrue(endpoint.released);
+   }
+
+   public void testRecoveryRegistrationOnFailure() throws Exception
+   {
+      HornetQResourceAdapter qResourceAdapter = new HornetQResourceAdapter();
+      qResourceAdapter.setConnectorClassName(INVM_CONNECTOR_FACTORY);
+      qResourceAdapter.setConnectionParameters("server-id=0");
+      HornetQRATestBase.MyBootstrapContext ctx = new HornetQRATestBase.MyBootstrapContext();
+
+      qResourceAdapter.setTransactionManagerLocatorClass("");
+      qResourceAdapter.start(ctx);
+      HornetQActivationSpec spec = new HornetQActivationSpec();
+      spec.setResourceAdapter(qResourceAdapter);
+      spec.setUseJNDI(false);
+      spec.setDestinationType("javax.jms.Queue");
+      spec.setDestination(MDBQUEUE);
+      // now override the connector class
+      spec.setConnectorClassName(NETTY_CONNECTOR_FACTORY);
+      spec.setSetupAttempts(2);
+      // using a wrong port number
+      spec.setConnectionParameters("port=6776");
+      DummyMessageEndpoint endpoint = new DummyMessageEndpoint(new CountDownLatch(1));
+      DummyMessageEndpointFactory endpointFactory = new DummyMessageEndpointFactory(endpoint, false);
+      qResourceAdapter.endpointActivation(endpointFactory, spec);
+
+      assertEquals(1, qResourceAdapter.getRecoveryManager().getResources().size());
+      qResourceAdapter.stop();
+      assertFalse(endpoint.released);
    }
 
    public void testResourceAdapterSetupOverrideNoCFParams() throws Exception


### PR DESCRIPTION
(this is from cherry-pick)

Conflicts:

```
tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/ResourceAdapterTest.java
```
