### PR TITLE
Javadoc 1.8 error fixes

### DIFF
--- a/hornetq-commons/src/main/java/org/hornetq/api/core/SimpleString.java
+++ b/hornetq-commons/src/main/java/org/hornetq/api/core/SimpleString.java
@@ -22,7 +22,7 @@ import org.hornetq.utils.DataConstants;
 /**
  * A simple String class that can store all characters, and stores as simple {@code byte[]}, this
  * minimises expensive copying between String objects.
- * <p/>
+ * <p>
  * This object is used heavily throughout HornetQ for performance reasons.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
@@ -45,7 +45,7 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
 
    /**
     * Returns a SimpleString constructed from the {@code string} parameter.
-    * <p/>
+    * <p>
     * If {@code string} is {@code null}, the return value will be {@code null} too.
     *
     * @param string String used to instantiate a SimpleString.

--- a/hornetq-commons/src/main/java/org/hornetq/utils/Base64.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/Base64.java
@@ -18,22 +18,18 @@ import java.nio.charset.StandardCharsets;
 /**
  * <p>Encodes and decodes to and from Base64 notation.</p>
  * <p>Homepage: <a href="http://iharder.net/base64">http://iharder.net/base64</a>.</p>
- * <p/>
  * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
  * several pieces of information to the encoder. In the "higher level" methods such as
  * encodeBytes( bytes, options ) the options parameter can be used to indicate such
  * things as first gzipping the bytes before encoding them, not inserting linefeeds
  * (though that breaks strict Base64 compatibility), and encoding using the URL-safe
  * and Ordered dialects.</p>
- * <p/>
  * <p>The constants defined in Base64 can be OR-ed together to combine options, so you
  * might make a call like this:</p>
- * <p/>
+ * <p>
  * <code>String encoded = Base64.encodeBytes( mybytes, Base64.GZIP | Base64.DONT_BREAK_LINES );</code>
- * <p/>
+ * </p>
  * <p>to compress the data before encoding it and then making the output have no newline characters.</p>
- * <p/>
- * <p/>
  * <p>
  * Change Log:
  * </p>
@@ -42,7 +38,7 @@ import java.nio.charset.StandardCharsets;
  * Base64.InputStream class to encode and decode on the fly which uses
  * less memory than encoding/decoding an entire file into memory before writing.</li>
  * <li>v2.2.1 - Fixed bug using URL_SAFE and ORDERED encodings. Fixed bug
- * when using very small files (~< 40 bytes).</li>
+ * when using very small files (~&lt; 40 bytes).</li>
  * <li>v2.2 - Added some helper methods for encoding/decoding directly from
  * one file to the next. Also added a main() method to support command line
  * encoding/decoding from one file to the next. Also added these Base64 dialects:
@@ -58,7 +54,6 @@ import java.nio.charset.StandardCharsets;
  * Special thanks to Jim Kellerman at <a href="http://www.powerset.com/">http://www.powerset.com/</a>
  * for contributing the new Base64 dialects.
  * </li>
- * <p/>
  * <li>v2.1 - Cleaned up javadoc comments and unused variables and methods. Added
  * some convenience methods for reading and writing to and from files.</li>
  * <li>v2.0.2 - Now specifies UTF-8 encoding in places where the code fails on systems
@@ -86,7 +81,6 @@ import java.nio.charset.StandardCharsets;
  * <li>v1.3.4 - Fixed when "improperly padded stream" error was thrown at the wrong time.</li>
  * <li>v1.3.3 - Fixed I/O streams which were totally messed up.</li>
  * </ul>
- * <p/>
  * <p>
  * I am placing this code in the Public Domain. Do with it as you will.
  * This software comes with no guarantees or warranties but with
@@ -1038,15 +1032,15 @@ public class Base64
     * version of that serialized object. If the object
     * cannot be serialized or there is another error,
     * the method will return <tt>null</tt>.
-    * <p/>
+    * <p>
     * Valid options:<pre>
     *   GZIP: gzip-compresses object before encoding it.
     *   DONT_BREAK_LINES: don't break lines at 76 characters
     *     <i>Note: Technically, this makes your encoding non-compliant.</i>
     * </pre>
-    * <p/>
+    * <p>
     * Example: <code>encodeObject( myObj, Base64.GZIP )</code> or
-    * <p/>
+    * <p>
     * Example: <code>encodeObject( myObj, Base64.GZIP | Base64.DONT_BREAK_LINES )</code>
     *
     * @param serializableObject The object to encode
@@ -1142,15 +1136,15 @@ public class Base64
 
    /**
     * Encodes a byte array into Base64 notation.
-    * <p/>
+    * <p>
     * Valid options:<pre>
     *   GZIP: gzip-compresses object before encoding it.
     *   DONT_BREAK_LINES: don't break lines at 76 characters
     *     <i>Note: Technically, this makes your encoding non-compliant.</i>
     * </pre>
-    * <p/>
+    * <p>
     * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
-    * <p/>
+    * <p>
     * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code>
     *
     * @param source  The data to convert
@@ -1180,15 +1174,15 @@ public class Base64
 
    /**
     * Encodes a byte array into Base64 notation.
-    * <p/>
+    * <p>
     * Valid options:<pre>
     *   GZIP: gzip-compresses object before encoding it.
     *   DONT_BREAK_LINES: don't break lines at 76 characters
     *     <i>Note: Technically, this makes your encoding non-compliant.</i>
     * </pre>
-    * <p/>
+    * <p>
     * Example: <code>encodeBytes( myData, Base64.GZIP )</code> or
-    * <p/>
+    * <p>
     * Example: <code>encodeBytes( myData, Base64.GZIP | Base64.DONT_BREAK_LINES )</code>
     *
     * @param source  The data to convert
@@ -1935,14 +1929,14 @@ public class Base64
       /**
        * Constructs a {@link Base64.InputStream} in
        * either ENCODE or DECODE mode.
-       * <p/>
+       * <p>
        * Valid options:<pre>
        *   ENCODE or DECODE: Encode or Decode as data is read.
        *   DONT_BREAK_LINES: don't break lines at 76 characters
        *     (only meaningful when encoding)
        *     <i>Note: Technically, this makes your encoding non-compliant.</i>
        * </pre>
-       * <p/>
+       * <p>
        * Example: <code>new Base64.InputStream( in, Base64.DECODE )</code>
        *
        * @param in      the <tt>java.io.InputStream</tt> from which to read data.
@@ -2189,14 +2183,14 @@ public class Base64
       /**
        * Constructs a {@link Base64.OutputStream} in
        * either ENCODE or DECODE mode.
-       * <p/>
+       * <p>
        * Valid options:<pre>
        *   ENCODE or DECODE: Encode or Decode as data is read.
        *   DONT_BREAK_LINES: don't break lines at 76 characters
        *     (only meaningful when encoding)
        *     <i>Note: Technically, this makes your encoding non-compliant.</i>
        * </pre>
-       * <p/>
+       * <p>
        * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>
        *
        * @param out     the <tt>java.io.OutputStream</tt> to which data will be written.

--- a/hornetq-commons/src/main/java/org/hornetq/utils/ClassloadingUtil.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/ClassloadingUtil.java
@@ -17,7 +17,7 @@ import java.net.URL;
 /**
  * This class will be used to perform generic class-loader operations,
  * such as load a class first using TCCL, and then the classLoader used by HornetQ (ClassloadingUtil.getClass().getClassLoader()).
- * <p/>
+ * <p>
  * Is't required to use a Security Block on any calls to this class.
  *
  * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>

--- a/hornetq-commons/src/main/java/org/hornetq/utils/PasswordMaskingUtil.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/PasswordMaskingUtil.java
@@ -23,7 +23,7 @@ import org.hornetq.api.core.HornetQExceptionType;
 /**
  * A PasswordMarkingUtil
  *
- * @author <mailto:hgao@redhat.com">Howard Gao</a>
+ * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>
  *
  *
  */

