### PR TITLE
Increase time out for replicated failover tests

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTest.java
@@ -685,7 +685,7 @@ public class FailoverTest extends FailoverTestBase
       backupServer.stop(); // Backup stops!
       beforeRestart(backupServer);
       backupServer.start();
-      assertTrue(backupServer.getServer().waitForBackupSync(10, TimeUnit.SECONDS));
+      assertTrue(backupServer.getServer().waitForBackupSync(30, TimeUnit.SECONDS));
       backupServer.stop(); // Backup stops!
 
       liveServer.stop();
@@ -739,7 +739,7 @@ public class FailoverTest extends FailoverTestBase
          adaptLiveConfigForReplicatedFailBack(liveServer.getServer().getConfiguration());
          beforeRestart(liveServer);
          liveServer.start();
-         assertTrue("live initialized...", liveServer.getServer().waitForActivation(15, TimeUnit.SECONDS));
+         assertTrue("live initialized...", liveServer.getServer().waitForActivation(40, TimeUnit.SECONDS));
          int i = 0;
          while (backupServer.isStarted() && i++ < 100)
          {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedLargeMessageWithDelayFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedLargeMessageWithDelayFailoverTest.java
@@ -31,7 +31,7 @@ public class ReplicatedLargeMessageWithDelayFailoverTest extends ReplicatedLarge
    protected void crash(boolean waitFailure, ClientSession... sessions) throws Exception
    {
       syncDelay.deliverUpToDateMsg();
-      waitForBackup(null, 5);
+      waitForBackup(null, 30);
       super.crash(waitFailure, sessions);
    }
 


### PR DESCRIPTION
Increase timeouts for replicated failover tests to make them stable on slower machines in QA lab. It takes some time to replicate journal from backup to live during failback.
