### PR TITLE
Fix rest tests failures on Windows platform

### DIFF
--- a/hornetq-rest/src/test/java/org/hornetq/rest/test/PersistentPushQueueConsumerTest.java
+++ b/hornetq-rest/src/test/java/org/hornetq/rest/test/PersistentPushQueueConsumerTest.java
@@ -182,7 +182,7 @@ public class PersistentPushQueueConsumerTest
          res.releaseConnection();
          Assert.assertEquals(201, res.getStatus());
 
-         Thread.sleep(1000);
+         Thread.sleep(5000);
 
          response = pushSubscription.request().get();
          PushRegistration reg2 = response.getEntity(PushRegistration.class);

--- a/hornetq-rest/src/test/java/org/hornetq/rest/test/PersistentPushTopicConsumerTest.java
+++ b/hornetq-rest/src/test/java/org/hornetq/rest/test/PersistentPushTopicConsumerTest.java
@@ -121,7 +121,7 @@ public class PersistentPushTopicConsumerTest
          res.releaseConnection();
          Assert.assertEquals(201, res.getStatus());
 
-         Thread.sleep(1000);
+         Thread.sleep(5000);
 
          response = pushSubscription.request().get();
          PushTopicRegistration reg2 = response.getEntity(PushTopicRegistration.class);


### PR DESCRIPTION
Those tests need more sleep time to pass on Windows.