--- a/hornetq-commons/src/main/java/org/hornetq/utils/TypedProperties.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/TypedProperties.java
@@ -36,10 +36,10 @@ import static org.hornetq.utils.DataConstants.STRING;
 
 /**
  * Property Value Conversion.
- * <p/>
- * This implementation follows section 3.5.4 of the <i>Java Message Service<i> specification
+ * <p>
+ * This implementation follows section 3.5.4 of the <i>Java Message Service</i> specification
  * (Version 1.1 April 12, 2002).
- * <p/>
+ * <p>
  * TODO - should have typed property getters and do conversions herein
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>

--- a/hornetq-commons/src/main/java/org/hornetq/utils/UUID.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/UUID.java
@@ -21,17 +21,17 @@ package org.hornetq.utils;
  * world). UUIDs are usually generated via UUIDGenerator (or in case of 'Null
  * UUID', 16 zero bytes, via static method getNullUUID()), or received from
  * external systems.
- * <p/>
+ * <p>
  * By default class caches the string presentations of UUIDs so that description
  * is only created the first time it's needed. For memory stingy applications
  * this caching can be turned off (note though that if uuid.toString() is never
  * called, desc is never calculated so only loss is the space allocated for the
  * desc pointer... which can of course be commented out to save memory).
- * <p/>
+ * <p>
  * Similarly, hash code is calculated when it's needed for the first time, and
  * from thereon that value is just returned. This means that using UUIDs as keys
  * should be reasonably efficient.
- * <p/>
+ * <p>
  * UUIDs can be compared for equality, serialized, cloned and even sorted.
  * Equality is a simple bit-wise comparison. Ordering (for sorting) is done by
  * first ordering based on type (in the order of numeric values of types),

--- a/hornetq-commons/src/main/java/org/hornetq/utils/UUIDTimer.java
+++ b/hornetq-commons/src/main/java/org/hornetq/utils/UUIDTimer.java
@@ -47,7 +47,7 @@ import java.util.Random;
  * system, file-based locking is used. This works between multiple JVMs and Jug
  * instances.
  * </ul>
- * <p/>
+ * <p>
  * Some additional assumptions about calculating the timestamp:
  * <ul>
  * <li>System.currentTimeMillis() is assumed to give time offset in UTC, or at
@@ -59,7 +59,7 @@ import java.util.Random;
  * of Gregorian calendar is assumed to be correct (which seems to be the case
  * when testing with Java calendars).
  * </ul>
- * <p/>
+ * <p>
  * Note about synchronization: this class is assumed to always be called from a
  * synchronized context (caller locks on either this object, or a similar timer
  * lock), and so has no method synchronization.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/BroadcastEndpoint.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/BroadcastEndpoint.java
@@ -16,14 +16,16 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * BroadcastEndpint is used in BroadcastGroups and DiscoveryGroups for topology updates.
- * <p/>
+ * <p>
  * A BroadcastEndpoint can perform one of the two following tasks:
+ * <ul>
  * <li>when being used in BroadcastGroups, it broadcasts connector informations</li>
  * <li>when being used in DiscoveryGroups, it receives broadcasts</li>
- * <p/>
+ * </ul>
+ * <p>
  * The two tasks are mutual exclusive, meaning a BroadcastEndpoint can either be a broadcaster
  * or a receiver, but not both.
- * <p/>
+ * <p>
  * It is an abstraction of various concrete broadcasting mechanisms. Different implementations
  * of this interface may use different broadcasting techniques like UDP multicasting or
  * JGroups channels.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/DiscoveryGroupConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/DiscoveryGroupConfiguration.java
@@ -22,11 +22,11 @@ import org.hornetq.utils.UUIDGenerator;
 /**
  * This file represents how we are using Discovery.
  * <p>
- * The discovery configuration could either use plain UDP, or JGroups.<br/>
+ * The discovery configuration could either use plain UDP, or JGroups.<br>
  * If using UDP, all the UDP properties will be filled and the jgroups properties will be
- * {@code null}.<br/>
+ * {@code null}.<br>
  * If using JGroups, all the UDP properties will be -1 or {@code null} and the jgroups properties
- * will be filled.<br/>
+ * will be filled.<br>
  * If by any reason, both properties are filled, the JGroups takes precedence. That means, if
  * {@code jgroupsFile != null} then the Grouping method used will be JGroups.
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/DiscoveryGroupConfigurationCompatibilityHelper.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/DiscoveryGroupConfigurationCompatibilityHelper.java
@@ -20,8 +20,8 @@ package org.hornetq.api.core;
  * UDP attributes in order to form a version 2.2 DiscoveryGroupConfiguration
  * in time of serialization.
  *
- * @see org.hornetq.api.core.DiscoveryGroupConfiguration.readObject(ObjectInputStream)
- * @see org.hornetq.api.core.DiscoveryGroupConfiguration.writeObject(ObjectOutputStream)
+ * @see DiscoveryGroupConfiguration#readObject(java.io.ObjectInputStream)
+ * @see DiscoveryGroupConfiguration#writeObject(java.io.ObjectOutputStream)
  *
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
  *         12/13/12

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/Interceptor.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/Interceptor.java
@@ -17,9 +17,9 @@ import org.hornetq.spi.core.protocol.RemotingConnection;
 
 /**
  * This is class is a simple way to intercepting calls on HornetQ client and servers.
- * <p/>
+ * <p>
  * To add an interceptor to HornetQ server, you have to modify the server configuration file
- * {@literal hornetq-configuration.xml}. <br/>
+ * {@literal hornetq-configuration.xml}.<br>
  * To add it to a client, use {@link ServerLocator#addIncomingInterceptor(Interceptor)}
  *
  * @author clebert.suconic@jboss.com

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/JGroupsBroadcastGroupConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/JGroupsBroadcastGroupConfiguration.java
@@ -29,15 +29,15 @@ import org.jgroups.ReceiverAdapter;
  * The configuration for creating broadcasting/discovery groups using JGroups channels
  * There are two ways to constructing a JGroups channel (JChannel):
  * <ol>
- * <li> by passing in a JGroups configuration file</li>
+ * <li> by passing in a JGroups configuration file<br>
  * The file must exists in the hornetq classpath. HornetQ creates a JChannel with the
  * configuration file and use it for broadcasting and discovery. In standalone server
- * mode HornetQ uses this way for constructing JChannels.
- * <li> by passing in a JChannel instance </li>
+ * mode HornetQ uses this way for constructing JChannels.</li>
+ * <li> by passing in a JChannel instance<br>
  * This is useful when HornetQ needs to get a JChannel from a running JGroups service as in the
- * case of AS7 integration.
+ * case of AS7 integration.</li>
  * </ol>
- * <p/>
+ * <p>
  * Note only one JChannel is needed in a VM. To avoid the channel being prematurely disconnected
  * by any party, a wrapper class is used.
  *

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/Message.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/Message.java
@@ -20,16 +20,14 @@ import org.hornetq.utils.UUID;
 
 /**
  * A Message is a routable instance that has a payload.
- * <p/>
+ * <p>
  * The payload (the "body") is opaque to the messaging system. A Message also has a fixed set of
  * headers (required by the messaging system) and properties (defined by the users) that can be used
  * by the messaging system to route the message (e.g. to ensure it matches a queue filter).
- * <p/>
  * <h2>Message Properties</h2>
- * <p/>
+ * <p>
  * Message can contain properties specified by the users. It is possible to convert from some types
  * to other types as specified by the following table:
- * <p/>
  * <pre>
  * |        | boolean byte short int long float double String byte[]
  * |----------------------------------------------------------------
@@ -44,8 +42,7 @@ import org.hornetq.utils.UUID;
  * |byte[]  |                                                   X
  * |-----------------------------------------------------------------
  * </pre>
- * <p/>
- * <br>
+ * <p>
  * If conversion is not allowed (for example calling {@code getFloatProperty} on a property set a
  * {@code boolean}), a {@link PropertyConversionException} will be thrown.
  *
@@ -123,7 +120,7 @@ public interface Message
 
    /**
     * Returns this message type.
-    * <p/>
+    * <p>
     * See fields {@literal *_TYPE} for possible values.
     */
    byte getType();
