### PR TITLE
Fix ServiceLoader ClassLoader

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
@@ -152,12 +152,13 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
 
       CoreProtocolManagerFactory coreProtocolManagerFactory = new CoreProtocolManagerFactory();
       //i know there is only 1
+      HornetQServerLogger.LOGGER.addingProtocolSupport(coreProtocolManagerFactory.getProtocols()[0]);
       this.protocolMap.put(coreProtocolManagerFactory.getProtocols()[0],
             coreProtocolManagerFactory.createProtocolManager(server, incomingInterceptors, outgoingInterceptors));
 
       if (config.isResolveProtocols())
       {
-         ServiceLoader<ProtocolManagerFactory> serviceLoader = ServiceLoader.load(ProtocolManagerFactory.class);
+         ServiceLoader<ProtocolManagerFactory> serviceLoader = ServiceLoader.load(ProtocolManagerFactory.class, this.getClass().getClassLoader());
          if (serviceLoader != null)
          {
             for (ProtocolManagerFactory next : serviceLoader)
@@ -165,6 +166,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
                String[] protocols = next.getProtocols();
                for (String protocol : protocols)
                {
+                  HornetQServerLogger.LOGGER.addingProtocolSupport(protocol);
                   protocolMap.put(protocol, next.createProtocolManager(server, incomingInterceptors, outgoingInterceptors));
                }
             }
@@ -178,6 +180,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             String[] protocols = protocolManagerFactory.getProtocols();
             for (String protocol : protocols)
             {
+               HornetQServerLogger.LOGGER.addingProtocolSupport(protocol);
                protocolMap.put(protocol, protocolManagerFactory.createProtocolManager(server, incomingInterceptors, outgoingInterceptors));
             }
          }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1273,4 +1273,9 @@ public interface HornetQServerLogger extends BasicLogger
    @Message(id = 224066, value = "Stopping ClusterManager. As it failed to authenticate with the cluster: {0}",
             format = Message.Format.MESSAGE_FORMAT)
    void clusterManagerAuthenticationError(String msg);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 224067, value = "Adding protocol support {0}",
+            format = Message.Format.MESSAGE_FORMAT)
+    void addingProtocolSupport(String protocolKey);
 }


### PR DESCRIPTION
When calling ServiceLoader.load(), pass the current class's ClassLoader
instead of the TCCL.
Add info log about the supported protocol
