### PR TITLE
[HORNETQ-1329] Make it possible for an alternative security provider to ...

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -100,6 +100,9 @@ public class NettyConnector extends AbstractConnector
    public static final String JAVAX_TRUSTSTORE_PATH_PROP_NAME = "javax.net.ssl.trustStore";
    public static final String JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME = "javax.net.ssl.trustStorePassword";
 
+   public static final String HORNETQ_KEYSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.keyStoreProvider";
+   public static final String HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.trustStoreProvider";
+
    // Attributes ----------------------------------------------------
 
    private ClientSocketChannelFactory channelFactory;
@@ -134,9 +137,13 @@ public class NettyConnector extends AbstractConnector
 
    private final int localPort;
 
+   private final String keyStoreProvider;
+
    private final String keyStorePath;
 
    private final String keyStorePassword;
+
+   private final String trustStoreProvider;
 
    private final String trustStorePath;
 
@@ -266,18 +273,28 @@ public class NettyConnector extends AbstractConnector
                                                      configuration);
       if (sslEnabled)
       {
+         keyStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME,
+                                                                  TransportConstants.DEFAULT_KEYSTORE_PROVIDER,
+                                                                  configuration);
+
          keyStorePath = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PATH_PROP_NAME,
                                                               TransportConstants.DEFAULT_KEYSTORE_PATH,
                                                               configuration);
+
          keyStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME,
                                                                     TransportConstants.DEFAULT_KEYSTORE_PASSWORD,
                                                                     configuration,
                                                                     HornetQDefaultConfiguration.getPropMaskPassword(),
                                                                     HornetQDefaultConfiguration.getPropMaskPassword());
 
+         trustStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME,
+                                                                    TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER,
+                                                                    configuration);
+
          trustStorePath = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,
                                                                 TransportConstants.DEFAULT_TRUSTSTORE_PATH,
                                                                 configuration);
+
          trustStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME,
                                                                       TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD,
                                                                       configuration,
@@ -286,8 +303,10 @@ public class NettyConnector extends AbstractConnector
       }
       else
       {
+         keyStoreProvider = null;
          keyStorePath = null;
          keyStorePassword = null;
+         trustStoreProvider = null;
          trustStorePath = null;
          trustStorePassword = null;
       }
@@ -420,6 +439,7 @@ public class NettyConnector extends AbstractConnector
          {
             // HORNETQ-680 - override the server-side config if client-side system properties are set
             String realKeyStorePath = keyStorePath;
+            String realKeyStoreProvider = keyStoreProvider;
             String realKeyStorePassword = keyStorePassword;
             if (System.getProperty(JAVAX_KEYSTORE_PATH_PROP_NAME) != null)
             {
@@ -430,7 +450,13 @@ public class NettyConnector extends AbstractConnector
                realKeyStorePassword = System.getProperty(JAVAX_KEYSTORE_PASSWORD_PROP_NAME);
             }
 
+            if (System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME) != null)
+            {
+               realKeyStoreProvider = System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME);
+            }
+
             String realTrustStorePath = trustStorePath;
