### PR TITLE
HORNETQ-1047 - Fail-over after fail-back doesn't work in JBoss AS

### DIFF
--- a/src/main/org/hornetq/core/server/ActivateCallback.java
+++ b/src/main/org/hornetq/core/server/ActivateCallback.java
@@ -25,4 +25,6 @@ public interface ActivateCallback
    void preActivate();
 
    void activated();
+
+   void failback();
 }

--- a/src/main/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/src/main/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -1365,6 +1365,14 @@ public class HornetQServerImpl implements HornetQServer
       }
    }
 
+   private void callFailbackCallbacks()
+   {
+      for (ActivateCallback callback : activateCallbacks)
+      {
+         callback.failback();
+      }
+   }
+
    private void initialiseLogging()
    {
       LogDelegateFactory logDelegateFactory = (LogDelegateFactory)instantiateInstance(configuration.getLogDelegateFactoryClassName());
@@ -1995,6 +2003,7 @@ public class HornetQServerImpl implements HornetQServer
                      {
                         log.debug(HornetQServerImpl.this + "::Stopping live node in favor of failback");
                         stop(true);
+                        callFailbackCallbacks();
                         // We need to wait some time before we start the backup again
                         // otherwise we may eventually start before the live had a chance to get it
                         Thread.sleep(configuration.getFailbackDelay());


### PR DESCRIPTION
I added a callback on the JMSServerManagerImpl so that when HornetQServerImpl fails-back it can clean up all the JMS admin objects (including their JNDI entries).  I also do no clear the "cachedCommands" so that they can be executed again when fail-over occurs again.  Otherwise the JMS admin objects would not get re-created and bound back into JNDI properly.
