### PR TITLE
HORNETQ-1314 - disable monitoring for in-vm connections

### DIFF
--- a/docs/user-manual/en/connection-ttl.xml
+++ b/docs/user-manual/en/connection-ttl.xml
@@ -108,7 +108,9 @@ finally
             instance, or if you're deploying JMS connection factory instances direct into JNDI on
             the server side, you can specify it in the xml config, using the parameter <literal
                 >connection-ttl</literal>.</para>
-        <para>The default value for connection ttl is <literal>60000</literal>ms, i.e. 1 minute. A
+        <para>The default value for connection ttl on an "unreliable" connection (e.g. a Netty
+            connection) is <literal>60000</literal>ms, i.e. 1 minute. The default value for connection
+            ttl on a "reliable" connection (e.g. an in-vm connection) is <literal>-1</literal>. A
             value of <literal>-1</literal> for <literal>ConnectionTTL</literal> means the server
             will never time out the connection on the server side.</para>
         <para id="connection-ttl.override">If you do not wish clients to be able to specify their own connection TTL, you can
@@ -156,8 +158,10 @@ java.lang.Exception
             deploying JMS connection factory instances direct into JNDI on the server side, you can
             specify it in the <literal>hornetq-jms.xml </literal> configuration file, using the
             parameter <literal>client-failure-check-period</literal>.</para>
-        <para>The default value for client failure check period is <literal>30000</literal>ms, i.e.
-            30 seconds. A value of <literal>-1</literal> means the client will never fail the
+        <para>The default value for client failure check period on an "unreliable" connection (e.g.
+            a Netty connection) is <literal>30000</literal>ms, i.e. 30 seconds. The default value
+            for client failure check period on a "reliable" connection (e.g. an in-vm connection)
+            is <literal>-1</literal>. A value of <literal>-1</literal> means the client will never fail the
             connection on the client side if no data is received from the server. Typically this is
             much lower than connection TTL to allow clients to reconnect in case of transitory
             failure.</para>

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/HornetQClient.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/HornetQClient.java
@@ -32,9 +32,13 @@ public final class HornetQClient
 
    public static final long DEFAULT_CLIENT_FAILURE_CHECK_PERIOD = HornetQDefaultConfiguration.getDefaultClientFailureCheckPeriod();
 
+   public static final long DEFAULT_CLIENT_FAILURE_CHECK_PERIOD_INVM = -1;
+
    // 1 minute - this should be higher than ping period
 
    public static final long DEFAULT_CONNECTION_TTL = HornetQDefaultConfiguration.getDefaultConnectionTtl();
+
+   public static final long DEFAULT_CONNECTION_TTL_INVM = -1;
 
    // Any message beyond this size is considered a large message (to be sent in chunks)
 

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -40,6 +40,7 @@ import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.api.core.client.ClientSession;
 import org.hornetq.api.core.client.FailoverEventListener;
 import org.hornetq.api.core.client.FailoverEventType;
+import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.api.core.client.SessionFailureListener;
 import org.hornetq.core.client.HornetQClientLogger;
@@ -216,9 +217,19 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
       this.callFailoverTimeout = callFailoverTimeout;
 
-      this.clientFailureCheckPeriod = clientFailureCheckPeriod;
-
-      this.connectionTTL = connectionTTL;
+      // HORNETQ-1314 - if this in an in-vm connection then disable connection monitoring
+      if (connectorFactory.isReliable() &&
+         clientFailureCheckPeriod == HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD &&
+         connectionTTL == HornetQClient.DEFAULT_CONNECTION_TTL)
+      {
+         this.clientFailureCheckPeriod = HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD_INVM;
+         this.connectionTTL = HornetQClient.DEFAULT_CONNECTION_TTL_INVM;
+      }
+      else
+      {
+         this.clientFailureCheckPeriod = clientFailureCheckPeriod;
+         this.connectionTTL = connectionTTL;
+      }
 
       this.retryInterval = retryInterval;
 
@@ -1396,25 +1407,26 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
             channel0.setHandler(new Channel0Handler(connection));
 
-            if (clientFailureCheckPeriod != -1)
+            if (pingerFuture == null)
             {
-               if (pingerFuture == null)
-               {
-                  pingRunnable = new PingRunnable();
+               pingRunnable = new PingRunnable();
 
+               if (clientFailureCheckPeriod != -1)
+               {
                   pingerFuture = scheduledThreadPool.scheduleWithFixedDelay(new ActualScheduledPinger(pingRunnable),
                                                                             0,
                                                                             clientFailureCheckPeriod,
                                                                             TimeUnit.MILLISECONDS);
-                  // To make sure the first ping will be sent
-                  pingRunnable.send();
                }
-               // send a ping every time we create a new remoting connection
-               // to set up its TTL on the server side
-               else
-               {
-                  pingRunnable.run();
-               }
+
+               // To make sure the first ping will be sent
+               pingRunnable.send();
+            }
+            // send a ping every time we create a new remoting connection
+            // to set up its TTL on the server side
+            else
+            {
+               pingRunnable.run();
             }
 
             if (serverLocator.getTopology() != null)

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnectorFactory.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnectorFactory.java
@@ -44,4 +44,9 @@ public class NettyConnectorFactory implements ConnectorFactory
       return TransportConstants.ALLOWABLE_CONNECTOR_KEYS;
    }
 
