### PR TITLE
HORNETQ-910 - Honor given max rate in createConsumer from max rate <= 0 session

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -1995,7 +1995,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                                                browseOnly,
                                                                clientWindowSize,
                                                                ackBatchSize,
-                                                               consumerMaxRate > 0 ? new TokenBucketLimiterImpl(maxRate,
+                                                               maxRate > 0 ? new TokenBucketLimiterImpl(maxRate,
                                                                                                                 false)
                                                                   : null,
                                                                executor,


### PR DESCRIPTION
By the way, internalCreateProducer has similar code but it adds the TockenBucketLimiterImpl if maxRate != -1 whereas internalCreateConsumer does it if maxRate > 0; I assume these two should be synced, maybe using the latter approach (not done in this PR).