@@ -174,14 +171,14 @@ public interface Message
 
    /**
     * Returns the message priority.
-    * <p/>
+    * <p>
     * Values range from 0 (less priority) to 9 (more priority) inclusive.
     */
    byte getPriority();
 
    /**
     * Sets the message priority.
-    * <p/>
+    * <p>
     * Value must be between 0 and 9 inclusive.
     *
     * @param priority the new message priority

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/TransportConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/TransportConfiguration.java
@@ -27,7 +27,6 @@ import org.hornetq.utils.UUIDGenerator;
  * Typically the constructors take the class name and parameters for needed to create the
  * connection. These will be different dependent on which connector is being used, i.e. Netty or
  * InVM etc. For example:
- * <p/>
  *
  * <pre>
  * HashMap&lt;String, Object&gt; map = new HashMap&lt;String, Object&gt;();
@@ -281,7 +280,7 @@ public class TransportConfiguration implements Serializable
 
    /**
     * Encodes this TransportConfiguration into a buffer.
-    * <p/>
+    * <p>
     * Note that this is only used internally HornetQ.
     *
     * @param buffer the buffer to encode into
@@ -331,7 +330,7 @@ public class TransportConfiguration implements Serializable
 
    /**
     * Decodes this TransportConfiguration from a buffer.
-    * <p/>
+    * <p>
     * Note this is only used internally by HornetQ
     *
     * @param buffer the buffer to decode from

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/UDPBroadcastGroupConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/UDPBroadcastGroupConfiguration.java
@@ -28,7 +28,7 @@ import org.hornetq.core.client.HornetQClientLogger;
 
 /**
  * The configuration used to determine how the server will broadcast members.
- * <p/>
+ * <p>
  * This is analogous to {@link org.hornetq.api.core.DiscoveryGroupConfiguration}
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a> Created 18 Nov 2008 08:44:30

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSession.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSession.java
@@ -168,7 +168,7 @@ public interface ClientSession extends XAResource, AutoCloseable
 
    /**
     * Creates a transient queue. A queue that will exist as long as there are consumers. When the last consumer is closed the queue will be deleted
-    * <p/>
+    * <p>
     * Notice: you will get an exception if the address or the filter doesn't match to an already existent queue
     *
     * @param address   the queue will be bound to this address
@@ -180,7 +180,7 @@ public interface ClientSession extends XAResource, AutoCloseable
 
    /**
     * Creates a transient queue. A queue that will exist as long as there are consumers. When the last consumer is closed the queue will be deleted
-    * <p/>
+    * <p>
     * Notice: you will get an exception if the address or the filter doesn't match to an already existent queue
     *
     * @param address   the queue will be bound to this address
@@ -337,12 +337,12 @@ public interface ClientSession extends XAResource, AutoCloseable
 
    /**
     * Creates a ClientConsumer to consume or browse messages from the queue with the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *
@@ -355,12 +355,12 @@ public interface ClientSession extends XAResource, AutoCloseable
 
    /**
     * Creates a ClientConsumer to consume or browse messages from the queue with the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *
@@ -374,12 +374,12 @@ public interface ClientSession extends XAResource, AutoCloseable
    /**
     * Creates a ClientConsumer to consume or browse messages matching the filter from the queue with
     * the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *
@@ -394,12 +394,12 @@ public interface ClientSession extends XAResource, AutoCloseable
    /**
     * Creates a ClientConsumer to consume or browse messages matching the filter from the queue with
     * the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *
@@ -414,12 +414,12 @@ public interface ClientSession extends XAResource, AutoCloseable
    /**
     * Creates a ClientConsumer to consume or browse messages matching the filter from the queue with
     * the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *
@@ -440,12 +440,12 @@ public interface ClientSession extends XAResource, AutoCloseable
    /**
     * Creates a ClientConsumer to consume or browse messages matching the filter from the queue with
     * the given name.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>true</code>, the ClientConsumer will receive the messages
     * from the queue but they will not be consumed (the messages will remain in the queue). Note
     * that paged messages will not be in the queue, and will therefore not be visible if
     * {@code browseOnly} is {@code true}.
-    * <p/>
+    * <p>
     * If <code>browseOnly</code> is <code>false</code>, the ClientConsumer will behave like consume
     * the messages from the queue and the messages will effectively be removed from the queue.
     *

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSessionFactory.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSessionFactory.java
@@ -36,7 +36,7 @@ public interface ClientSessionFactory extends AutoCloseable
 
    /**
     * Creates a <em>transacted</em> session.
-    * <p/>
+    * <p>
     * It is up to the client to commit when sending and acknowledging messages.
     *
     * @return a transacted ClientSession
@@ -91,7 +91,7 @@ public interface ClientSessionFactory extends AutoCloseable
 
    /**
     * Creates a session.
-    * <p/>
+    * <p>
     * It is possible to <em>pre-acknowledge messages on the server</em> so that the client can avoid additional network trip
     * to the server to acknowledge messages. While this increase performance, this does not guarantee delivery (as messages
     * can be lost after being pre-acknowledged on the server). Use with caution if your application design permits it.
@@ -107,7 +107,7 @@ public interface ClientSessionFactory extends AutoCloseable
 
    /**
     * Creates an <em>authenticated</em> session.
-    * <p/>
+    * <p>
     * It is possible to <em>pre-acknowledge messages on the server</em> so that the client can avoid additional network trip
     * to the server to acknowledge messages. While this increase performance, this does not guarantee delivery (as messages
     * can be lost after being pre-acknowledged on the server). Use with caution if your application design permits it.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
@@ -19,11 +19,11 @@ import org.hornetq.core.client.impl.Topology;
 
 /**
  * The serverLocator locates a server, but beyond that it locates a server based on a list.
- * <p/>
+ * <p>
  * If you are using straight TCP on the configuration, and if you configure your serverLocator to be
  * HA, the locator will always get an updated list of members to the server, the server will send
  * the updated list to the client.
- * <p/>
+ * <p>
  * If you use UDP or JGroups (exclusively JGropus or UDP), the initial discovery is done by the
  * grouping finder, after the initial connection is made the server will always send updates to the
  * client. But the listeners will listen for updates on grouping.
@@ -44,7 +44,7 @@ public interface ServerLocator extends AutoCloseable
     * This method will disable any checks when a GarbageCollection happens
     * leaving connections open. The JMS Layer will make specific usage of this
     * method, since the ConnectionFactory.finalize should release this.
-    * <p/>
+    * <p>
     * Warning: You may leave resources unattended if you call this method and
     * don't take care of cleaning the resources yourself.
     */
@@ -99,7 +99,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the period used to check if a client has failed to receive pings from the server.
-    * <p/>
+    * <p>
     * Period is in milliseconds, default value is
     * {@link HornetQClient#DEFAULT_CLIENT_FAILURE_CHECK_PERIOD}.
     *
@@ -110,7 +110,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Sets the period (in milliseconds) used to check if a client has failed to receive pings from
     * the server.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable) or greater than 0.
     *
     * @param clientFailureCheckPeriod the period to check failure
