### PR TITLE
HORNETQ-1047 - JNDI lookups break after failover after failback

### DIFF
--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -257,7 +257,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
             run.run();
          }
 
-         cachedCommands.clear();
+         // do not clear the cachedCommands - HORNETQ-1047
 
          recoverJndiBindings();
       }


### PR DESCRIPTION
git cherry-pick 135b3c28cb7bc9123e06c8de2a5fa023984eaccc
