### PR TITLE
[HORNETQ-1329] Make it possible for an alternative security provider to ...

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -125,8 +125,10 @@ public class NettyConnector extends AbstractConnector
    public static final String JAVAX_KEYSTORE_PASSWORD_PROP_NAME = "javax.net.ssl.keyStorePassword";
    public static final String JAVAX_TRUSTSTORE_PATH_PROP_NAME = "javax.net.ssl.trustStore";
    public static final String JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME = "javax.net.ssl.trustStorePassword";
+   public static final String HORNETQ_KEYSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.keyStoreProvider";
    public static final String HORNETQ_KEYSTORE_PATH_PROP_NAME = "org.hornetq.ssl.keyStore";
    public static final String HORNETQ_KEYSTORE_PASSWORD_PROP_NAME = "org.hornetq.ssl.keyStorePassword";
+   public static final String HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.trustStoreProvider";
    public static final String HORNETQ_TRUSTSTORE_PATH_PROP_NAME = "org.hornetq.ssl.trustStore";
    public static final String HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME = "org.hornetq.ssl.trustStorePassword";
 
@@ -183,9 +185,13 @@ public class NettyConnector extends AbstractConnector
 
    private final int localPort;
 
+   private final String keyStoreProvider;
+
    private final String keyStorePath;
 
    private final String keyStorePassword;
+
+   private final String trustStoreProvider;
 
    private final String trustStorePath;
 
@@ -309,18 +315,28 @@ public class NettyConnector extends AbstractConnector
                                                      configuration);
       if (sslEnabled)
       {
+         keyStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME,
+                                                                  TransportConstants.DEFAULT_KEYSTORE_PROVIDER,
+                                                                  configuration);
+
          keyStorePath = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PATH_PROP_NAME,
                                                               TransportConstants.DEFAULT_KEYSTORE_PATH,
                                                               configuration);
+
          keyStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME,
                                                                     TransportConstants.DEFAULT_KEYSTORE_PASSWORD,
                                                                     configuration,
                                                                     HornetQDefaultConfiguration.getPropMaskPassword(),
                                                                     HornetQDefaultConfiguration.getPropMaskPassword());
 
+         trustStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME,
+                                                                    TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER,
+                                                                    configuration);
+
          trustStorePath = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,
                                                                 TransportConstants.DEFAULT_TRUSTSTORE_PATH,
                                                                 configuration);
+
          trustStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME,
                                                                       TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD,
                                                                       configuration,
@@ -337,8 +353,10 @@ public class NettyConnector extends AbstractConnector
       }
       else
       {
+         keyStoreProvider = TransportConstants.DEFAULT_KEYSTORE_PROVIDER;
          keyStorePath = TransportConstants.DEFAULT_KEYSTORE_PATH;
          keyStorePassword = TransportConstants.DEFAULT_KEYSTORE_PASSWORD;
+         trustStoreProvider = TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER;
          trustStorePath = TransportConstants.DEFAULT_TRUSTSTORE_PATH;
          trustStorePassword = TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD;
          enabledCipherSuites = TransportConstants.DEFAULT_ENABLED_CIPHER_SUITES;
@@ -453,6 +471,7 @@ public class NettyConnector extends AbstractConnector
          {
             // HORNETQ-680 - override the server-side config if client-side system properties are set
             String realKeyStorePath = keyStorePath;
+            String realKeyStoreProvider = keyStoreProvider;
             String realKeyStorePassword = keyStorePassword;
             if (System.getProperty(JAVAX_KEYSTORE_PATH_PROP_NAME) != null)
             {
@@ -463,6 +482,10 @@ public class NettyConnector extends AbstractConnector
                realKeyStorePassword = System.getProperty(JAVAX_KEYSTORE_PASSWORD_PROP_NAME);
             }
 
+            if (System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME) != null)
+            {
+               realKeyStoreProvider = System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME);
+            }
             if (System.getProperty(HORNETQ_KEYSTORE_PATH_PROP_NAME) != null)
             {
                realKeyStorePath = System.getProperty(HORNETQ_KEYSTORE_PATH_PROP_NAME);
@@ -473,6 +496,7 @@ public class NettyConnector extends AbstractConnector
             }
 
             String realTrustStorePath = trustStorePath;
