### PR TITLE
using getBodyBuffer() to getBodyBufferCopy() in ServerMessageImpl.toString()

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
@@ -314,7 +314,7 @@ public class ServerMessageImpl extends MessageImpl implements ServerMessage
    @Override
    public String toString()
    {
-      return "ServerMessage[messageID=" + messageID + ",durable=" + isDurable() + ",userID=" + getUserID() + ",priority=" + this.getPriority() + ", bodySize=" + this.getBodyBuffer().capacity() +
+      return "ServerMessage[messageID=" + messageID + ",durable=" + isDurable() + ",userID=" + getUserID() + ",priority=" + this.getPriority() + ", bodySize=" + this.getBodyBufferCopy().capacity() +
           ",expiration=" + (this.getExpiration() != 0 ? new java.util.Date(this.getExpiration()) : 0) +
           ", durable=" + durable + ", address=" + getAddress()  + ",properties=" + properties.toString() + "]@" + System.identityHashCode(this);
    }


### PR DESCRIPTION
getBodyBuffer() will alter the readerIndex of the internal buffer of the message. This will
cause problem if the toString() is called before the message is marshaled to the netty.
