### PR TITLE
use compare on netty version check, avoiding cases like https://bugzilla.redhat.com/show_bug.cgi?id=923646

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -509,7 +509,10 @@ public class NettyConnector extends AbstractConnector
          batchFlusherFuture = scheduledThreadPool.scheduleWithFixedDelay(flusher, batchDelay, batchDelay, TimeUnit.MILLISECONDS);
       }
 
-      if (!Version.ID.equals(VersionLoader.getVersion().getNettyVersion()))
+      // QE will eventually rebuild Netty and the hash main change.
+      // to avoid further confusion we just verify if our version is contained within the final Netty
+      // No reason to require the exact same build. As long as we have the same version we are ok
+      if (!Version.ID.contains(VersionLoader.getVersion().getNettyVersion()))
       {
          HornetQClientLogger.LOGGER.unexpectedNettyVersion(VersionLoader.getVersion().getNettyVersion(), Version.ID);
       }

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,18 @@
     </prerequisites>
 
    <properties>
+      <!-- don't forget to update netty.version.string manually after updating this. look at the explanation on netty.version.string -->
       <netty.version>3.6.6.Final</netty.version>
-      <netty.version.string>${netty.version}-90e1eb2</netty.version.string>
-      <hornetq.version.versionName>colonizer</hornetq.version.versionName>
+
+       <!-- please keep netty.version.string literal,
+          RedHat production team will patch our builds on netty.version..
+          Our verification for the right Netty version only needs a Netty.getVersion().contains("our-string");
+          if we make this a variable we will have to rebuild hornetq for any minor rebuild from the production team
+          and other issues along it.
+         -->
+      <netty.version.string>3.6.6.Final</netty.version.string>
+
+      <hornetq.version.versionName>Andromedian Fly</hornetq.version.versionName>
       <hornetq.version.majorVersion>2</hornetq.version.majorVersion>
       <hornetq.version.minorVersion>4</hornetq.version.minorVersion>
       <hornetq.version.microVersion>0</hornetq.version.microVersion>

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
@@ -45,7 +45,7 @@ public class NettyConnectorTest extends UnitTestCase
       assertTrue("pom.xml 'netty.version.string' property set to expect\n'" +
                           VersionLoader.getVersion().getNettyVersion() + "'\nGetting\n'" +
                           org.jboss.netty.util.Version.ID + "'",
-                 org.jboss.netty.util.Version.ID.equals(VersionLoader.getVersion().getNettyVersion()));
+                 org.jboss.netty.util.Version.ID.contains(VersionLoader.getVersion().getNettyVersion()));
    }
 
    @Test


### PR DESCRIPTION
Cherry-pick from 2.3 / git:9c1c26b9680f7990838fe4755197c1a533340df8
