### PR TITLE
Change scope of logmanager dependency to test only.

### DIFF
--- a/hornetq-journal/pom.xml
+++ b/hornetq-journal/pom.xml
@@ -28,6 +28,7 @@
       <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.hornetq</groupId>


### PR DESCRIPTION
Some one with a little more knowledge of HornetQ might want to test this, but the test scope should be appropriate. It's leaking the dependency into WildFly.
