### PR TITLE
Add missing checkstyle throws indentation setting

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -69,6 +69,7 @@
       <module name="Indentation">
          <property name="basicOffset" value="3"/>
          <property name="caseIndent" value="3"/>
+         <property name="throwsIndent" value="3"/>
       </module>
    </module>
 </module>


### PR DESCRIPTION
Without this I see quite a few "method/ctor def throws at indentation level X not at correct indentation, Y" errors in Eclipse, seemingly for all throws statements that are placed on a new line.