@@ -120,9 +120,9 @@ public interface ServerLocator extends AutoCloseable
    /**
     * When <code>true</code>, consumers created through this factory will create temporary files to
     * cache large messages.
-    * <p/>
+    * <p>
     * There is 1 temporary file created for each large message.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_CACHE_LARGE_MESSAGE_CLIENT}.
     *
     * @return <code>true</code> if consumers created through this factory will cache large messages
@@ -139,7 +139,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the connection <em>time-to-live</em>.
-    * <p/>
+    * <p>
     * This TTL determines how long the server will keep a connection alive in the absence of any
     * data arriving from the client. Value is in milliseconds, default value is
     * {@link HornetQClient#DEFAULT_CONNECTION_TTL}.
@@ -150,7 +150,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets this factory's connections <em>time-to-live</em>.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable) or greater or equals to 0.
     *
     * @param connectionTTL period in milliseconds
@@ -159,7 +159,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the blocking calls timeout.
-    * <p/>
+    * <p>
     * If client's blocking calls to the server take more than this timeout, the call will throw a
     * {@link HornetQException} with the code {@link HornetQExceptionType#CONNECTION_TIMEDOUT}. Value
     * is in milliseconds, default value is {@link HornetQClient#DEFAULT_CALL_TIMEOUT}.
@@ -170,7 +170,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the blocking call timeout.
-    * <p/>
+    * <p>
     * Value must be greater or equals to 0
     *
     * @param callTimeout blocking call timeout in milliseconds
@@ -181,7 +181,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Returns the blocking calls failover timeout when the client is awaiting failover,
     * this is over and above the normal call timeout.
-    * <p/>
+    * <p>
     * If client is in the process of failing over when a blocking call is called then the client will wait this long before
     * actually trying the send.
     *
@@ -191,9 +191,9 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the blocking call failover timeout.
-    * <p/>
+    * <p>
     * When the client is awaiting failover, this is over and above the normal call timeout.
-    * <p/>
+    * <p>
     * Value must be greater or equals to -1, -1 means forever
     *
     * @param callFailoverTimeout blocking call timeout in milliseconds
@@ -202,7 +202,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the large message size threshold.
-    * <p/>
+    * <p>
     * Messages whose size is if greater than this value will be handled as <em>large messages</em>.
     * Value is in bytes, default value is {@link HornetQClient#DEFAULT_MIN_LARGE_MESSAGE_SIZE}.
     *
@@ -212,7 +212,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the large message size threshold.
-    * <p/>
+    * <p>
     * Value must be greater than 0.
     *
     * @param minLargeMessageSize large message size threshold in bytes
@@ -221,7 +221,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the window size for flow control of the consumers created through this factory.
-    * <p/>
+    * <p>
     * Value is in bytes, default value is {@link HornetQClient#DEFAULT_CONSUMER_WINDOW_SIZE}.
     *
     * @return the window size used for consumer flow control
@@ -230,7 +230,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the window size for flow control of the consumers created through this factory.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable flow control), 0 (to not buffer any messages) or greater than 0
     * (to set the maximum size of the buffer)
     *
@@ -240,9 +240,9 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum rate of message consumption for consumers created through this factory.
-    * <p/>
+    * <p>
     * This value controls the rate at which a consumer can consume messages. A consumer will never consume messages at a rate faster than the rate specified.
-    * <p/>
+    * <p>
     * Value is -1 (to disable) or a positive integer corresponding to the maximum desired message consumption rate specified in units of messages per second.
     * Default value is {@link HornetQClient#DEFAULT_CONSUMER_MAX_RATE}.
     *
@@ -252,7 +252,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum rate of message consumption for consumers created through this factory.
-    * <p/>
+    * <p>
     * Value must -1 (to disable) or a positive integer corresponding to the maximum desired message consumption rate specified in units of messages per second.
     *
     * @param consumerMaxRate maximum rate of message consumption (in messages per seconds)
@@ -261,7 +261,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the size for the confirmation window of clients using this factory.
-    * <p/>
+    * <p>
     * Value is in bytes or -1 (to disable the window). Default value is
     * {@link HornetQClient#DEFAULT_CONFIRMATION_WINDOW_SIZE}.
     *
@@ -271,7 +271,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the size for the confirmation window buffer of clients using this factory.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable the window) or greater than 0.
     *
     * @param confirmationWindowSize size of the confirmation window (in bytes)
@@ -280,7 +280,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the window size for flow control of the producers created through this factory.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable flow control) or greater than 0 to determine the maximum amount of bytes at any give time (to prevent overloading the connection).
     * Default value is {@link HornetQClient#DEFAULT_PRODUCER_WINDOW_SIZE}.
     *
@@ -290,7 +290,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the window size for flow control of the producers created through this factory.
-    * <p/>
+    * <p>
     * Value must be -1 (to disable flow control) or greater than 0.
     *
     * @param producerWindowSize window size (in bytest) for flow control of the producers created through this factory.
@@ -299,9 +299,9 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum rate of message production for producers created through this factory.
-    * <p/>
+    * <p>
     * This value controls the rate at which a producer can produce messages. A producer will never produce messages at a rate faster than the rate specified.
-    * <p/>
+    * <p>
     * Value is -1 (to disable) or a positive integer corresponding to the maximum desired message production rate specified in units of messages per second.
     * Default value is {@link HornetQClient#DEFAULT_PRODUCER_MAX_RATE}.
     *
@@ -311,7 +311,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum rate of message production for producers created through this factory.
-    * <p/>
+    * <p>
     * Value must -1 (to disable) or a positive integer corresponding to the maximum desired message production rate specified in units of messages per second.
     *
     * @param producerMaxRate maximum rate of message production (in messages per seconds)
@@ -321,7 +321,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Returns whether consumers created through this factory will block while
     * sending message acknowledgments or do it asynchronously.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_BLOCK_ON_ACKNOWLEDGE}.
     *
     * @return whether consumers will block while sending message
@@ -344,7 +344,7 @@ public interface ServerLocator extends AutoCloseable
     * <br>
     * If the session is configured to send durable message asynchronously, the client can set a SendAcknowledgementHandler on the ClientSession
     * to be notified once the message has been handled by the server.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_BLOCK_ON_DURABLE_SEND}.
     *
     * @return whether producers will block while sending persistent messages or do it asynchronously
@@ -363,7 +363,7 @@ public interface ServerLocator extends AutoCloseable
     * <br>
     * If the session is configured to send non-durable message asynchronously, the client can set a SendAcknowledgementHandler on the ClientSession
     * to be notified once the message has been handled by the server.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_BLOCK_ON_NON_DURABLE_SEND}.
     *
     * @return whether producers will block while sending non-durable messages or do it asynchronously
@@ -380,7 +380,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Returns whether producers created through this factory will automatically
     * assign a group ID to the messages they sent.
-    * <p/>
+    * <p>
     * if <code>true</code>, a random unique group ID is created and set on each message for the property
     * {@link org.hornetq.api.core.Message#HDR_GROUP_ID}.
     * Default value is {@link HornetQClient#DEFAULT_AUTO_GROUP}.
@@ -399,7 +399,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the group ID that will be eventually set on each message for the property {@link org.hornetq.api.core.Message#HDR_GROUP_ID}.
-    * <p/>
+    * <p>
     * Default value is is {@code null} and no group ID will be set on the messages.
     *
     * @return the group ID that will be eventually set on each message
@@ -415,7 +415,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns whether messages will pre-acknowledged on the server before they are sent to the consumers or not.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_PRE_ACKNOWLEDGE}
     */
    boolean isPreAcknowledge();
@@ -432,7 +432,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the acknowledgments batch size.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_ACK_BATCH_SIZE}.
     *
     * @return the acknowledgments batch size
@@ -441,7 +441,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the acknowledgments batch size.
-    * <p/>
+    * <p>
     * Value must be equal or greater than 0.
     *
     * @param ackBatchSize acknowledgments batch size
@@ -464,7 +464,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Returns whether this factory will use global thread pools (shared among all the factories in the same JVM)
     * or its own pools.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_USE_GLOBAL_POOLS}.
     *
     * @return <code>true</code> if this factory uses global thread pools, <code>false</code> else
@@ -481,7 +481,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum size of the scheduled thread pool.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE}.
     *
     * @return the maximum size of the scheduled thread pool.
@@ -490,7 +490,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum size of the scheduled thread pool.
-    * <p/>
+    * <p>
     * This setting is relevant only if this factory does not use global pools.
     * Value must be greater than 0.
     *
@@ -500,7 +500,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum size of the thread pool.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_THREAD_POOL_MAX_SIZE}.
     *
     * @return the maximum size of the thread pool.
@@ -509,7 +509,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum size of the thread pool.
-    * <p/>
+    * <p>
     * This setting is relevant only if this factory does not use global pools.
     * Value must be -1 (for unlimited thread pool) or greater than 0.
     *
