### PR TITLE
fix tck failure:  com/sun/ts/tests/jms/core/topictests/TopicTests.java#consumerTests_from_ejb

### DIFF
--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnection.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnection.java
@@ -98,6 +98,8 @@ public class HornetQConnection extends HornetQConnectionForContextImpl implement
 
    private String clientID;
 
+   private boolean preconfiguredClientID;
+
    private final ClientSessionFactory sessionFactory;
 
    private final SimpleString uid;
@@ -135,6 +137,11 @@ public class HornetQConnection extends HornetQConnectionForContextImpl implement
       this.connectionType = connectionType;
 
       this.clientID = clientID;
+
+      if (this.clientID != null)
+      {
+         this.preconfiguredClientID = true;
+      }
 
       this.sessionFactory = sessionFactory;
 
@@ -810,5 +817,10 @@ public class HornetQConnection extends HornetQConnectionForContextImpl implement
          }
 
       }
+   }
+
+   public boolean isPreconfiguredClientID()
+   {
+      return this.preconfiguredClientID;
    }
 }

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQMessageProducer.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQMessageProducer.java
@@ -72,7 +72,22 @@ public class HornetQMessageProducer implements MessageProducer, QueueSender, Top
    {
       this.jbossConn = jbossConn;
 
-      connID = jbossConn.getClientID() != null ? new SimpleString(jbossConn.getClientID()) : jbossConn.getUID();
+      String clientID = jbossConn.getClientID();
+      if (clientID != null)
+      {
+         if (jbossConn.isPreconfiguredClientID())
+         {
+            connID = new SimpleString(clientID + jbossConn.getUID());
+         }
+         else
+         {
+            connID = new SimpleString(clientID);
+         }
+      }
+      else
+      {
+         connID = jbossConn.getUID();
+      }
 
       this.clientProducer = producer;
 

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQSession.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQSession.java
@@ -675,9 +675,18 @@ public class HornetQSession implements QueueSession, TopicSession
             String filter;
             if (connection.getClientID() != null)
             {
-               filter =
+               if (connection.isPreconfiguredClientID())
+               {
+                  filter =
+                        HornetQConnection.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + connection.getClientID() + connection.getUID() +
+                                 "'";
+               }
+               else
+               {
+                  filter =
                         HornetQConnection.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + connection.getClientID() +
                                  "'";
+               }
             }
             else
             {


### PR DESCRIPTION
 com/sun/ts/tests/jms/core/topictests/TopicTests.java#consumerTests_from_ejb

Description: 
When clientID is preconfigured on CF, each connection from this CF will have same clientIDs,
which makes noLocal on topic subscriber's not working properly when you send a message from such a connection
and received it from another. Because of the two connections have same clientID, so the message won't get
received.

To solve this problem the connection's UID is used in creating topic subscribers so that different connections
from the CF have different identifiers.
