### PR TITLE
Upgrade JBoss Logging processor to resolve compile-time WARNING messages...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>1.0.0.Final</version>
+            <version>1.2.0.Final</version>
             <scope>provided</scope>
          </dependency>
 


### PR DESCRIPTION
... about the supported source version

e.g.: 

[WARNING] Supported source version 'RELEASE_6' from annotation processor 'org.jboss.logging.processor.apt.LoggingToolsProcessor' less than -source '1.7'
