### PR TITLE
Fixing random failure of test org.hornetq.tests.integration.cluster.failover.BackupSyncLargeMessageTest.testDeleteLargeMessages()

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMConnection.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMConnection.java
@@ -129,6 +129,25 @@ public class InVMConnection implements Connection
 
    public void checkFlushBatchBuffer()
    {
+      final CountDownLatch latch = new CountDownLatch(1);
+      executor.execute(new Runnable(){
+         public void run()
+         {
+            latch.countDown();
+         }
+      });
+
+      try
+      {
+         if (!latch.await(10, TimeUnit.SECONDS))
+         {
+            HornetQServerLogger.LOGGER.timedOutFlushingInvmChannel();
+         }
+      }
+      catch (InterruptedException e)
+      {
+         throw new HornetQInterruptedException(e);
+      }
    }
 
    public void write(final HornetQBuffer buffer)

--- a/hornetq-server/src/main/java/org/hornetq/core/replication/ReplicationManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/replication/ReplicationManager.java
@@ -111,7 +111,7 @@ public final class ReplicationManager implements HornetQComponent
    private volatile boolean enabled;
 
    private final Object replicationLock = new Object();
-   private final Object largeMessageSyncGuard = new Object();
+
    private final HashMap<Long, Pair<String, Long>> largeMessagesToSync = new HashMap<Long, Pair<String, Long>>();
 
    private final Queue<OperationContext> pendingTokens = new ConcurrentLinkedQueue<OperationContext>();

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -565,6 +565,7 @@ public class HornetQServerImpl implements HornetQServer
 
          if (localReplicationManager != null)
          {
+            localReplicationManager.getBackupTransportConnection().getTransportConnection().checkFlushBatchBuffer();
             replicationManager.sendLiveIsStopping(LiveStopping.STOP_CALLED);
             // Schedule for 10 seconds
             // this pool gets a 'hard' shutdown, no need to manage the Future of this Runnable.


### PR DESCRIPTION
Cause of the failure:

This test sets up a live-backup, sends a few large messages, consumes half of them before crash the server and failover, and check the
large messages dir of the backup that the half consumed large message files are deleted.

The deletion of each large message file from the backup is driven by a ReplicationLargeMessageEndMessage sent from live via the
replication channel asynchronously. When server stops and notifies the backup to failover

(see HornetQServerImpl.stop(...))

replicationManager.sendLiveIsStopping(LiveStopping.STOP_CALLED);

it is possible that some of those ReplicationLargeMessageEndMessages are still cached at the live server side even after the backup
has received the 'STOP_CALLED' message and initiates failover process. This may leave some of those messages un-processed and so those
large messages are not deleted from backup's large message dir, resulting in assertion failure at the end of test.

How to Fix:

Before sending out the STOP_CALLED message to backup, the live should flush the replication connections of any pending messages.

//this make sure all pending replication messages are flushed before failover
localReplicationManager.getBackupTransportConnection().getTransportConnection().checkFlushBatchBuffer();
replicationManager.sendLiveIsStopping(LiveStopping.STOP_CALLED);
