### PR TITLE
[HORNETQ-1172] Provide Websocket-like HTTP upgrade protocol

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
@@ -419,4 +419,8 @@ public interface HornetQClientLogger extends BasicLogger
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 214022, value = "Invalid protocol specified. Supported protocols are: {0}", format = Message.Format.MESSAGE_FORMAT)
    void invalidProtocol(String validProtocols);
+
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 214023, value = "HTTP Handshake failed, the received accept value %s does not match the expected response %s")
+   void httpHandshakeFailed(String response, String expectedResponse);
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
@@ -41,6 +41,8 @@ public class TransportConstants
 
    public static final String HTTP_REQUIRES_SESSION_ID = "http-requires-session-id";
 
+   public static final String HTTP_UPGRADE_ENABLED_PROP_NAME = "http-upgrade-enabled";
+
    public static final String USE_SERVLET_PROP_NAME = "use-servlet";
 
    public static final String SERVLET_PATH = "servlet-path";
@@ -156,6 +158,8 @@ public class TransportConstants
 
    public static final boolean DEFAULT_HTTP_REQUIRES_SESSION_ID = false;
 
+   public static final boolean DEFAULT_HTTP_UPGRADE_ENABLED = false;
+
    public static final String DEFAULT_SERVLET_PATH = "/messaging/HornetQServlet";
 
    public static final long DEFAULT_BATCH_DELAY = 0;
@@ -182,6 +186,7 @@ public class TransportConstants
       allowableAcceptorKeys.add(TransportConstants.SSL_ENABLED_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HTTP_RESPONSE_TIME_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HTTP_SERVER_SCAN_PERIOD_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_INVM_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.PROTOCOL_PROP_NAME);
@@ -217,6 +222,7 @@ public class TransportConstants
       allowableConnectorKeys.add(TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD);
       allowableConnectorKeys.add(TransportConstants.HTTP_REQUIRES_SESSION_ID);
+      allowableConnectorKeys.add(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_SERVLET_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.SERVLET_PATH);
       allowableConnectorKeys.add(TransportConstants.USE_NIO_PROP_NAME);

--- a/hornetq-server/src/main/java/org/hornetq/core/protocol/ProtocolHandler.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/protocol/ProtocolHandler.java
@@ -101,10 +101,15 @@ public class ProtocolHandler
 
       @Override
       protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+         if (ctx.isRemoved()) {
+             return;
+         }
+
          // Will use the first five bytes to detect a protocol.
          if (in.readableBytes() < 8) {
             return;
          }
+
          final int magic1 = in.getUnsignedByte(in.readerIndex());
          final int magic2 = in.getUnsignedByte(in.readerIndex() + 1);
          if (http && isHttp(magic1, magic2))
@@ -135,6 +140,7 @@ public class ProtocolHandler
          NettyServerConnection connection = channelHandler.createConnection(ctx, protocolToUse, httpEnabled);
          protocolManagerToUse.handshake(connection, new ChannelBufferWrapper(in));
          pipeline.remove(this);