+            String realTrustStoreProvider = trustStoreProvider;
             String realTrustStorePassword = trustStorePassword;
             if (System.getProperty(JAVAX_TRUSTSTORE_PATH_PROP_NAME) != null)
             {
@@ -483,6 +507,10 @@ public class NettyConnector extends AbstractConnector
                realTrustStorePassword = System.getProperty(JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME);
             }
 
+            if (System.getProperty(HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME) != null)
+            {
+               realTrustStoreProvider = System.getProperty(HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME);
+            }
             if (System.getProperty(HORNETQ_TRUSTSTORE_PATH_PROP_NAME) != null)
             {
                realTrustStorePath = System.getProperty(HORNETQ_TRUSTSTORE_PATH_PROP_NAME);
@@ -491,7 +519,7 @@ public class NettyConnector extends AbstractConnector
             {
                realTrustStorePassword = System.getProperty(HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME);
             }
-            context = SSLSupport.createContext(realKeyStorePath, realKeyStorePassword, realTrustStorePath, realTrustStorePassword);
+            context = SSLSupport.createContext(realKeyStoreProvider, realKeyStorePath, realKeyStorePassword, realTrustStoreProvider, realTrustStorePath, realTrustStorePassword);
          }
          catch (Exception e)
          {

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
@@ -66,9 +66,13 @@ public class TransportConstants
 
    public static final String LOCAL_PORT_PROP_NAME = "local-port";
 
+   public static final String KEYSTORE_PROVIDER_PROP_NAME = "key-store-provider";
+
    public static final String KEYSTORE_PATH_PROP_NAME = "key-store-path";
 
    public static final String KEYSTORE_PASSWORD_PROP_NAME = "key-store-password";
+
+   public static final String TRUSTSTORE_PROVIDER_PROP_NAME = "trust-store-provider";
 
    public static final String TRUSTSTORE_PATH_PROP_NAME = "trust-store-path";
 
@@ -130,9 +134,13 @@ public class TransportConstants
 
    public static final int DEFAULT_STOMP_PORT = 61613;
 
+   public static final String DEFAULT_KEYSTORE_PROVIDER = "JKS";
+
    public static final String DEFAULT_KEYSTORE_PATH = null;
 
    public static final String DEFAULT_KEYSTORE_PASSWORD = null;
+
+   public static final String DEFAULT_TRUSTSTORE_PROVIDER = "JKS";
 
    public static final String DEFAULT_TRUSTSTORE_PATH = null;
 
@@ -197,8 +205,10 @@ public class TransportConstants
       allowableAcceptorKeys.add(TransportConstants.PROTOCOLS_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HOST_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.PORT_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PATH_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME);
@@ -236,8 +246,10 @@ public class TransportConstants
       allowableConnectorKeys.add(TransportConstants.PORT_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.LOCAL_ADDRESS_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.LOCAL_PORT_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.KEYSTORE_PATH_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME);

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/ssl/SSLSupport.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/ssl/SSLSupport.java
@@ -47,11 +47,12 @@ public class SSLSupport
 
    // Public --------------------------------------------------------
 
-   public static SSLContext createContext(final String keystorePath, final String keystorePassword, final String trustStorePath, final String trustStorePassword) throws Exception
+   public static SSLContext createContext(final String keystoreProvider, final String keystorePath, final String keystorePassword,
+                                          final String trustStoreProvider, final String trustStorePath, final String trustStorePassword) throws Exception
    {
       SSLContext context = SSLContext.getInstance("TLS");
-      KeyManager[] keyManagers = SSLSupport.loadKeyManagers(keystorePath, keystorePassword);
-      TrustManager[] trustManagers = SSLSupport.loadTrustManager(trustStorePath, trustStorePassword);
+      KeyManager[] keyManagers = SSLSupport.loadKeyManagers(keystoreProvider, keystorePath, keystorePassword);
+      TrustManager[] trustManagers = SSLSupport.loadTrustManager(trustStoreProvider, trustStorePath, trustStorePassword);
       context.init(keyManagers, trustManagers, new SecureRandom());
       return context;
    }
@@ -86,34 +87,38 @@ public class SSLSupport
 
    // Private -------------------------------------------------------
 
-   private static TrustManager[] loadTrustManager(final String trustStorePath,
+   private static TrustManager[] loadTrustManager(final String trustStoreProvider,
+                                                  final String trustStorePath,
                                                   final String trustStorePassword) throws Exception
    {
-      if (trustStorePath == null)
+      if (trustStorePath == null && ("JKS".equals(trustStoreProvider) || trustStoreProvider == null))
       {
          return null;
       }
       else
       {
          TrustManagerFactory trustMgrFactory;
-         KeyStore trustStore = SSLSupport.loadKeystore(trustStorePath, trustStorePassword);
+         KeyStore trustStore = SSLSupport.loadKeystore(trustStoreProvider, trustStorePath, trustStorePassword);
          trustMgrFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
          trustMgrFactory.init(trustStore);
          return trustMgrFactory.getTrustManagers();
       }
    }
 
-   private static KeyStore loadKeystore(final String keystorePath, final String keystorePassword) throws Exception
+   private static KeyStore loadKeystore(final String keystoreProvider, final String keystorePath, final String keystorePassword) throws Exception
    {
-      assert keystorePath != null;
+      assert keystorePath != null || "JKS".equals(keystoreProvider) == false;
       assert keystorePassword != null;
 
-      KeyStore ks = KeyStore.getInstance("JKS");
+      KeyStore ks = KeyStore.getInstance(keystoreProvider);
       InputStream in = null;
       try
       {
-         URL keystoreURL = SSLSupport.validateStoreURL(keystorePath);
-         in = keystoreURL.openStream();
+         if ("JKS".equals(keystoreProvider))
+         {
+            URL keystoreURL = SSLSupport.validateStoreURL(keystorePath);
+            in = keystoreURL.openStream();
+         }
          ks.load(in, keystorePassword.toCharArray());
       }
       finally
@@ -132,16 +137,16 @@ public class SSLSupport
       return ks;
    }
 
-   private static KeyManager[] loadKeyManagers(final String keystorePath, final String keystorePassword) throws Exception
+   private static KeyManager[] loadKeyManagers(final String keyStoreProvider, final String keystorePath, final String keystorePassword) throws Exception
    {
-      if (keystorePath == null)
+      if (keystorePath == null && ("JKS".equals(keyStoreProvider) || keyStoreProvider == null))
       {
          return null;
       }
       else
       {
          KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-         KeyStore ks = SSLSupport.loadKeystore(keystorePath, keystorePassword);
+         KeyStore ks = SSLSupport.loadKeystore(keyStoreProvider, keystorePath, keystorePassword);
          kmf.init(ks, keystorePassword.toCharArray());
 
          return kmf.getKeyManagers();

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
@@ -14,6 +14,7 @@ package org.hornetq.core.remoting.impl.netty;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.AccessController;
@@ -46,6 +47,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.GlobalEventExecutor;
+
 import org.hornetq.api.config.HornetQDefaultConfiguration;
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.SimpleString;
@@ -116,9 +118,13 @@ public class NettyAcceptor implements Acceptor
 
    private final int port;
 
+   private final String keyStoreProvider;
+
    private final String keyStorePath;
 
    private final String keyStorePassword;
+
+   private final String trustStoreProvider;
 
    private final String trustStorePath;
 
@@ -202,17 +208,28 @@ public class NettyAcceptor implements Acceptor
                                                 configuration);
       if (sslEnabled)
       {
+         keyStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME,
+                                                                  TransportConstants.DEFAULT_KEYSTORE_PROVIDER,
+                                                                  configuration);
+
          keyStorePath = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PATH_PROP_NAME,
                                                               TransportConstants.DEFAULT_KEYSTORE_PATH,
                                                               configuration);
+
          keyStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME,
                                                                     TransportConstants.DEFAULT_KEYSTORE_PASSWORD,
                                                                     configuration,
                                                                     HornetQDefaultConfiguration.getPropMaskPassword(),
                                                                     HornetQDefaultConfiguration.getPropMaskPassword());
+
+         trustStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME,
+                                                                    TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER,
+                                                                    configuration);
+
          trustStorePath = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,
                                                                 TransportConstants.DEFAULT_TRUSTSTORE_PATH,
                                                                 configuration);
