### PR TITLE
add netty property http-upgrade-endpoint

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -745,6 +745,14 @@ public class NettyConnector extends AbstractConnector
                   request.headers().set(HttpHeaders.Names.UPGRADE, HORNETQ_REMOTING);
                   request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.UPGRADE);
 
+                  final String endpoint = ConfigurationHelper.getStringProperty(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME,
+                     null,
+                     configuration);
+                  if (endpoint != null)
+                  {
+                     request.headers().set(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, endpoint);
+                  }
+
                   // Get 16 bit nonce and base 64 encode it
                   byte[] nonce = randomBytes(16);
                   String key = base64(nonce);

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
@@ -44,6 +44,8 @@ public class TransportConstants
 
    public static final String HTTP_UPGRADE_ENABLED_PROP_NAME = "http-upgrade-enabled";
 
+   public static final String HTTP_UPGRADE_ENDPOINT_PROP_NAME = "http-upgrade-endpoint";
+
    public static final String USE_SERVLET_PROP_NAME = "use-servlet";
 
    public static final String SERVLET_PATH = "servlet-path";
@@ -226,6 +228,7 @@ public class TransportConstants
       allowableConnectorKeys.add(TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD);
       allowableConnectorKeys.add(TransportConstants.HTTP_REQUIRES_SESSION_ID);
       allowableConnectorKeys.add(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_SERVLET_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.SERVLET_PATH);
       allowableConnectorKeys.add(TransportConstants.USE_NIO_PROP_NAME);


### PR DESCRIPTION
When using http-upgrade, the connector is multiplexed to the acceptor
through the Web server and its HTTP port
If there are multiple acceptors that are registered for the HTTP upgrade
mechanism, we need a HTTP header to match the connector initiating the
HTTP request with the acceptor that will take over the upgrade.
The property http-upgrade-endpoint is used for this case.
