### PR TITLE
HORNETQ-1276 Deadlock between StompProtocolManager.cleanup() and StompSession.sendMessage()

### DIFF
--- a/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompProtocolManager.java
+++ b/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompProtocolManager.java
@@ -292,6 +292,7 @@ class StompProtocolManager implements ProtocolManager, NotificationListener
             {
                try
                {
+                  session.getSession().stop();
                   session.getSession().rollback(true);
                   session.getSession().close(false);
                }


### PR DESCRIPTION
By stopping the session first we can avoid the deadlock
