### PR TITLE
HORNETQ-1047 - JNDI lookups break after failover after failback

### DIFF
--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -257,7 +257,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
             run.run();
          }
 
-         cachedCommands.clear();
+         // do not clear the cachedCommands - HORNETQ-1047
 
          recoverJndiBindings();
       }


### PR DESCRIPTION
This is similar to the PR for 2.2.eap5 but all that is necessary here is simply to _not_ clear the cached commands since the ActivateCallback interface was already modified by Andy to support the necessary behavior on failback.
