### PR TITLE
HORNETQ-1242 :

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -102,8 +102,8 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
 
    private final Topology topology;
 
-   //needs to be serializable
-   private final String topologyArrayGuard = new String();
+   //needs to be serializable and not final for retrocompatibility
+   private String topologyArrayGuard = new String();
 
    private volatile Pair<TransportConfiguration, TransportConfiguration>[] topologyArray;
 
@@ -180,11 +180,8 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
 
    private int initialMessagePacketSize;
 
-   /**
-    * As the class is Serializable, the guard field must be of a serializable type in order to be
-    * final.
-    */
-   private final String stateGuard = new String();
+   //needs to be serializable and not final for retrocompatibility
+   private String stateGuard = new String();
    private transient STATE state;
    private transient CountDownLatch latch;
 
@@ -1788,9 +1785,18 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    private void readObject(ObjectInputStream is) throws ClassNotFoundException, IOException
    {
       is.defaultReadObject();
+      if(stateGuard == null)
+      {
+          stateGuard = new String();
+      }
+      if(topologyArrayGuard == null)
+      {
+          topologyArrayGuard = new String();
+      }
       //is transient so need to create, for compatibility issues
       packetDecoder = ClientPacketDecoder.INSTANCE;
    }
+
    private final class StaticConnector implements Serializable
    {
       private static final long serialVersionUID = 6772279632415242634l;

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
@@ -137,7 +137,9 @@ public class ClusterTopologyChangeMessage_V2 extends ClusterTopologyChangeMessag
          pair = new Pair<TransportConfiguration, TransportConfiguration>(a, b);
          last = buffer.readBoolean();
       }
-      nodeName = buffer.readNullableString();
+      if(buffer.readableBytes() > 0) {
+        nodeName = buffer.readNullableString();
+      }
    }
 
    @Override

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
       <hornetq.version.majorVersion>2</hornetq.version.majorVersion>
       <hornetq.version.minorVersion>3</hornetq.version.minorVersion>
       <hornetq.version.microVersion>13</hornetq.version.microVersion>
-      <hornetq.version.incrementingVersion>123</hornetq.version.incrementingVersion>
+      <hornetq.version.incrementingVersion>123,122</hornetq.version.incrementingVersion>
       <hornetq.version.versionSuffix>Final</hornetq.version.versionSuffix>
       <hornetq.version.versionTag>HornetQ_2_3_13_Final</hornetq.version.versionTag>
       <HornetQ-Version>

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/VersionLoaderTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/VersionLoaderTest.java
@@ -16,6 +16,7 @@ package org.hornetq.tests.unit.util;
 import org.junit.Test;
 
 import java.util.Properties;
+import java.util.StringTokenizer;
 
 import org.junit.Assert;
 
@@ -50,13 +51,13 @@ public class VersionLoaderTest extends UnitTestCase
       Assert.assertEquals(props.get("hornetq.version.versionName"), version.getVersionName());
       Assert.assertEquals(props.get("hornetq.version.versionSuffix"), version.getVersionSuffix());
 
-      Assert.assertEquals(Integer.parseInt((String)props.get("hornetq.version.majorVersion")),
+      Assert.assertEquals(Integer.parseInt(props.getProperty("hornetq.version.majorVersion")),
                           version.getMajorVersion());
-      Assert.assertEquals(Integer.parseInt((String)props.get("hornetq.version.minorVersion")),
+      Assert.assertEquals(Integer.parseInt(props.getProperty("hornetq.version.minorVersion")),
                           version.getMinorVersion());
-      Assert.assertEquals(Integer.parseInt((String)props.get("hornetq.version.microVersion")),
-                          version.getMicroVersion());
-      Assert.assertEquals(Integer.parseInt((String)props.get("hornetq.version.incrementingVersion")),
+      Assert.assertEquals(Integer.parseInt(props.getProperty("hornetq.version.microVersion")),
+                          version.getMicroVersion());           
+      Assert.assertEquals(Integer.parseInt(new StringTokenizer(props.getProperty("hornetq.version.incrementingVersion"), ",").nextToken()),
                           version.getIncrementingVersion());
    }
 


### PR DESCRIPTION
Allowing the topology message to be received correctly
Changing the client version so it can connect to the older server by allowing a list of compatible server versions.
Filling the fields that are not present in HornetQ 2.2.x and thus won't get filled during deserialization. Making them not final to be able to do this.
