### PR TITLE
[HORNETQ-1230] fix compliance of RA getXAResources

### DIFF
--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
@@ -201,7 +201,22 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
          HornetQRALogger.LOGGER.trace("getXAResources(" + Arrays.toString(specs) + ")");
       }
 
-      throw new ResourceException("Unsupported");
+      if (useAutoRecovery)
+      {
+         // let the TM handle the recovery
+         return null;
+      }
+      else
+      {
+         List<XAResource> xaresources = new ArrayList<XAResource>();
+         for (ActivationSpec spec : specs) {
+            HornetQActivation activation = activations.get(spec);
+            if (activation != null) {
+               xaresources.addAll(activation.getXAResources());
+            }
+         }
+         return xaresources.toArray(new XAResource[xaresources.size()]);
+      }
    }
 
    /**

--- a/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivation.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivation.java
@@ -28,6 +28,7 @@ import javax.resource.ResourceException;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.resource.spi.work.Work;
 import javax.resource.spi.work.WorkManager;
+import javax.transaction.xa.XAResource;
 
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.HornetQExceptionType;
@@ -278,6 +279,23 @@ public class HornetQActivation
    }
 
    /**
+    *
+    * @return the list of XAResources for this activation endpoint
+    */
+   public List<XAResource> getXAResources()
+   {
+      List<XAResource> xaresources = new ArrayList<XAResource>();
+      for (HornetQMessageHandler handler : handlers)
+      {
+         XAResource xares = handler.getXAResource();
+         if (xares != null) {
+            xaresources.add(xares);
+         }
+      }
+      return xaresources;
+   }
+
+    /**
     * Stop the activation
     */
    public void stop()

--- a/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
@@ -21,6 +21,7 @@ import javax.resource.spi.endpoint.MessageEndpoint;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
+import javax.transaction.xa.XAResource;
 
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.SimpleString;
@@ -199,6 +200,11 @@ public class HornetQMessageHandler implements MessageHandler
          useXA = false;
       }
       consumer.setMessageHandler(this);
+   }
+
+   XAResource getXAResource()
+   {
+      return useXA ? session : null;
    }
 
    public void interruptConsumer()


### PR DESCRIPTION
fix HornetQResourceAdapter.getXAResources() by returning null (instead
of raising an exception) when auto recovery is used.
If there is no auto recovery, return the XAResources for each RA's
inflow activation endpoint.