+            String realTrustStoreProvider = trustStoreProvider;
             String realTrustStorePassword = trustStorePassword;
             if (System.getProperty(JAVAX_TRUSTSTORE_PATH_PROP_NAME) != null)
             {
@@ -440,7 +466,12 @@ public class NettyConnector extends AbstractConnector
             {
                realTrustStorePassword = System.getProperty(JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME);
             }
-            context = SSLSupport.createContext(realKeyStorePath, realKeyStorePassword, realTrustStorePath, realTrustStorePassword);
+
+            if (System.getProperty(HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME) != null)
+            {
+               realTrustStoreProvider = System.getProperty(HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME);
+            }
+            context = SSLSupport.createContext(realKeyStoreProvider, realKeyStorePath, realKeyStorePassword, realTrustStoreProvider, realTrustStorePath, realTrustStorePassword);
          }
          catch (Exception e)
          {

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/TransportConstants.java
@@ -61,9 +61,13 @@ public class TransportConstants
 
    public static final String LOCAL_PORT_PROP_NAME = "local-port";
 
+   public static final String KEYSTORE_PROVIDER_PROP_NAME = "key-store-provider";
+
    public static final String KEYSTORE_PATH_PROP_NAME = "key-store-path";
 
    public static final String KEYSTORE_PASSWORD_PROP_NAME = "key-store-password";
+
+   public static final String TRUSTSTORE_PROVIDER_PROP_NAME = "trust-store-provider";
 
    public static final String TRUSTSTORE_PATH_PROP_NAME = "trust-store-path";
 
@@ -125,9 +129,13 @@ public class TransportConstants
 
    public static final int DEFAULT_STOMP_PORT = 61613;
 
+   public static final String DEFAULT_KEYSTORE_PROVIDER = "JKS";
+
    public static final String DEFAULT_KEYSTORE_PATH = null;
 
    public static final String DEFAULT_KEYSTORE_PASSWORD = null;
+
+   public static final String DEFAULT_TRUSTSTORE_PROVIDER = "JKS";
 
    public static final String DEFAULT_TRUSTSTORE_PATH = null;
 
@@ -185,8 +193,10 @@ public class TransportConstants
       allowableAcceptorKeys.add(TransportConstants.PROTOCOL_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HOST_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.PORT_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PATH_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.NEED_CLIENT_AUTH_PROP_NAME);
@@ -220,8 +230,10 @@ public class TransportConstants
       allowableConnectorKeys.add(TransportConstants.PORT_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.LOCAL_ADDRESS_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.LOCAL_PORT_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.KEYSTORE_PATH_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.TCP_NODELAY_PROPNAME);

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
@@ -15,6 +15,7 @@ package org.hornetq.core.remoting.impl.netty;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Iterator;
@@ -122,9 +123,13 @@ public class NettyAcceptor implements Acceptor
 
    private final int port;
 
+   private final String keyStoreProvider;
+
    private final String keyStorePath;
 
    private final String keyStorePassword;
+
+   private final String trustStoreProvider;
 
    private final String trustStorePath;
 
@@ -254,17 +259,28 @@ public class NettyAcceptor implements Acceptor
                                                 configuration);
       if (sslEnabled)
       {
+         keyStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME,
+                                                                  TransportConstants.DEFAULT_KEYSTORE_PROVIDER,
+                                                                  configuration);
+
          keyStorePath = ConfigurationHelper.getStringProperty(TransportConstants.KEYSTORE_PATH_PROP_NAME,
                                                               TransportConstants.DEFAULT_KEYSTORE_PATH,
                                                               configuration);
+
          keyStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME,
                                                                     TransportConstants.DEFAULT_KEYSTORE_PASSWORD,
                                                                     configuration,
                                                                     HornetQDefaultConfiguration.getPropMaskPassword(),
                                                                     HornetQDefaultConfiguration.getPropMaskPassword());
+
+         trustStoreProvider = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME,
+                                                                    TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER,
+                                                                    configuration);
+
          trustStorePath = ConfigurationHelper.getStringProperty(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,
                                                                 TransportConstants.DEFAULT_TRUSTSTORE_PATH,
                                                                 configuration);