@@ -519,7 +519,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the time to retry connections created by this factory after failure.
-    * <p/>
+    * <p>
     * Value is in milliseconds, default is {@link HornetQClient#DEFAULT_RETRY_INTERVAL}.
     *
     * @return the time to retry connections created by this factory after failure
@@ -528,7 +528,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the time to retry connections created by this factory after failure.
-    * <p/>
+    * <p>
     * Value must be greater than 0.
     *
     * @param retryInterval time (in milliseconds) to retry connections created by this factory after failure
@@ -537,7 +537,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the multiplier to apply to successive retry intervals.
-    * <p/>
+    * <p>
     * Default value is  {@link HornetQClient#DEFAULT_RETRY_INTERVAL_MULTIPLIER}.
     *
     * @return the multiplier to apply to successive retry intervals
@@ -546,7 +546,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the multiplier to apply to successive retry intervals.
-    * <p/>
+    * <p>
     * Value must be positive.
     *
     * @param retryIntervalMultiplier multiplier to apply to successive retry intervals
@@ -555,7 +555,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum retry interval (in the case a retry interval multiplier has been specified).
-    * <p/>
+    * <p>
     * Value is in milliseconds, default value is  {@link HornetQClient#DEFAULT_MAX_RETRY_INTERVAL}.
     *
     * @return the maximum retry interval
@@ -564,7 +564,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum retry interval.
-    * <p/>
+    * <p>
     * Value must be greater than 0.
     *
     * @param maxRetryInterval maximum retry interval to apply in the case a retry interval multiplier
@@ -574,7 +574,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the maximum number of attempts to retry connection in case of failure.
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_RECONNECT_ATTEMPTS}.
     *
     * @return the maximum number of attempts to retry connection in case of failure.
@@ -583,7 +583,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum number of attempts to retry connection in case of failure.
-    * <p/>
+    * <p>
     * Value must be -1 (to retry infinitely), 0 (to never retry connection) or greater than 0.
     *
     * @param reconnectAttempts maximum number of attempts to retry connection in case of failure
@@ -592,7 +592,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the maximum number of attempts to establish an initial connection.
-    * <p/>
+    * <p>
     * Value must be -1 (to retry infinitely), 0 (to never retry connection) or greater than 0.
     *
     * @param reconnectAttempts maximum number of attempts for the initial connection
@@ -607,7 +607,7 @@ public interface ServerLocator extends AutoCloseable
    /**
     * Returns true if the client will automatically attempt to connect to the backup server if the initial
     * connection to the live server fails
-    * <p/>
+    * <p>
     * Default value is {@link HornetQClient#DEFAULT_FAILOVER_ON_INITIAL_CONNECTION}.
     */
    boolean isFailoverOnInitialConnection();
@@ -621,7 +621,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the class name of the connection load balancing policy.
-    * <p/>
+    * <p>
     * Default value is "org.hornetq.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy".
     *
     * @return the class name of the connection load balancing policy
@@ -630,7 +630,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the class name of the connection load balancing policy.
-    * <p/>
+    * <p>
     * Value must be the name of a class implementing {@link ConnectionLoadBalancingPolicy}.
     *
     * @param loadBalancingPolicyClassName class name of the connection load balancing policy
@@ -639,7 +639,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Returns the initial size of messages created through this factory.
-    * <p/>
+    * <p>
     * Value is in bytes, default value is  {@link HornetQClient#DEFAULT_INITIAL_MESSAGE_PACKET_SIZE}.
     *
     * @return the initial size of messages created through this factory
@@ -648,7 +648,7 @@ public interface ServerLocator extends AutoCloseable
 
    /**
     * Sets the initial size of messages created through this factory.
-    * <p/>
+    * <p>
     * Value must be greater than 0.
     *
     * @param size initial size of messages created through this factory.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/TopologyMember.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/TopologyMember.java
@@ -22,7 +22,7 @@ import org.hornetq.spi.core.protocol.RemotingConnection;
 
 /**
  * A member of the topology.
- * <p/>
+ * <p>
  * Each TopologyMember represents a single server and possibly any backup server that may take over
  * its duties (using the nodeId of the original server).
  */
@@ -31,10 +31,10 @@ public interface TopologyMember extends Serializable
    /**
     * Returns the {@code backup-group-name} of the live server and backup servers associated with
     * Topology entry.
-    * <p/>
+    * <p>
     * This is a server configuration value. A (remote) backup will only work with live servers that
     * have a matching {@code backup-group-name}.
-    * <p/>
+    * <p>
     * This value does not apply to "shared-storage" backup and live pairs.
     *
     * @return the {@code backup-group-name}

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/management/NotificationType.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/management/NotificationType.java
@@ -18,7 +18,7 @@ package org.hornetq.api.core.management;
  * These notifications can be received through:
  * <ul>
  * <li>JMX' MBeans subscriptions
- * <li>Core messages to a notification address (default value is {@value hornetq.notifications})
+ * <li>Core messages to a notification address (default value is {@code hornetq.notifications})
  * <li>JMS messages
  * </ul>
  * @see the HornetQ user manual section on "Management Notifications"

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/management/Parameter.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/management/Parameter.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
 
 /**
  * Info for a MBean Operation Parameter.
- * <b>
+ * <p>
  * This annotation is used only for methods which can be invoked
  * through a GUI.
  *

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
@@ -124,7 +124,7 @@ public interface QueueControl
    /**
     * Lists all the messages being deliver per consumer.
     * <br>
-    * The Map's key is a toString representation for the consumer. Each consumer will then return a Map<String,Object>[] same way is returned by {@link #listScheduledMessages()}
+    * The Map's key is a toString representation for the consumer. Each consumer will then return a {@code Map<String,Object>[]} same way is returned by {@link #listScheduledMessages()}
     */
    @Operation(desc = "List all messages being delivered per consumer")
    Map<String, Map<String, Object>[]> listDeliveringMessages() throws Exception;

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
@@ -50,7 +50,6 @@ public interface ClientConsumerInternal extends ClientConsumer
 
    /**
     * To be called by things like MDBs during shutdown of the server
-    * @param interrupt
     * @throws HornetQException
     */
    void interruptHandlers() throws HornetQException;

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -511,7 +511,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    /**
     * Note, we DO NOT currently support direct consumers (i.e. consumers where delivery occurs on
     * the remoting thread).
-    * <p/>
+    * <p>
     * Direct consumers have issues with blocking and failover. E.g. if direct then inside
     * MessageHandler call a blocking method like rollback or acknowledge (blocking) This can block
     * until failover completes, which disallows the thread to be used to deliver any responses to

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
@@ -37,7 +37,7 @@ import org.hornetq.utils.ConcurrentHashSet;
 
 /**
  * A DelegatingSession
- * <p/>
+ * <p>
  * We wrap the real session, so we can add a finalizer on this and close the session
  * on GC if it has not already been closed
  *

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/LargeMessageControllerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/LargeMessageControllerImpl.java
@@ -321,7 +321,7 @@ public class LargeMessageControllerImpl implements LargeMessageController
 
    /**
     * @param timeWait Milliseconds to Wait. 0 means forever
-    * @throws Exception
+    * @throws HornetQException
     */
    public synchronized boolean waitCompletion(final long timeWait) throws HornetQException
    {

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorInternal.java
@@ -56,7 +56,7 @@ public interface ServerLocatorInternal extends ServerLocator
 
    /**
     * Like {@link #connect()} but it does not log warnings if it fails to connect.
-    * @throws Exception
+    * @throws HornetQException
     */
    ClientSessionFactoryInternal connectNoWarnings() throws HornetQException;
 

--- a/hornetq-core-client/src/main/java/org/hornetq/core/cluster/DiscoveryGroup.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/cluster/DiscoveryGroup.java
@@ -35,16 +35,16 @@ import org.hornetq.utils.TypedProperties;
 
 /**
  * This class is used to search for members on the cluster through the opaque interface {@link BroadcastEndpoint}.
- * <p/>
+ * <p>
  * There are two current implementations, and that's probably all we will ever need.
- * <p/>
+ * <p>
  * We will probably keep both interfaces for a while as UDP is a simple solution requiring no extra dependencies which
  * is suitable for users looking for embedded solutions.
+ * <p>
+ * Created 17 Nov 2008 13:21:45
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  * @author Clebert Suconic
- *         <p/>
- *         Created 17 Nov 2008 13:21:45
  */
 public final class DiscoveryGroup implements HornetQComponent
 {

--- a/hornetq-core-client/src/main/java/org/hornetq/core/message/impl/MessageImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/message/impl/MessageImpl.java
@@ -32,7 +32,7 @@ import org.hornetq.utils.UUID;
 
 /**
  * A concrete implementation of a message
- * <p/>
+ * <p>
  * All messages handled by HornetQ core are of this type
  *
  * @author <a href="mailto:ovidiu@feodorov.com">Ovidiu Feodorov</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/Channel.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/Channel.java
@@ -18,12 +18,12 @@ import org.hornetq.api.core.HornetQException;
 
 /**
  * A channel is a way of interleaving data meant for different endpoints over the same {@link org.hornetq.core.protocol.core.CoreRemotingConnection}.
- * <p/>
+ * <p>
  * Any packet sent will have its channel id set to the specific channel sending so it can be routed to its correct channel
  * when received by the {@link org.hornetq.core.protocol.core.CoreRemotingConnection}. see {@link org.hornetq.core.protocol.core.Packet#setChannelID(long)}.
- * <p/>
+ * <p>
  * Each Channel should will forward any packets received to its {@link org.hornetq.core.protocol.core.ChannelHandler}.
- * <p/>
+ * <p>
  * A Channel *does not* support concurrent access by more than one thread!
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
@@ -89,14 +89,14 @@ public interface Channel
 
    /**
     * Closes this channel.
-    * <p/>
+    * <p>
     * once closed no packets can be sent.
     */
    void close();
 
    /**
     * Transfers the connection used by this channel to the one specified.
-    * <p/>
+    * <p>
     * All new packets will be sent via this connection.
     * @param newConnection the new connection
     */
@@ -104,7 +104,7 @@ public interface Channel
 
    /**
     * resends any packets that have not received confirmations yet.
-    * <p/>
+    * <p>
     * Typically called after a connection has been transferred.
     *
     * @param lastConfirmedCommandID the last confirmed packet
@@ -120,7 +120,7 @@ public interface Channel
 
    /**
     * locks the channel.
-    * <p/>
+    * <p>
     * While locked no packets can be sent or received
     */
    void lock();
@@ -168,7 +168,7 @@ public interface Channel
 
    /**
     * Called by {@link org.hornetq.core.protocol.core.CoreRemotingConnection} when a packet is received.
-    * <p/>
+    * <p>
     * This method should then call its {@link org.hornetq.core.protocol.core.ChannelHandler} after appropriate processing of
     * the packet
     *

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/CommandConfirmationHandler.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/CommandConfirmationHandler.java
@@ -15,10 +15,10 @@ package org.hornetq.core.protocol.core;
 
 /**
  * A CommandConfirmationHandler is used by the channel to confirm confirmations of packets.
+ * <p>
+ * Created 9 Feb 2009 12:39:11
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
- *         <p/>
- *         Created 9 Feb 2009 12:39:11
  */
 public interface CommandConfirmationHandler
 {

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/Packet.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/Packet.java
@@ -46,7 +46,7 @@ public interface Packet
 
    /**
     * returns the type of the packet.
-    * <p/>
+    * <p>
     * This is needed when decoding the packet
     *
     * @return the packet type

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionAddMetaDataMessage.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionAddMetaDataMessage.java
@@ -20,7 +20,7 @@ import org.hornetq.core.protocol.core.impl.PacketImpl;
  *
  * Packet deprecated: It exists only to support old formats
  *
- * @author <a href="mailto:hgao@redhat.com>Howard Gao</a>
+ * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>
  *
  *
  */

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionAddMetaDataMessageV2.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionAddMetaDataMessageV2.java
@@ -20,7 +20,7 @@ import org.hornetq.core.protocol.core.impl.PacketImpl;
  *
  * This packet replaces {@link SessionAddMetaDataMessage}
  *
- * @author Clebert Suconic</a>
+ * @author Clebert Suconic
  *
  *
  */

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionCommitMessage.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionCommitMessage.java
@@ -21,9 +21,6 @@ import org.hornetq.core.protocol.core.impl.PacketImpl;
 public class SessionCommitMessage extends PacketImpl
 {
 
-   /**
-    * @param type
-    */
    public SessionCommitMessage()
    {
       super(SESS_COMMIT);

--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionSendContinuationMessage.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/SessionSendContinuationMessage.java
@@ -17,7 +17,7 @@ import org.hornetq.api.core.client.SendAcknowledgementHandler;
 import org.hornetq.core.message.impl.MessageInternal;
 
 /**
- * A SessionSendContinuationMessage<br/>
+ * A SessionSendContinuationMessage<br>
  * Created Dec 4, 2008 12:25:14 PM
  *
  * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/CloseListener.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/CloseListener.java
@@ -14,7 +14,7 @@ package org.hornetq.core.remoting;
 
 /**
  * CloseListeners can be registered with a {@link org.hornetq.spi.core.protocol.RemotingConnection} to get notified when the connection is closed.
- * <p/>
+ * <p>
  * {@link org.hornetq.spi.core.protocol.RemotingConnection#addCloseListener(CloseListener)}
  *
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
@@ -85,7 +85,7 @@ public class TransportConstants
    public static final String NETTY_VERSION;
 
    /**
-    * Disable Nagle's algorithm.<br/>
+    * Disable Nagle's algorithm.<br>
     * Valid for (client) Sockets.
     *
     * @see <a

--- a/hornetq-core-client/src/main/java/org/hornetq/core/server/management/NotificationService.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/server/management/NotificationService.java
@@ -26,7 +26,6 @@ public interface NotificationService
     * <li><code>ManagementHelper.HDR_NOTIFICATION_MESSAGE</code> - a message contextual to the notification (SimpleString)</li>
     * <li><code>ManagementHelper.HDR_NOTIFICATION_TIMESTAMP</code> - the timestamp when the notification occurred (long)</li>
     * </ul>
-    * <p/>
     * in addition to the properties defined in <code>props</code>
     *
     * @see ManagementHelper

--- a/hornetq-core-client/src/main/java/org/hornetq/core/transaction/impl/XidImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/transaction/impl/XidImpl.java
@@ -23,7 +23,7 @@ import org.hornetq.utils.Base64;
  *
  * Xid implementation
  *
- * @author <a href="mailto:adrian@jboss.org>Adrian Brock</a>
+ * @author <a href="mailto:adrian@jboss.org">Adrian Brock</a>
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  * @author <a href="mailto:juha@jboss.org">Juha Lindfors</a>
  *

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/protocol/RemotingConnection.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/protocol/RemotingConnection.java
@@ -49,7 +49,7 @@ public interface RemotingConnection extends BufferHandler
 
    /**
     * add a failure listener.
-    * <p/>
+    * <p>
     * The listener will be called in the event of connection failure.
     *
     * @param listener the listener
@@ -66,7 +66,7 @@ public interface RemotingConnection extends BufferHandler
 
    /**
     * add a CloseListener.
-    * <p/>
+    * <p>
     * This will be called in the event of the connection being closed.
     *
     * @param listener the listener to add
@@ -98,7 +98,7 @@ public interface RemotingConnection extends BufferHandler
 
    /**
     * set the failure listeners.
-    * <p/>
+    * <p>
     * These will be called in the event of the connection being closed. Any previosuly added listeners will be removed.
     *
     * @param listeners the listeners to add.

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/BufferDecoder.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/BufferDecoder.java
@@ -25,7 +25,7 @@ public interface BufferDecoder
 {
    /**
     * called by the remoting system prior to {@link org.hornetq.spi.core.remoting.BufferHandler#bufferReceived(Object, org.hornetq.api.core.HornetQBuffer)}.
-    * <p/>
+    * <p>
     * The implementation should return true if there is enough data in the buffer to decode. otherwise false.
     *                  * @param buffer the buffer
     * @return true id the buffer can be decoded..

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/BufferHandler.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/BufferHandler.java
@@ -16,7 +16,7 @@ import org.hornetq.api.core.HornetQBuffer;
 
 /**
  * A BufferHandler that will handle buffers received by an acceptor.
- * <p/>
+ * <p>
  * The Buffer Handler will decode the buffer and take the appropriate action, typically forwarding to the correct channel.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/Connector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/Connector.java
@@ -40,7 +40,7 @@ public interface Connector
 
    /**
     * Create and return a connection from this connector.
-    * <p/>
+    * <p>
     * This method must NOT throw an exception if it fails to create the connection
     * (e.g. network is not available), in this case it MUST return null
     *

--- a/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/ConnectorFactory.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/spi/core/remoting/ConnectorFactory.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A ConnectorFactory is used by the client for creating connectors.
- * <p/>
+ * <p>
  * A Connector is used to connect to an {@link org.hornetq.spi.core.remoting.Acceptor}.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
@@ -46,7 +46,7 @@ public interface ConnectorFactory
 
    /**
     * Returns the allowable properties for this connector.
-    * <p/>
+    * <p>
     * This will differ between different connector implementations.
     *
     * @return the allowable properties.

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/BufferHelper.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/BufferHelper.java
@@ -18,7 +18,7 @@ import org.hornetq.api.core.SimpleString;
 /**
  * Helper methods to read and write from HornetQBuffer.
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  *
  *
  */

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/InflaterWriter.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/InflaterWriter.java
@@ -19,11 +19,11 @@ import java.util.zip.Inflater;
 
 /**
  * A InflaterWriter
- * <p/>
+ * <p>
  * This class takes an OutputStream. Compressed bytes
  * can directly be written into this class. The class will
  * decompress the bytes and write them to the output stream.
- * <p/>
+ * <p>
  * Not for concurrent use.
  *
  * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/PriorityLinkedList.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/PriorityLinkedList.java
@@ -17,7 +17,7 @@ package org.hornetq.utils;
  * A type of linked list which maintains items according to a priority
  * and allows adding and removing of elements at both ends, and peeking
  *
- * @author <a href="mailto:tim.fox@jboss.com>Tim Fox</a>
+ * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  * @version <tt>$Revision: 1174 $</tt>
  */
 public interface PriorityLinkedList<T>

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/PriorityLinkedListImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/PriorityLinkedListImpl.java
@@ -17,11 +17,11 @@ import java.util.NoSuchElementException;
 
 /**
  * A priority linked list implementation
- * <p/>
+ * <p>
  * It implements this by maintaining an individual LinkedBlockingDeque for each priority level.
  *
- * @author <a href="mailto:tim.fox@jboss.com>Tim Fox</a>
- * @author <a href="mailto:jmesnil@redhat.com>Jeff Mesnil</a>
+ * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
+ * @author <a href="mailto:jmesnil@redhat.com">Jeff Mesnil</a>
  * @version <tt>$Revision: 1174 $</tt>
  */
 public class PriorityLinkedListImpl<T> implements PriorityLinkedList<T>

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/SizeFormatterUtil.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/SizeFormatterUtil.java
@@ -15,7 +15,7 @@ package org.hornetq.utils;
 /**
  * A SizeFormatterUtil
  *
- * @author <a href="mailto:jmesnil@gmail.com>Jeff Mesnil</a>
+ * @author <a href="mailto:jmesnil@gmail.com">Jeff Mesnil</a>
  *
  *
  */

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/XMLUtil.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/XMLUtil.java
@@ -170,10 +170,10 @@ public final class XMLUtil
    /**
     * This metod is here because Node.getTextContent() is not available in JDK 1.4 and I would like
     * to have an uniform access to this functionality.
-    * <p/>
+    * <p>
     * Note: if the content is another element or set of elements, it returns a string representation
     * of the hierarchy.
-    * <p/>
+    * <p>
     * TODO implementation of this method is a hack. Implement it properly.
     */
    public static String getTextContent(final Node n)

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/json/JSONArray.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/json/JSONArray.java
@@ -195,10 +195,7 @@ public class JSONArray
    /**
     * Construct a JSONArray from a collection of beans.
     * The collection should have Java Beans.
-    *
-    * @throws JSONException If not an array.
     */
-
    public JSONArray(final Collection collection, final boolean includeSuperClass)
    {
       myArrayList = collection == null ? new ArrayList<Object>() : new ArrayList<Object>(collection.size());

--- a/hornetq-core-client/src/main/java/org/hornetq/utils/json/JSONObject.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/utils/json/JSONObject.java
@@ -87,7 +87,7 @@ import java.util.TreeSet;
  * and if they do not contain leading or trailing spaces, and if they do not contain any of these
  * characters: <code>{ } [ ] / \ : , = ; #</code> and if they do not look like numbers and if they
  * are not the reserved words <code>true</code>, <code>false</code>, or {@code null}.</li>
- * <li>Keys can be followed by <code>=</code> or <code>=></code> as well as by <code>:</code>.</li>
+ * <li>Keys can be followed by <code>=</code> or <code>=&gt;</code> as well as by <code>:</code>.</li>
  * <li>Values can be followed by <code>;</code> <small>(semicolon)</small> as well as by
  * <code>,</code> <small>(comma)</small>.</li>
  * <li>Numbers may have the <code>0-</code> <small>(octal)</small> or <code>0x-</code>
@@ -270,7 +270,7 @@ public class JSONObject
    /**
     * Construct a JSONObject from a Map.
     *
-    * Note: Use this constructor when the map contains <key,bean>.
+    * Note: Use this constructor when the map contains &lt;key,bean&gt;.
     *
     * @param map - A map with Key-Bean data.
     * @param includeSuperClass - Tell whether to include the super class properties.
@@ -1219,7 +1219,7 @@ public class JSONObject
 
    /**
     * Produce a string in double quotes with backslash sequences in all the
-    * right places. A backslash will be inserted within </, allowing JSON
+    * right places. A backslash will be inserted within &lt;/, allowing JSON
     * text to be delivered in HTML. In JSON text, a string cannot contain a
     * control character or an unescaped quote or backslash.
     * @param string A String

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQBytesMessage.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQBytesMessage.java
@@ -26,7 +26,6 @@ import org.hornetq.core.message.impl.MessageImpl;
 
 /**
  * HornetQ implementation of a JMS {@link BytesMessage}.
- * <p/>
  *
  * @author Norbert Lataille (Norbert.Lataille@m4x.org)
  * @author <a href="mailto:adrian@jboss.org">Adrian Brock</a>

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnection.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnection.java
@@ -49,7 +49,7 @@ import org.hornetq.utils.VersionLoader;
 
 /**
  * HornetQ implementation of a JMS Connection.
- * <p/>
+ * <p>
  * The flat implementation of {@link TopicConnection} and {@link QueueConnection} is per design,
  * following the common usage of these as one flat API in JMS 1.1.
  *

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQObjectMessage.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQObjectMessage.java
@@ -30,7 +30,7 @@ import org.hornetq.api.core.client.ClientSession;
  * HornetQ implementation of a JMS ObjectMessage.
  * <br>
  * Don't used ObjectMessage if you want good performance!
- * <p/>
+ * <p>
  * Serialization is slooooow!
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQSession.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQSession.java
@@ -497,7 +497,7 @@ public class HornetQSession implements QueueSession, TopicSession
     * Validate different filters in different possible scenarios
     *
     * @param topic
-    * @param sharedSubscriptionName
+    * @param name
     * @param messageSelector
     * @return
     * @throws JMSException

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQTopic.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQTopic.java
@@ -52,7 +52,6 @@ public class HornetQTopic extends HornetQDestination implements Topic
     * @param address
     * @param name
     * @param temporary
-    * @param queue
     * @param session
     */
    protected HornetQTopic(String address, String name, boolean temporary, HornetQSession session)

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQXAConnectionFactory.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQXAConnectionFactory.java
@@ -22,7 +22,7 @@ import org.hornetq.api.jms.JMSFactoryType;
 
 /**
  * A class that represents a XAConnectionFactory.
- * <p/>
+ * <p>
  * We consider the XAConnectionFactory to be the most complete possible option. It can be casted to any other connection factory since it is fully functional
  *
  * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQXAQueueConnectionFactory.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQXAQueueConnectionFactory.java
@@ -47,8 +47,7 @@ public class HornetQXAQueueConnectionFactory extends HornetQConnectionFactory im
 
    /**
     * @param ha
-    * @param discoveryAddress
-    * @param discoveryPort
+    * @param groupConfiguration
     */
    public HornetQXAQueueConnectionFactory(final boolean ha, final DiscoveryGroupConfiguration groupConfiguration)
    {

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/ThreadAwareContext.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/ThreadAwareContext.java
@@ -95,8 +95,8 @@ public class ThreadAwareContext
    }
 
    /**
-    * Asserts a {@link javax.jms.CompletionListener} is not calling from its own {@Link javax.jms.Connection} or from
-    * a {@Link javax.jms.MessageProducer} .
+    * Asserts a {@link javax.jms.CompletionListener} is not calling from its own {@link javax.jms.Connection} or from
+    * a {@link javax.jms.MessageProducer} .
     * <p>
     * Note that the code must work without any need for further synchronization, as there is the
     * requirement that only one CompletionListener be called at a time. In other words,
@@ -132,7 +132,7 @@ public class ThreadAwareContext
 
    /**
     * Asserts a {@link javax.jms.MessageListener} is not calling from its own {@link javax.jms.Connection} or
-    *  {@Link javax.jms.MessageConsumer}.
+    *  {@link javax.jms.MessageConsumer}.
     * <p>
     * Note that the code must work without any need for further synchronization, as there is the
     * requirement that only one MessageListener be called at a time. In other words,

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/JMSStorageManager.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/JMSStorageManager.java
@@ -23,7 +23,7 @@ import org.hornetq.jms.persistence.config.PersistedType;
 /**
  * A JMSPersistence
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  *
  *
  */

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedConnectionFactory.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedConnectionFactory.java
@@ -20,7 +20,7 @@ import org.hornetq.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
 /**
  * A PersistedConnectionFactory
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  *
  *
  */

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedDestination.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedDestination.java
@@ -21,7 +21,7 @@ import org.hornetq.utils.DataConstants;
 /**
  * A PersistedDestination
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  */
 public class PersistedDestination implements EncodingSupport
 {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedJNDI.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedJNDI.java
@@ -23,7 +23,7 @@ import org.hornetq.utils.DataConstants;
 /**
  * A PersistedJNDI
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  */
 public class PersistedJNDI implements EncodingSupport
 {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedType.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/config/PersistedType.java
@@ -15,7 +15,7 @@ package org.hornetq.jms.persistence.config;
 /**
  * A PersistedType
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  */
 public enum PersistedType
 {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
@@ -41,7 +41,7 @@ import org.hornetq.utils.IDGenerator;
 /**
  * A JournalJMSStorageManagerImpl
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  */
 public final class JMSJournalStorageManagerImpl implements JMSStorageManager
 {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/nullpm/NullJMSStorageManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/persistence/impl/nullpm/NullJMSStorageManagerImpl.java
@@ -24,7 +24,7 @@ import org.hornetq.jms.persistence.config.PersistedType;
 /**
  * A NullJMSStorageManagerImpl
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  *
  *
  */

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/JMSServerConfigParser.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/JMSServerConfigParser.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Node;
 /**
  * A JMSServerConfigParser
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  *
  *
  */

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
@@ -25,9 +25,9 @@ import org.hornetq.utils.DataConstants;
 
 /**
  * This class contains the configuration properties of a connection factory.
- * <p/>
+ * <p>
  * It is also persisted on the journal at the time of management is used to created a connection factory and set to store.
- * <p/>
+ * <p>
  * Every property on this class has to be also set through encoders through EncodingSupport implementation at this class.
  *
  * @author <a href="mailto:jmesnil@redhat.com">Jeff Mesnil</a>

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/embedded/EmbeddedJMS.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/embedded/EmbeddedJMS.java
@@ -24,7 +24,7 @@ import org.hornetq.spi.core.naming.BindingRegistry;
 /**
  * Simple bootstrap class that parses hornetq config files (server and jms and security) and starts
  * a HornetQServer instance and populates it with configured JMS endpoints.
- * <p/>
+ * <p>
  * JMS Endpoints are registered with a simple MapBindingRegistry.  If you want to use a different registry
  * you must set the registry property of this class or call the setRegistry() method if you want to use JNDI
  *

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerConfigParserImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerConfigParserImpl.java
@@ -44,7 +44,7 @@ import org.w3c.dom.NodeList;
 /**
  * JMS Configuration File Parser.
  *
- * @author <mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
+ * @author <a href="mailto:clebert.suconic@jboss.org">Clebert Suconic</a>
  */
 public final class JMSServerConfigParserImpl implements JMSServerConfigParser
 {

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -87,10 +87,10 @@ import org.hornetq.utils.json.JSONObject;
 /**
  * A Deployer used to create and add to JNDI queues, topics and connection
  * factories. Typically this would only be used in an app server env.
- * <p/>
- * JMS Connection Factories & Destinations can be configured either
+ * <p>
+ * JMS Connection Factories and Destinations can be configured either
  * using configuration files or using a JMSConfiguration object.
- * <p/>
+ * <p>
  * If configuration files are used, JMS resources are redeployed if the
  * files content is changed.
  * If a JMSConfiguration object is used, the JMS resources can not be
@@ -446,7 +446,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
     * Notice that this component has a {@link #startCalled} boolean to control its internal
     * life-cycle, but its {@link #isStarted()} returns the value of {@code server.isStarted()} and
     * not the value of {@link #startCalled}.
-    * <p/>
+    * <p>
     * This method and {@code server.start()} are interdependent in the following way:
     * <ol>
     * <li>{@link JMSServerManagerImpl#start()} is called, it sets {@code start_called=true}, and

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQRecoveryRegistry.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQRecoveryRegistry.java
@@ -25,9 +25,7 @@ import org.jboss.tm.XAResourceRecovery;
 
 /**
  * <p>This class is used by the Resource Adapter to register RecoveryDiscovery, which is based on the {@link XARecoveryConfig}</p>
- * <p/>
  * <p>Each outbound or inboud connection will pass the configuration here through by calling the method {@link HornetQRecoveryRegistry#register(XARecoveryConfig)}</p>
- * <p/>
  * <p>Later the {@link RecoveryDiscovery} will call {@link HornetQRecoveryRegistry#nodeUp(String, Pair, String, String)}
  * so we will keep a track of nodes on the cluster
  * or nodes where this server is connected to. </p>
@@ -164,7 +162,7 @@ public class HornetQRecoveryRegistry implements XAResourceRecovery
 
    /**
     * @param nodeID
-    * @param pair
+    * @param networkConfiguration
     * @param username
     * @param password
     */

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQXAResourceRecovery.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQXAResourceRecovery.java
@@ -22,29 +22,26 @@ import org.hornetq.jms.server.HornetQJMSServerLogger;
 
 /**
  * A XAResourceRecovery instance that can be used to recover any JMS provider.
- * <p/>
+ * <p>
  * In reality only recover, rollback and commit will be called but we still need to be implement all
  * methods just in case.
- * <p/>
+ * <p>
  * To enable this add the following to the jbossts-properties file
- * <p/>
  * <pre>
- * <property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ1"
- *                 value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.invm.InVMConnectorFactory"/>
+ * &lt;property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ1"
+ *                 value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.invm.InVMConnectorFactory"/&gt;
  * </pre>
- * <p/>
+ * <p>
  * you'll need something like this if the HornetQ Server is remote
- * <p/>
  * <pre>
- *      <property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ2"
- *                  value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost,port=5445"/>-->
+ *      &lt;property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ2"
+ *                  value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost,port=5445"/&gt;
  * </pre>
- * <p/>
- * you'll need something like this if the HornetQ Server is remote and has failover configured-->
- * <p/>
+ * <p>
+ * you'll need something like this if the HornetQ Server is remote and has failover configured
  * <pre>
- *             <property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ2"
- *                       value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost,port=5445;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost2,port=5446"/>-->
+ *             &lt;property name="com.arjuna.ats.jta.recovery.XAResourceRecovery.HORNETQ2"
+ *                       value="org.hornetq.jms.server.recovery.HornetQXAResourceRecovery;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost,port=5445;org.hornetq.core.remoting.impl.netty.NettyConnectorFactory,guest,guest,host=localhost2,port=5446"/&gt;
  * </pre>
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQXAResourceWrapper.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/recovery/HornetQXAResourceWrapper.java
@@ -38,7 +38,7 @@ import org.hornetq.jms.server.HornetQJMSServerLogger;
  * to retry on failure without having to manually retry
  *
  * @author <a href="adrian@jboss.com">Adrian Brock</a>
- * @author <a href="tim.fox@jboss.com">Tim Fox/a>
+ * @author <a href="tim.fox@jboss.com">Tim Fox</a>
  * @author <a href="mailto:jmesnil@redhat.com">Jeff Mesnil</a>
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
  *


### PR DESCRIPTION
This is not exhaustive, there are still mainly "reference not found" errors for {@link...}s when subprojects refer to each others' things but it's a start.