+         ctx.flush();
       }
 
       private boolean isHttp(int magic1, int magic2)

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -32,7 +32,8 @@ import org.hornetq.spi.core.remoting.ConnectionLifeCycleListener;
  */
 public class InVMAcceptorFactory implements AcceptorFactory
 {
-   public Acceptor createAcceptor(final ClusterConnection clusterConnection,
+   public Acceptor createAcceptor(final String name,
+                                  final ClusterConnection clusterConnection,
                                   final Map<String, Object> configuration,
                                   final BufferHandler handler,
                                   final ConnectionLifeCycleListener listener,

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptorFactory.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptorFactory.java
@@ -32,7 +32,8 @@ import org.hornetq.spi.core.remoting.ConnectionLifeCycleListener;
  */
 public class NettyAcceptorFactory implements AcceptorFactory
 {
-   public Acceptor createAcceptor(final ClusterConnection connection,
+   public Acceptor createAcceptor(final String name,
+                                  final ClusterConnection connection,
                                   final Map<String, Object> configuration,
                                   final BufferHandler handler,
                                   final ConnectionLifeCycleListener listener,
@@ -40,7 +41,7 @@ public class NettyAcceptorFactory implements AcceptorFactory
                                   final ScheduledExecutorService scheduledThreadPool,
                                   final Map<String, ProtocolManager> protocolMap)
    {
-      return new NettyAcceptor(connection, configuration, handler, listener, threadPool, scheduledThreadPool, protocolMap);
+      return new NettyAcceptor(name, connection, configuration, handler, listener, scheduledThreadPool, protocolMap);
    }
 
    public Set<String> getAllowableProperties()

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/RemotingService.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/RemotingService.java
@@ -19,6 +19,7 @@ import org.hornetq.api.core.Interceptor;
 import org.hornetq.core.protocol.core.CoreRemotingConnection;
 import org.hornetq.core.security.HornetQPrincipal;
 import org.hornetq.spi.core.protocol.RemotingConnection;
+import org.hornetq.spi.core.remoting.Acceptor;
 
 /**
  * @author <a href="mailto:jmesnil@redhat.com">Jeff Mesnil</a>
@@ -65,4 +66,13 @@ public interface RemotingService
     * @param backupTransportConnection
     */
    void freeze(CoreRemotingConnection rc);
+
+   /**
+    * Returns the acceptor identified by its {@code
+    *  name} or {@code null} if it does not exists.
+    *
+    * @param name the name of the acceptor
+    */
+   Acceptor getAcceptor(String name);
+
 }

--- a/hornetq-server/src/main/java/org/hornetq/spi/core/remoting/AcceptorFactory.java
+++ b/hornetq-server/src/main/java/org/hornetq/spi/core/remoting/AcceptorFactory.java
@@ -16,9 +16,11 @@ package org.hornetq.spi.core.remoting;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.hornetq.core.protocol.ProtocolHandler;
+import org.hornetq.core.remoting.server.impl.RemotingServiceImpl;
 import org.hornetq.core.server.cluster.ClusterConnection;
 import org.hornetq.spi.core.protocol.ProtocolManager;
 
@@ -37,7 +39,7 @@ public interface AcceptorFactory
     * Create a new instance of an Acceptor.
     *
     *
-    *
+    * @param name                the name of the acceptor
     * @param configuration       the configuration
     * @param handler             the handler
     * @param listener            the listener
@@ -46,8 +48,9 @@ public interface AcceptorFactory
     * @param protocolMap
     * @return an acceptor
     */
-   Acceptor createAcceptor(ClusterConnection clusterConnection,
-                           final Map<String, Object> configuration,
+   Acceptor createAcceptor(String name,
+                           ClusterConnection clusterConnection,
+                           Map<String, Object> configuration,
                            BufferHandler handler,
                            ConnectionLifeCycleListener listener,
                            Executor threadPool,

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
@@ -1,0 +1,222 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.hornetq.tests.integration.transports.netty;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.UPGRADE;
+import static io.netty.handler.codec.http.HttpResponseStatus.SWITCHING_PROTOCOLS;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.MAGIC_NUMBER;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_ACCEPT;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_KEY;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.createExpectedResponse;
+import static org.hornetq.tests.util.RandomUtil.randomString;
+
+import java.util.HashMap;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import org.hornetq.api.core.SimpleString;
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.api.core.client.ClientConsumer;
+import org.hornetq.api.core.client.ClientMessage;
+import org.hornetq.api.core.client.ClientProducer;
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.api.core.client.ClientSessionFactory;
+import org.hornetq.api.core.client.HornetQClient;
+import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.remoting.impl.netty.NettyAcceptor;
+import org.hornetq.core.remoting.impl.netty.PartialPooledByteBufAllocator;
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
+import org.hornetq.core.server.HornetQServer;
+import org.hornetq.core.server.HornetQServers;
+import org.hornetq.jms.client.HornetQTextMessage;
+import org.hornetq.tests.util.UnitTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test that Netty Connector can connect to a Web Server and upgrade from a HTTP request to its remoting protocol.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class NettyConnectorWithHTTPUpgradeTest extends UnitTestCase {
+
+    private static final SimpleString QUEUE = new SimpleString("NettyConnectorWithHTTPUpgradeTest");
+
+    private static final int HTTP_PORT = 8080;
+
+    private Configuration conf;
+    private HornetQServer server;
+    private ServerLocator locator;
+    private String acceptorName;
+
+    private NioEventLoopGroup bossGroup;
+    private NioEventLoopGroup workerGroup;
+
+    @Override
+    @Before
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        conf = createDefaultConfig();
+
+        acceptorName = randomString();
+        conf.setSecurityEnabled(false);
+        HashMap<String, Object> params = new HashMap<String, Object>();
+        // This prop controls the usage of HTTP Get + Upgrade from Netty connector
+        params.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
+        params.put(TransportConstants.PORT_PROP_NAME, HTTP_PORT);
+        conf.getAcceptorConfigurations().add(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params, acceptorName));
+
+        server = addServer(HornetQServers.newHornetQServer(conf, false));
+
+        server.start();
+        locator = HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY, params));
+        addServerLocator(locator);
+
+        // THe web server owns the HTTP port, not HornetQ.
+        startWebServer(HTTP_PORT);
+    }
+
+    @After
+    public void tearDown() {
+        stopWebServer();
+    }
+
+    @Test
+    public void sendAndReceiveOverHTTPPort() throws Exception {
+        ClientSessionFactory sf = createSessionFactory(locator);
+        ClientSession session = sf.createSession(false, true, true);
+
+        session.createQueue(QUEUE, QUEUE, null, false);
+
+        ClientProducer producer = session.createProducer(QUEUE);
+
+        final int numMessages = 100;
+
+        for (int i = 0; i < numMessages; i++)
+        {
+            ClientMessage message = session.createMessage(HornetQTextMessage.TYPE,
+                    false,
+                    0,
+                    System.currentTimeMillis(),
+                    (byte)1);
+            message.getBodyBuffer().writeString("sendAndReceiveOverHTTPPort");
+            producer.send(message);
+        }
+
+        ClientConsumer consumer = session.createConsumer(QUEUE);
+
+        session.start();
+
+        for (int i = 0; i < numMessages; i++)
+        {
+            ClientMessage message2 = consumer.receive();
+
+            assertNotNull(message2);
+            assertEquals("sendAndReceiveOverHTTPPort", message2.getBodyBuffer().readString());
+
+            message2.acknowledge();
+        }
+
+        session.close();
+    }
+
+    private void startWebServer(int port) throws InterruptedException {
+        bossGroup = new NioEventLoopGroup();
+        workerGroup = new NioEventLoopGroup();
+        ServerBootstrap b = new ServerBootstrap();
+        b.childOption(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new ChannelInitializer<SocketChannel>()
+                {
+                    @Override
+                    protected void initChannel(SocketChannel ch) throws Exception
+                    {
+                        // create a HTTP server
+                        ChannelPipeline p = ch.pipeline();
+                        p.addLast("decoder", new HttpRequestDecoder());
+                        p.addLast("encoder", new HttpResponseEncoder());
+                        p.addLast("http-upgrade-handler", new SimpleChannelInboundHandler<Object>()
+                        {
+                            // handle HTTP GET + Upgrade with a handshake specific to HornetQ remoting.
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception
+                            {
+                                if (msg instanceof HttpRequest)
+                                {
+                                    HttpRequest request = (HttpRequest) msg;
+
+                                    String upgrade = request.headers().get(UPGRADE);
+                                    String secretKey = request.headers().get(SEC_HORNETQ_REMOTING_KEY);
+
+                                    FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, SWITCHING_PROTOCOLS);
+                                    response.headers().set(UPGRADE, upgrade);
+                                    response.headers().set(SEC_HORNETQ_REMOTING_ACCEPT, createExpectedResponse(MAGIC_NUMBER, secretKey));
+                                    ctx.writeAndFlush(response);
+
+                                    // when the handshake is successful, the HTTP handlers are removed
+                                    ctx.pipeline().remove("decoder");
+                                    ctx.pipeline().remove("encoder");
+                                    ctx.pipeline().remove(this);
+
+                                    System.out.println("HTTP handshake sent, transferring channel");
+                                    // transfer the control of the channel to the Netty Acceptor
+                                    NettyAcceptor acceptor = (NettyAcceptor) server.getRemotingService().getAcceptor(acceptorName);
+                                    acceptor.transfer(ctx.channel());
+                                    // at this point, the HTTP upgrade process is over and the netty acceptor behaves like regular ones.
+                                }
+                            }
+                        });
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception
+                    {
+                        ctx.flush();
+                    }
+                });
+        b.bind(port).sync();
+    }
+
+    private void stopWebServer()
+    {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+    }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
@@ -78,7 +78,8 @@ public class NettyAcceptorFactoryTest extends UnitTestCase
 
       };
 
-      Acceptor acceptor = factory.createAcceptor(null,
+      Acceptor acceptor = factory.createAcceptor("netty",
+                                                 null,
                                                  params,
                                                  handler,
                                                  listener,

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
@@ -47,7 +47,6 @@ import org.hornetq.tests.util.UnitTestCase;
  */
 public class NettyAcceptorTest extends UnitTestCase
 {
-   private ExecutorService pool1;
    private ScheduledExecutorService pool2;
 
    @Override
@@ -69,8 +68,6 @@ public class NettyAcceptorTest extends UnitTestCase
       }
       finally
       {
-         if (pool1 != null)
-            pool1.shutdownNow();
          if (pool2 != null)
             pool2.shutdownNow();
          super.tearDown();
@@ -108,12 +105,12 @@ public class NettyAcceptorTest extends UnitTestCase
          {
          }
       };
-      pool1 = Executors.newCachedThreadPool();
       pool2 = Executors.newScheduledThreadPool(HornetQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize());
-      NettyAcceptor acceptor = new NettyAcceptor(params,
+      NettyAcceptor acceptor = new NettyAcceptor("netty",
+                                                 null,
+                                                 params,
                                                  handler,
                                                  listener,
-                                                 pool1,
                                                  pool2,
             null);
 
@@ -130,10 +127,8 @@ public class NettyAcceptorTest extends UnitTestCase
       Assert.assertFalse(acceptor.isStarted());
       UnitTestCase.checkFreePort(TransportConstants.DEFAULT_PORT);
 
-      pool1.shutdown();
       pool2.shutdown();
 
-      pool1.awaitTermination(1, TimeUnit.SECONDS);
       pool2.awaitTermination(1, TimeUnit.SECONDS);
    }
 


### PR DESCRIPTION
add http-upgrade-enable property (disabled by default) to
use HTTP Upgrade mechanism when connecting to the server.
The 1st request will be a HTTP Request + Upgrade: hornetq-remoting sent
to the server's Web container that'll reply with a HTTP 101 Switching
protocols.
When the client receives this response, it will switch to the
hornetq remoting protocol and remove the HTTP handler.
