### PR TITLE
Delivery count decrement twice if message sends to deadletter address

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
@@ -1087,10 +1087,6 @@ public class QueueImpl implements Queue
 
          resetAllIterators();
       }
-      else
-      {
-         decDelivering();
-      }
    }
 
    public void expire(final MessageReference ref) throws Exception


### PR DESCRIPTION
There is a queue with max-delivery-attempts = 1. There is core bridge (or my custom consumer) which increment delivery count and cancel each message using this method. If I put 3 messages to the queue, all they will be moved to deadletter address after attempt to deliver. After that сall queue.getInstantMessageCount() will return "-3". This happens because decDelivering method called twice: first in cancel(MessageReference, long), second in postAcknowledge(MessageReference).

Test case:
//my consumer example
public class MyConsumer implements Consumer {
public HandleStatus handle(final MessageReference messageReference) throws Exception { 
messageReference.handled();
messageReference.incrementDeliveryCount();
executor.submit(new Runnable() {
public void run() {
queue.cancel(messageReference,System.currentTimeMillis());
System.out.println(queue.getInstantMessageCount());
}
});
return HandleStatus.HANDLED;
}
}

Executor executor; //Some executor

System.out.println(queue.getInstantMessageCount()); //print 0;

queue.addConsumer(new MyConsumer);
queue.deliverAsync();

//putting message to Queue
//will print -1