+   @Override
+   public boolean isReliable()
+   {
+      return false;
+   }
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/ConnectorFactory.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/ConnectorFactory.java
@@ -52,4 +52,12 @@ public interface ConnectorFactory
     * @return the allowable properties.
     */
    Set<String> getAllowableProperties();
+
+   /**
+    * Indicates if connectors from this factory are reliable or not. If a connector is reliable then connection
+    * monitoring (i.e. pings/pongs) will be disabled.
+    *
+    * @return whether or not connectors from this factory are reliable
+    */
+   boolean isReliable();
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMConnectorFactory.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/invm/InVMConnectorFactory.java
@@ -54,4 +54,9 @@ public class InVMConnectorFactory implements ConnectorFactory
       return TransportConstants.ALLOWABLE_CONNECTOR_KEYS;
    }
 
+   @Override
+   public boolean isReliable()
+   {
+      return true;
+   }
 }

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/ResourceAdapterTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/ra/ResourceAdapterTest.java
@@ -25,8 +25,8 @@ import org.hornetq.api.core.client.ClientSessionFactory;
 import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.api.jms.HornetQJMSClient;
-import org.hornetq.core.remoting.impl.invm.InVMConnector;
-import org.hornetq.core.remoting.impl.netty.NettyConnector;
+import org.hornetq.core.remoting.impl.invm.InVMConnectorFactory;
+import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.jms.client.HornetQConnectionFactory;
 import org.hornetq.jms.client.HornetQDestination;
@@ -61,7 +61,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testDefaultConnectionFactory() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       HornetQConnectionFactory factory = ra.getDefaultHornetQConnectionFactory();
       Assert.assertEquals(factory.getCallTimeout(), HornetQClient.DEFAULT_CALL_TIMEOUT);
       Assert.assertEquals(factory.getClientFailureCheckPeriod(), HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD);
@@ -95,7 +95,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void test2DefaultConnectionFactorySame() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       HornetQConnectionFactory factory = ra.getDefaultHornetQConnectionFactory();
       HornetQConnectionFactory factory2 = ra.getDefaultHornetQConnectionFactory();
       Assert.assertEquals(factory, factory2);
@@ -105,7 +105,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testCreateConnectionFactoryNoOverrides() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       HornetQConnectionFactory factory = ra.createHornetQConnectionFactory(new ConnectionFactoryProperties());
       Assert.assertEquals(factory.getCallTimeout(), HornetQClient.DEFAULT_CALL_TIMEOUT);
       Assert.assertEquals(factory.getClientFailureCheckPeriod(), HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD);
@@ -139,7 +139,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testDefaultConnectionFactoryOverrides() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       ra.setAutoGroup(!HornetQClient.DEFAULT_AUTO_GROUP);
       ra.setBlockOnAcknowledge(!HornetQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE);
       ra.setBlockOnNonDurableSend(!HornetQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND);
@@ -195,7 +195,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testCreateConnectionFactoryOverrides() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       ConnectionFactoryProperties connectionFactoryProperties = new ConnectionFactoryProperties();
       connectionFactoryProperties.setAutoGroup(!HornetQClient.DEFAULT_AUTO_GROUP);
       connectionFactoryProperties.setBlockOnAcknowledge(!HornetQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE);
@@ -252,10 +252,10 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testCreateConnectionFactoryOverrideConnector() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       ConnectionFactoryProperties connectionFactoryProperties = new ConnectionFactoryProperties();
       ArrayList<String> value = new ArrayList<String>();
-      value.add(NettyConnector.class.getName());
+      value.add(NettyConnectorFactory.class.getName());
       connectionFactoryProperties.setParsedConnectorClassNames(value);
       HornetQConnectionFactory factory = ra.createHornetQConnectionFactory(connectionFactoryProperties);
       HornetQConnectionFactory defaultFactory = ra.getDefaultHornetQConnectionFactory();
@@ -266,7 +266,7 @@ public class ResourceAdapterTest extends ServiceTestBase
    public void testCreateConnectionFactoryOverrideDiscovery() throws Exception
    {
       HornetQResourceAdapter ra = new HornetQResourceAdapter();
-      ra.setConnectorClassName(InVMConnector.class.getName());
+      ra.setConnectorClassName(InVMConnectorFactory.class.getName());
       ConnectionFactoryProperties connectionFactoryProperties = new ConnectionFactoryProperties();
       connectionFactoryProperties.setDiscoveryAddress("myhost");
       connectionFactoryProperties.setDiscoveryPort(5678);


### PR DESCRIPTION
Note: the behavior of the pinger has been changed here as well.  A single ping is _always_ sent no matter what so that the server will set the connection-ttl even when the client-failure-check-period is -1.
