### PR TITLE
HORNETQ-1231 listDeliveringdMessagesAsJSON ignores messages that are being consumed

### DIFF
--- a/src/main/org/hornetq/api/core/management/QueueControl.java
+++ b/src/main/org/hornetq/api/core/management/QueueControl.java
@@ -137,7 +137,7 @@ public interface QueueControl
     * @throws Exception
     */
    @Operation(desc = "list all messages being delivered per consumer using JSON form")
-   String listDeliveringdMessagesAsJSON() throws Exception;
+   String listDeliveringMessagesAsJSON() throws Exception;
 
    /**
     * Lists all the messages in this queue matching the specified filter.

--- a/src/main/org/hornetq/core/management/impl/QueueControlImpl.java
+++ b/src/main/org/hornetq/core/management/impl/QueueControlImpl.java
@@ -453,7 +453,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
 
    }
 
-   public String listDeliveringdMessagesAsJSON() throws Exception
+   public String listDeliveringMessagesAsJSON() throws Exception
    {
       checkStarted();
 

--- a/src/main/org/hornetq/core/paging/cursor/PagedReferenceImpl.java
+++ b/src/main/org/hornetq/core/paging/cursor/PagedReferenceImpl.java
@@ -54,6 +54,8 @@ public class PagedReferenceImpl implements PagedReference
 
    private final PageSubscription subscription;
 
+   private long consumerId = -1;
+
    public ServerMessage getMessage()
    {
       return getPagedMessage().getMessage();
@@ -265,6 +267,18 @@ public class PagedReferenceImpl implements PagedReference
              ", subscription=" +
              subscription +
              "]";
+   }
+
+   @Override
+   public void setConsumerId(long id)
+   {
+      consumerId = id;
+   }
+
+   @Override
+   public long getConsumerId()
+   {
+      return consumerId;
    }
 
 }

--- a/src/main/org/hornetq/core/server/MessageReference.java
+++ b/src/main/org/hornetq/core/server/MessageReference.java
@@ -71,4 +71,8 @@ public interface MessageReference
 
 
    void handled();
+
+   void setConsumerId(long id);
+
+   long getConsumerId();
 }

--- a/src/main/org/hornetq/core/server/ServerSession.java
+++ b/src/main/org/hornetq/core/server/ServerSession.java
@@ -147,4 +147,20 @@ public interface ServerSession
 
    void setSessionContext(OperationContext context);
 
+   /**
+    * HornetQ RA will acknowledge a message before calling MDB if it is transactional
+    * that will cause the message to be removed from the consumer's delivering 
+    * list before the tx is finished. We need to add those acked messages when
+    * getting messages in delivery state.
+    * 
+    * @param refList : the list to add messages to.
+    * @param consumerId : the consumer
+    */
+   void getInTxMessages(List<MessageReference> refList, long consumerId);
+
+   /**
+    * Is this session created from RA?
+    */
+   boolean isFromRa();
+
 }

--- a/src/main/org/hornetq/core/server/impl/LastValueQueue.java
+++ b/src/main/org/hornetq/core/server/impl/LastValueQueue.java
@@ -268,5 +268,17 @@ public class LastValueQueue extends QueueImpl
       {
          return ref.getMessage().getMemoryEstimate();
       }
+
+      @Override
+      public void setConsumerId(long id)
+      {
+         ref.setConsumerId(id);
+      }
+
+      @Override
+      public long getConsumerId()
+      {
+         return ref.getConsumerId();
+      }
    }
 }

--- a/src/main/org/hornetq/core/server/impl/MessageReferenceImpl.java
+++ b/src/main/org/hornetq/core/server/impl/MessageReferenceImpl.java
@@ -44,6 +44,8 @@ public class MessageReferenceImpl implements MessageReference
 
    private final Queue queue;
 
+   private long consumerId = -1;
+
    // Static --------------------------------------------------------
 
    private static final int memoryOffset;
@@ -209,6 +211,18 @@ public class MessageReferenceImpl implements MessageReference
              getMessage();
    }
    // Package protected ---------------------------------------------
+
+   @Override
+   public void setConsumerId(long id)
+   {
+      this.consumerId = id;
+   }
+
+   @Override
+   public long getConsumerId()
+   {
+      return this.consumerId;
+   }
 
    // Protected -----------------------------------------------------
 

--- a/src/main/org/hornetq/core/server/impl/QueueImpl.java
+++ b/src/main/org/hornetq/core/server/impl/QueueImpl.java
@@ -2585,7 +2585,7 @@ public class QueueImpl implements Queue
       LinkedListIterator<MessageReference> iter;
    }
 
-   private final class RefsOperation implements TransactionOperation
+   public final class RefsOperation implements TransactionOperation
    {
       List<MessageReference> refsToAck = new ArrayList<MessageReference>();
 

--- a/src/main/org/hornetq/core/server/impl/ServerConsumerImpl.java
+++ b/src/main/org/hornetq/core/server/impl/ServerConsumerImpl.java
@@ -223,6 +223,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
    {
       synchronized(lock)
       {
+         session.getInTxMessages(refList, id);
          refList.addAll(deliveringRefs);
       }
    }
@@ -695,6 +696,11 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
                                 " queue = " +
                                 messageQueue.getName());
                throw e;
+            }
+
+            if (session.isFromRa() && (!startedTransaction))
+            {
+               ref.setConsumerId(id);
             }
 
             ref.getQueue().acknowledge(tx, ref);

--- a/tests/src/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/src/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
@@ -316,7 +316,7 @@ public class QueueControlUsingCoreTest extends QueueControlTest
          }
 
          @Override
-         public String listDeliveringdMessagesAsJSON() throws Exception
+         public String listDeliveringMessagesAsJSON() throws Exception
          {
             return (String)proxy.invokeOperation("listDeliveringdMessagesAsJSON");
          }


### PR DESCRIPTION
In HorneQ RA if the session is transactional the message is acknowledged before the onMessage() is called. If onMessage() takes long time to finish and during that time the getDeliveringMessage is called, the acked message won't be counted.
