### PR TITLE
JBAPP-10945 : Backporting fix for EAP5

### DIFF
--- a/src/main/org/hornetq/core/deployers/impl/FileConfigurationParser.java
+++ b/src/main/org/hornetq/core/deployers/impl/FileConfigurationParser.java
@@ -745,6 +745,10 @@ public class FileConfigurationParser
                else if (FileConfigurationParser.MANAGE_NAME.equals(type))
                {
                   manageRoles.add(role.trim());
+               } 
+               else 
+               {
+                   FileConfigurationParser.log.warn(String.format("Wrong configuration for role, {0} is not a valid permission", type));
                }
                if (!allRoles.contains(role.trim()))
                {


### PR DESCRIPTION
Logging a warning message when an inexisting role is defined in permissions.
Jira : https://issues.jboss.org/browse/JBPAPP-10945
Upstream PR: https://github.com/hornetq/hornetq/pull/1469
