### PR TITLE
Bug 912653 Remote JNDI is not working with a HornetQ-only JMS bridge

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -15,6 +15,7 @@ package org.hornetq.core.client.impl;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.security.AccessController;
@@ -544,6 +545,51 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       }
    }
 
+   private ServerLocatorImpl(ServerLocatorImpl locator)
+   {
+      ha = locator.ha;
+      finalizeCheck = locator.finalizeCheck;
+      clusterConnection = locator.clusterConnection;
+      initialConnectors = locator.initialConnectors;
+      discoveryGroupConfiguration = locator.discoveryGroupConfiguration;
+      topology = locator.topology;
+      topologyArray = locator.topologyArray;
+      receivedTopology = locator.receivedTopology;
+      compressLargeMessage = locator.compressLargeMessage;
+      cacheLargeMessagesClient = locator.cacheLargeMessagesClient;
+      clientFailureCheckPeriod = locator.clientFailureCheckPeriod;
+      connectionTTL = locator.connectionTTL;
+      callTimeout = locator.callTimeout;
+      callFailoverTimeout = locator.callFailoverTimeout;
+      minLargeMessageSize = locator.minLargeMessageSize;
+      consumerWindowSize = locator.consumerWindowSize;
+      consumerMaxRate = locator.consumerMaxRate;
+      confirmationWindowSize = locator.confirmationWindowSize;
+      producerWindowSize = locator.producerWindowSize;
+      producerMaxRate = locator.producerMaxRate;
+      blockOnAcknowledge = locator.blockOnAcknowledge;
+      blockOnDurableSend = locator.blockOnDurableSend;
+      blockOnNonDurableSend = locator.blockOnNonDurableSend;
+      autoGroup = locator.autoGroup;
+      preAcknowledge = locator.preAcknowledge;
+      connectionLoadBalancingPolicyClassName = locator.connectionLoadBalancingPolicyClassName;
+      ackBatchSize = locator.ackBatchSize;
+      useGlobalPools = locator.useGlobalPools;
+      scheduledThreadPoolMaxSize = locator.scheduledThreadPoolMaxSize;
+      threadPoolMaxSize = locator.threadPoolMaxSize;
+      retryInterval = locator.retryInterval;
+      retryIntervalMultiplier = locator.retryIntervalMultiplier;
+      maxRetryInterval = locator.maxRetryInterval;
+      reconnectAttempts = locator.reconnectAttempts;
+      initialConnectAttempts = locator.initialConnectAttempts;
+      failoverOnInitialConnection = locator.failoverOnInitialConnection;
+      initialMessagePacketSize = locator.initialMessagePacketSize;
+      startExecutor = locator.startExecutor;
+      afterConnectListener = locator.afterConnectListener;
+      groupID = locator.groupID;
+      nodeID = locator.nodeID;
+      clusterTransportConfiguration = locator.clusterTransportConfiguration;
+   }
 
    private synchronized TransportConfiguration selectConnector()
    {
@@ -2001,5 +2047,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       {
          return state != STATE.INITIALIZED;
       }
+   }
+
+   private Object writeReplace() throws ObjectStreamException
+   {
+      ServerLocatorImpl clone = new ServerLocatorImpl(this);
+      return clone;
    }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/client/ConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/client/ConnectionTest.java
@@ -13,8 +13,15 @@
 
 package org.hornetq.tests.integration.jms.client;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.junit.Test;
 
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
 import javax.jms.Session;
 import javax.jms.XAConnection;
 import javax.jms.XASession;
@@ -51,5 +58,68 @@ public class ConnectionTest extends JMSTestBase
       Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
       assertFalse(sess instanceof XASession);
+   }
+
+   @Test
+   public void testConnectionFactorySerialization() throws Exception
+   {
+      //first try cf without any connection being created
+      ConnectionFactory newCF = getCFThruSerialization(cf);
+      testCreateConnection(newCF);
+      
+      //now serialize a cf after a connection has been created
+      //https://issues.jboss.org/browse/WFLY-327
+      Connection aConn = null;
+      try
+      {
+         aConn = cf.createConnection();
+         newCF = getCFThruSerialization(cf);
+         testCreateConnection(newCF);
+      }
+      finally
+      {
+         if (aConn != null)
+         {
+            aConn.close();
+         }
+      }
+
+   }
+
+   private ConnectionFactory getCFThruSerialization(ConnectionFactory fact) throws Exception
+   {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      ObjectOutputStream oos = new ObjectOutputStream(bos);
+
+      oos.writeObject(cf);
+      ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+      ObjectInputStream ois = new ObjectInputStream(bis);
+      ConnectionFactory newCF = (ConnectionFactory) ois.readObject();
+      oos.close();
+      ois.close();
+
+      return newCF;
+   }
+
+   private void testCreateConnection(ConnectionFactory fact) throws Exception
+   {
+      Connection newConn = null;
+      try
+      {
+         newConn = fact.createConnection();
+         newConn.start();
+         newConn.stop();
+         Session session1 = newConn.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+         session1.close();
+         Session session2 = newConn.createSession(true, Session.SESSION_TRANSACTED);
+         session2.close();
+      }
+      finally
+      {
+         if (newConn != null)
+         {
+            newConn.close();
+         }
+      }
    }
 }


### PR DESCRIPTION
Using writeReplace() method to return a 'cloned' locator without those non serializable fields.
