### PR TITLE
HORNETQ-1275 - Deadlock in stomp delivery

### DIFF
--- a/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompConnection.java
+++ b/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompConnection.java
@@ -606,11 +606,11 @@ public final class StompConnection implements RemotingConnection
       {
          if (minLargeMessageSize == -1 || (message.getBodyBuffer().writerIndex() < minLargeMessageSize))
          {
-            stompSession.sendInternal(message, true);
+            stompSession.sendInternal(message, false);
          }
          else
          {
-            stompSession.sendInternalLarge(message, true);
+            stompSession.sendInternalLarge(message, false);
          }
       }
       catch (Exception e)


### PR DESCRIPTION
The cause of deadlock is that the direct delivery and indirectly delivery happens at the same time during the stomp delivery
By change the stomp session not to use direct delivery will prevent such a dead-lock.
