### PR TITLE
Allow the topology message to be received correctly, and retry from the ...

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -836,7 +836,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                CreateSessionResponseMessage response;
                try
                {
-                  response = (CreateSessionResponseMessage)channel1.sendBlocking(request, PacketImpl.CREATESESSION_RESP);
+                  response = sendCreateSessionMessage(channel1, request);
                }
                catch (HornetQException e)
                {
@@ -945,6 +945,28 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
       // Should never get here
       throw HornetQClientMessageBundle.BUNDLE.clietSessionInternal();
+   }
+
+   private CreateSessionResponseMessage sendCreateSessionMessage(final Channel channel1, Packet request) throws HornetQException {
+      CreateSessionResponseMessage response = null;
+
+      try
+      {
+         response = (CreateSessionResponseMessage)channel1.sendBlocking(request, PacketImpl.CREATESESSION_RESP);
+      }
+      catch (HornetQException e)
+      {
+         if (e.getType() == HornetQExceptionType.INCOMPATIBLE_CLIENT_SERVER_VERSIONS)
+         {
+            if (((CreateSessionMessage) request).getVersion() == 123)
+            {
+               ((CreateSessionMessage) request).setVersion(122);
+               response = (CreateSessionResponseMessage)channel1.sendBlocking(request, PacketImpl.CREATESESSION_RESP);
+            }
+         }
+      }
+      
+      return response;
    }
 
    private void callSessionFailureListeners(final HornetQException me, final boolean afterReconnect,

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -102,8 +102,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
 
    private final Topology topology;
 
-   //needs to be serializable
-   private final String topologyArrayGuard = new String();
+   private String topologyArrayGuard = new String();
 
    private volatile Pair<TransportConfiguration, TransportConfiguration>[] topologyArray;
 
@@ -179,12 +178,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    private boolean failoverOnInitialConnection;
 
    private int initialMessagePacketSize;
-
-   /**
-    * As the class is Serializable, the guard field must be of a serializable type in order to be
-    * final.
-    */
-   private final String stateGuard = new String();
+   private String stateGuard = new String();
    private transient STATE state;
    private transient CountDownLatch latch;
 
@@ -1788,9 +1782,18 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    private void readObject(ObjectInputStream is) throws ClassNotFoundException, IOException
    {
       is.defaultReadObject();
+      if(stateGuard == null)
+      {
+          stateGuard = new String();
+      }
+      if(topologyArrayGuard == null)
+      {
+          topologyArrayGuard = new String();
+      }
       //is transient so need to create, for compatibility issues
       packetDecoder = ClientPacketDecoder.INSTANCE;
    }
+
    private final class StaticConnector implements Serializable
    {
       private static final long serialVersionUID = 6772279632415242634l;

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
@@ -137,7 +137,9 @@ public class ClusterTopologyChangeMessage_V2 extends ClusterTopologyChangeMessag
          pair = new Pair<TransportConfiguration, TransportConfiguration>(a, b);
          last = buffer.readBoolean();
       }
-      nodeName = buffer.readNullableString();
+      if(buffer.readableBytes() > 0) {
+        nodeName = buffer.readNullableString();
+      }
    }
 
    @Override

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/CreateSessionMessage.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/CreateSessionMessage.java
@@ -109,6 +109,11 @@ public class CreateSessionMessage extends PacketImpl
       return version;
    }
 
+   public void setVersion(int version)
+   {
+      this.version = version;
+   }
+
    public String getUsername()
    {
       return username;


### PR DESCRIPTION
...client if the server rejects because of compatibility.  Initialize the fields that are not present in HornetQ 2.2.x and thus won't get initialized during deserialization.