+
          trustStorePassword = ConfigurationHelper.getPasswordProperty(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME,
                                                                       TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD,
                                                                       configuration,
@@ -277,8 +293,10 @@ public class NettyAcceptor implements Acceptor
       }
       else
       {
+         keyStoreProvider = TransportConstants.DEFAULT_KEYSTORE_PROVIDER;
          keyStorePath = TransportConstants.DEFAULT_KEYSTORE_PATH;
          keyStorePassword = TransportConstants.DEFAULT_KEYSTORE_PASSWORD;
+         trustStoreProvider = TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER;
          trustStorePath = TransportConstants.DEFAULT_TRUSTSTORE_PATH;
          trustStorePassword = TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD;
          needClientAuth = TransportConstants.DEFAULT_NEED_CLIENT_AUTH;
@@ -351,10 +369,11 @@ public class NettyAcceptor implements Acceptor
       {
          try
          {
-            if (keyStorePath == null)
+            if (keyStorePath == null && TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER.equals(keyStoreProvider))
                throw new IllegalArgumentException("If \"" + TransportConstants.SSL_ENABLED_PROP_NAME +
-                                                     "\" is true then \"" + TransportConstants.KEYSTORE_PATH_PROP_NAME + "\" must be non-null");
-            context = SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+                                                     "\" is true then \"" + TransportConstants.KEYSTORE_PATH_PROP_NAME + "\" must be non-null " +
+                                                     "unless an alternative \"" + TransportConstants.KEYSTORE_PROVIDER_PROP_NAME + "\" has been specified.");
+            context = SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
          }
          catch (Exception e)
          {

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
@@ -27,9 +27,14 @@ import org.junit.Test;
  */
 public class SSLSupportTest extends UnitTestCase
 {
+
+   private String keyStoreProvider;
+
    private String keyStorePath;
 
    private String keyStorePassword;
+
+   private String trustStoreProvider;
 
    private String trustStorePath;
 
@@ -51,8 +56,10 @@ public class SSLSupportTest extends UnitTestCase
    {
       super.setUp();
 
+      keyStoreProvider = "JKS";
       keyStorePath = "server-side.keystore";
       keyStorePassword = "secureexample";
+      trustStoreProvider = "JKS";
       trustStorePath = "server-side.truststore";
       trustStorePassword = keyStorePassword;
    }
@@ -60,21 +67,21 @@ public class SSLSupportTest extends UnitTestCase
    @Test
    public void testContextWithRightParameters() throws Exception
    {
-      SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    // This is valid as it will create key and trust managers with system defaults
    @Test
    public void testContextWithNullParameters() throws Exception
    {
-      SSLSupport.createContext(null, null, null, null);
+      SSLSupport.createContext(null, null, null, null, null, null);
    }
 
    @Test
    public void testContextWithKeyStorePathAsURL() throws Exception
    {
       URL url = Thread.currentThread().getContextClassLoader().getResource(keyStorePath);
-      SSLSupport.createContext(url.toString(), keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, url.toString(), keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -82,7 +89,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       URL url = Thread.currentThread().getContextClassLoader().getResource(keyStorePath);
       File file = new File(url.toURI());
-      SSLSupport.createContext(file.getAbsolutePath(), keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, file.getAbsolutePath(), keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -90,7 +97,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext("not a keystore", keyStorePassword, trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, "not a keystore", keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -103,7 +110,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(null, keyStorePassword, trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, null, keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
       }
       catch (Exception e)
       {
@@ -122,7 +129,7 @@ public class SSLSupportTest extends UnitTestCase
          return;
       }
 
-      SSLSupport.createContext("src/test/resources/server-side.keystore", keyStorePassword, trustStorePath, trustStorePassword);
+      SSLSupport.createContext(keyStoreProvider, "src/test/resources/server-side.keystore", keyStorePassword, trustStoreProvider, trustStorePath, trustStorePassword);
    }
 
    @Test
@@ -130,7 +137,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, "bad password", trustStorePath, trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, "bad password", trustStoreProvider, trustStorePath, trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -143,7 +150,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, keyStorePassword, "not a trust store", trustStorePassword);
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, "not a trust store", trustStorePassword);
          Assert.fail();
       }
       catch (Exception e)
@@ -156,7 +163,7 @@ public class SSLSupportTest extends UnitTestCase
    {
       try
       {
-         SSLSupport.createContext(keyStorePath, keyStorePassword, trustStorePath, "bad passord");
+         SSLSupport.createContext(keyStoreProvider, keyStorePath, keyStorePassword, trustStoreProvider, trustStorePath, "bad passord");
          Assert.fail();
       }
       catch (Exception e)


### PR DESCRIPTION
...be specified for the key and trust stores used by NettyConnector and NettyAcceptor.

Amongst other things this makes it possible for a PKCS#11 provider to be specified.
