### PR TITLE
https://issues.jboss.org/browse/HORNETQ-1259 - Consumer.close() shouldn't fire redelivery check

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/Queue.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/Queue.java
@@ -83,6 +83,8 @@ public interface Queue extends Bindable
 
    void cancel(Transaction tx, MessageReference ref);
 
+   void cancel(Transaction tx, MessageReference ref, boolean ignoreRedeliveryCheck);
+
    void cancel(MessageReference reference, long timeBase) throws Exception;
 
    void deliverAsync();
@@ -193,7 +195,7 @@ public interface Queue extends Bindable
 
    Collection<Consumer> getConsumers();
 
-   boolean checkRedelivery(MessageReference ref, long timeBase) throws Exception;
+   boolean checkRedelivery(MessageReference ref, long timeBase, boolean ignoreRedeliveryDelay) throws Exception;
 
    LinkedListIterator<MessageReference> iterator();
    

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
@@ -1039,6 +1039,11 @@ public class QueueImpl implements Queue
 
    private final RefsOperation getRefsOperation(final Transaction tx)
    {
+      return getRefsOperation(tx, false);
+   }
+
+   private final RefsOperation getRefsOperation(final Transaction tx, boolean ignoreRedlieveryCheck)
+   {
       synchronized (tx)
       {
          RefsOperation oper = (RefsOperation)tx.getProperty(TransactionPropertyIndexes.REFS_OPERATION);
@@ -1052,19 +1057,29 @@ public class QueueImpl implements Queue
             tx.addOperation(oper);
          }
 
+         if (ignoreRedlieveryCheck)
+         {
+            oper.setIgnoreRedeliveryCheck();
+         }
+
          return oper;
       }
    }
 
    public void cancel(final Transaction tx, final MessageReference reference)
    {
-      getRefsOperation(tx).addAck(reference);
+      cancel(tx, reference, false);
+   }
+
+   public void cancel(final Transaction tx, final MessageReference reference, boolean ignoreRedeliveryCheck)
+   {
+      getRefsOperation(tx, ignoreRedeliveryCheck).addAck(reference);
    }
 
    public synchronized void cancel(final MessageReference reference, final long timeBase) throws Exception
    {
       deliveringCount.decrementAndGet();
-      if (checkRedelivery(reference, timeBase))
+      if (checkRedelivery(reference, timeBase, false))
       {
          if (!scheduledDeliveryHandler.checkAndSchedule(reference, false))
          {
@@ -2168,7 +2183,7 @@ public class QueueImpl implements Queue
       }
    }
 
-   public boolean checkRedelivery(final MessageReference reference, final long timeBase) throws Exception
+   public boolean checkRedelivery(final MessageReference reference, final long timeBase, final boolean ignoreRedeliveryDelay) throws Exception
    {
       ServerMessage message = reference.getMessage();
 
@@ -2207,7 +2222,7 @@ public class QueueImpl implements Queue
       else
       {
          // Second check Redelivery Delay
-         if (redeliveryDelay > 0)
+         if (!ignoreRedeliveryDelay && redeliveryDelay > 0)
          {
             redeliveryDelay = calculateRedeliveryDelay(addressSettings, deliveryCount);
 
@@ -2626,6 +2641,19 @@ public class QueueImpl implements Queue
 
       List<ServerMessage> pagedMessagesToPostACK = null;
 
+      /**
+       * It will ignore redelivery check, which is used during consumer.close
+       * to not perform reschedule redelivery check
+       */
+      protected boolean ignoreRedeliveryCheck = false;
+
+
+      // once turned on, we shouldn't turn it off, that's why no parameters
+      public void setIgnoreRedeliveryCheck()
+      {
+         ignoreRedeliveryCheck = true;
+      }
+
       synchronized void addAck(final MessageReference ref)
       {
          refsToAck.add(ref);
@@ -2654,7 +2682,8 @@ public class QueueImpl implements Queue
             }
             try
             {
-               if (ref.getQueue().checkRedelivery(ref, timeBase))
+               // if ignore redelivery check, we just perform redelivery straight
+               if (ref.getQueue().checkRedelivery(ref, timeBase, ignoreRedeliveryCheck))
                {
                   LinkedList<MessageReference> toCancel = queueMap.get(ref.getQueue());
 

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
@@ -422,7 +422,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
       {
          MessageReference ref = iter.next();
 
-         ref.getQueue().cancel(tx, ref);
+         ref.getQueue().cancel(tx, ref, true);
       }
 
       tx.rollback();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ConsumerCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ConsumerCloseTest.java
@@ -11,6 +11,11 @@
  * permissions and limitations under the License.
  */
 package org.hornetq.tests.integration.client;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.hornetq.core.client.impl.ClientConsumerImpl;
+import org.hornetq.core.settings.impl.AddressSettings;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -107,7 +112,7 @@ public class ConsumerCloseTest extends ServiceTestBase
 
       ClientProducer producer = session.createProducer(address);
 
-      final int numMessages = 10;
+      final int numMessages = 100;
 
       for (int i = 0; i < numMessages; i++)
       {
@@ -116,13 +121,16 @@ public class ConsumerCloseTest extends ServiceTestBase
          producer.send(message);
       }
 
+      final CountDownLatch received = new CountDownLatch(1);
+      final CountDownLatch waitingToProceed = new CountDownLatch(1);
       class MyHandler implements MessageHandler
       {
          public void onMessage(final ClientMessage message)
          {
             try
             {
-               Thread.sleep(1000);
+               received.countDown();
+               waitingToProceed.await();
             }
             catch (Exception e)
             {
@@ -134,7 +142,151 @@ public class ConsumerCloseTest extends ServiceTestBase
 
       session.start();
 
-      Thread.sleep(1000);
+      assertTrue(received.await(5, TimeUnit.SECONDS));
+
+      long timeout = System.currentTimeMillis() + 1000;
+
+      // Instead of waiting a long time (like 1 second) we just make sure the buffer is full on the client
+      while (((ClientConsumerImpl)consumer).getBufferSize() < 2 && System.currentTimeMillis() > timeout)
+      {
+         Thread.sleep(10);
+      }
+
+      waitingToProceed.countDown();
+
+
+
+      // Close shouldn't wait for all messages to be processed before closing
+      long start = System.currentTimeMillis();
+      consumer.close();
+      long end = System.currentTimeMillis();
+
+      Assert.assertTrue(end - start <= 1500);
+
+   }
+
+   @Test
+   public void testCloseWithScheduledRedelivery() throws Exception
+   {
+
+
+      AddressSettings settings = new AddressSettings();
+      settings.setRedeliveryDelay(50000);
+      server.getAddressSettingsRepository().addMatch("#", settings);
+
+      ClientConsumer consumer = session.createConsumer(queue);
+
+      ClientProducer producer = session.createProducer(address);
+
+      final int numMessages = 100;
+
+      for (int i = 0; i < numMessages; i++)
+      {
+         ClientMessage message = session.createMessage(false);
+
+         producer.send(message);
+      }
+
+      session.start();
+
+      ClientMessage msg = consumer.receive(5000);
+      msg.acknowledge();
+
+      long timeout = System.currentTimeMillis() + 1000;
+
+      while (((ClientConsumerImpl)consumer).getBufferSize() < 2 && System.currentTimeMillis() > timeout)
+      {
+         Thread.sleep(10);
+      }
+
+      consumer.close();
+
+
+      consumer = session.createConsumer(queue);
+
+      // We received one, so we must receive the others now
+      for (int i = 0 ; i < numMessages - 1; i++)
+      {
+         msg = consumer.receive(1000);
+         assertNotNull("Expected message at i=" + i, msg);
+         msg.acknowledge();
+      }
+
+      assertNull(consumer.receiveImmediate());
+
+      // Close shouldn't wait for all messages to be processed before closing
+      long start = System.currentTimeMillis();
+      consumer.close();
+      long end = System.currentTimeMillis();
+
+      Assert.assertTrue(end - start <= 1500);
+
+   }
+
+   @Test
+   public void testCloseWithScheduledRedeliveryWithTX() throws Exception
+   {
+
+
+      AddressSettings settings = new AddressSettings();
+      settings.setRedeliveryDelay(1000);
+      server.getAddressSettingsRepository().addMatch("#", settings);
+
+      ClientProducer producer = session.createProducer(address);
+
+      final int numMessages = 100;
+
+      for (int i = 0; i < numMessages; i++)
+      {
+         ClientMessage message = session.createMessage(false);
+         message.putIntProperty("count", i);
+         producer.send(message);
+      }
+
+      session.close();
+
+      session = addClientSession(sf.createSession(false, false));
+
+      ClientConsumer consumer = session.createConsumer(queue);
+
+      session.start();
+
+      ClientMessage msg = consumer.receive(500);
+      msg.acknowledge();
+
+      long timeout = System.currentTimeMillis() + 1000;
+
+      while (((ClientConsumerImpl)consumer).getBufferSize() < 2 && System.currentTimeMillis() > timeout)
+      {
+         Thread.sleep(10);
+      }
+
+      consumer.close();
+
+      session.rollback();
+
+
+      consumer = session.createConsumer(queue);
+
+      // We received one, so we must receive the others now
+      for (int i = 0 ; i < numMessages - 1; i++)
+      {
+         msg = consumer.receive(1000);
+         assertNotNull("Expected message at i=" + i, msg);
+         msg.acknowledge();
+      }
+
+      assertNull(consumer.receiveImmediate());
+
+      // The first message received after redeliveryDelay
+      msg = consumer.receive(5000);
+      assertNotNull(msg);
+      assertEquals(0, msg.getIntProperty("count").intValue());
+      msg.acknowledge();
+      session.commit();
+
+      assertNull(consumer.receiveImmediate());
+
 
       // Close shouldn't wait for all messages to be processed before closing
       long start = System.currentTimeMillis();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/scheduling/DelayedMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/scheduling/DelayedMessageTest.java
@@ -108,6 +108,8 @@ public class DelayedMessageTest extends ServiceTestBase
       {
          ClientMessage tm = consumer2.receive(500);
 
+         tm.acknowledge();
+
          Assert.assertNotNull(tm);
 
          Assert.assertEquals("message" + i, tm.getBodyBuffer().readString());

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/scheduling/ScheduledMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/scheduling/ScheduledMessageTest.java
@@ -193,13 +193,17 @@ public class ScheduledMessageTest extends ServiceTestBase
 
       session.start();
       ClientMessage message3 = consumer.receive(1000);
+      message3.acknowledge();
       ClientMessage message2 = consumer2.receive(1000);
+      message2.acknowledge();
       Assert.assertEquals("m1", message3.getBodyBuffer().readString());
       Assert.assertEquals("m1", message2.getBodyBuffer().readString());
       long time = System.currentTimeMillis();
       // force redelivery
       consumer.close();
       consumer2.close();
+      // this will make it redelivery-delay
+      session.rollback();
       consumer = session.createConsumer(atestq);
       consumer2 = session.createConsumer(atestq2);
       message3 = consumer.receive(5250);
@@ -244,14 +248,17 @@ public class ScheduledMessageTest extends ServiceTestBase
       session.start();
       ClientMessage message3 = consumer.receive(1000);
       Assert.assertNotNull(message3);
+      message3.acknowledge();
       ClientMessage message2 = consumer2.receive(1000);
       Assert.assertNotNull(message2);
+      message2.acknowledge();
       Assert.assertEquals("m1", message3.getBodyBuffer().readString());
       Assert.assertEquals("m1", message2.getBodyBuffer().readString());
       long time = System.currentTimeMillis();
       // force redelivery
       consumer.close();
       consumer2.close();
+      session.rollback();
       producer.close();
       session.close();
       server.stop();

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -61,6 +61,12 @@ public class FakeQueue implements Queue
 
    }
 
+   @Override
+   public void cancel(Transaction tx, MessageReference ref, boolean ignoreRedeliveryCheck)
+   {
+      // no-op
+   }
+
    PageSubscription subs;
 
    public boolean isDirectDeliver()
@@ -201,7 +207,7 @@ public class FakeQueue implements Queue
    }
 
    @Override
-   public boolean checkRedelivery(final MessageReference ref, final long timeBase) throws Exception
+   public boolean checkRedelivery(final MessageReference ref, final long timeBase, final boolean check) throws Exception
    {
       // no-op
       return false;


### PR DESCRIPTION
...