+
          trustStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME,
                                                                       TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD,
                                                                       configuration,
@@ -233,8 +250,10 @@ public class NettyAcceptor implements Acceptor
       }
       else
       {
+         keyStoreProvider = TransportConstants.DEFAULT_KEYSTORE_PROVIDER;
          keyStorePath = TransportConstants.DEFAULT_KEYSTORE_PATH;
          keyStorePassword = TransportConstants.DEFAULT_KEYSTORE_PASSWORD;
+         trustStoreProvider = TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER;
          trustStorePath = TransportConstants.DEFAULT_TRUSTSTORE_PATH;
          trustStorePassword = TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD;
          enabledCipherSuites = TransportConstants.DEFAULT_ENABLED_CIPHER_SUITES;
@@ -306,10 +325,11 @@ public class NettyAcceptor implements Acceptor
       {
          try
          {
-            if (keyStorePath == null)
+            if (keyStorePath == null && TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER.equals(keyStoreProvider))
                throw new IllegalArgumentException("If \"" + TransportConstants.SSL_ENABLED_PROP_NAME +
-                                                     "\" is true then \"" + TransportConstants.KEYSTORE_PATH_PROP_NAME + "\" must be non-null");
-            context = SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+                                                     "\" is true then \"" + TransportConstants.KEYSTORE_PATH_PROP_NAME + "\" must be non-null " +
+                                                     "unless an alternative \"" + TransportConstants.KEYSTORE_PROVIDER_PROP_NAME + "\" has been specified.");
+            context = SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
          }
          catch (Exception e)
          {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
@@ -389,7 +389,7 @@ public class CoreClientOverOneWaySSLTest extends ServiceTestBase
 
    public static String[] getEnabledCipherSuites() throws Exception
    {
-      SSLContext context = SSLSupport.createContext(SERVER_SIDE_KEYSTORE, PASSWORD, CLIENT_SIDE_TRUSTSTORE, PASSWORD);
+      SSLContext context = SSLSupport.createContext("JKS", SERVER_SIDE_KEYSTORE, PASSWORD, "JKS", CLIENT_SIDE_TRUSTSTORE, PASSWORD);
       SSLEngine engine = context.createSSLEngine();
       return engine.getEnabledCipherSuites();
    }

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
@@ -26,9 +26,14 @@ import org.junit.Test;
  */
 public class SSLSupportTest extends UnitTestCase
 {
+
+   private String keyStoreProvider;
+
    private String keyStorePath;
 
    private String keyStorePassword;
+
+   private String trustStoreProvider;
 
    private String trustStorePath;
 
@@ -50,8 +55,10 @@ public class SSLSupportTest extends UnitTestCase
    {
       super.setUp();
 
+      keyStoreProvider = "JKS";
       keyStorePath = "server-side.keystore";
       keyStorePassword = "secureexample";
+      trustStoreProvider = "JKS";
       trustStorePath = "server-side.truststore";
       trustStorePassword = keyStorePassword;
    }
@@ -59,21 +66,21 @@ public class SSLSupportTest extends UnitTestCase
    @Test
    public void testContextWithRightParameters() throws Exception
    {
-      SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    // This is valid as it will create key and trust managers with system defaults
    @Test
    public void testContextWithNullParameters() throws Exception
    {
-      SSLSupport.createContext(null, null, null, null);
+      SSLSupport.createContext(null, null, null, null, null, null);
    }
 
    @Test
    public void testContextWithKeyStorePathAsURL() throws Exception
    {
       URL url = Thread.currentThread().getContextClassLoader().getResource(keyStorePath);
-      SSLSupport.createContext(url.toString(), keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, url.toString(), keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -81,7 +88,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       URL url = Thread.currentThread().getContextClassLoader().getResource(keyStorePath);
       File file = new File(url.toURI());
-      SSLSupport.createContext(file.getAbsolutePath(), keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, file.getAbsolutePath(), keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -89,7 +96,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext("not a keystore", keyStorePassword, trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, "not a keystore", keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -102,7 +109,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(null, keyStorePassword, trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, null, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
       }
       catch (Exception e)
       {
@@ -121,7 +128,7 @@ public class SSLSupportTest extends UnitTestCase
          return;
       }
 
-      SSLSupport.createContext("src/test/resources/server-side.keystore", keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, "src/test/resources/server-side.keystore", keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -129,7 +136,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, "bad password", trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, "bad password", trustStoreProvider, trustStorePath, trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -142,7 +149,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, keyStorePassword, "not a trust store", trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, "not a trust store", trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -155,7 +162,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, "bad passord");
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, "bad passord");
          Assert.fail();
       }
       catch (Exception e)


### PR DESCRIPTION
...be specified for the key and trust stores used by NettyConnector and NettyAcceptor.

Amongst other things this makes it possible for a PKCS#11 provider to be specified.
