### PR TITLE
Update jboss-logging and jboss-logmanager dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,13 +154,13 @@
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.1.0.GA</version>
+            <version>3.1.4.GA</version>
          </dependency>
 
          <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
-            <version>1.2.2.GA</version>
+            <version>1.5.1.Final</version>
          </dependency>
 
          <dependency>


### PR DESCRIPTION
The current versions in use are about 2 years old.  The older jboss-logmanager lacks many basic features that are present in other loggers like slf4j and log4j.  Amongst other things, the newer version adds syslog support which is quite important for many people.
