### PR TITLE
fix apostrophes which can break logging messages

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientMessageBundle.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientMessageBundle.java
@@ -126,7 +126,7 @@ public interface HornetQClientMessageBundle
    @Message(id = 119023, value =  "The large message lost connection with its session, either because of a rollback or a closed session", format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException largeMessageLostSession();
 
-   @Message(id = 119024, value =  "Couldn't select a TransportConfiguration to create SessionFactory", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119024, value =  "Could not select a TransportConfiguration to create SessionFactory", format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException noTCForSessionFactory();
 
    @Message(id = 119025, value = "Error saving the message body", format = Message.Format.MESSAGE_FORMAT)
@@ -203,25 +203,25 @@ public interface HornetQClientMessageBundle
    @Message(id = 119048, value = "nodes hava a different number of attributes", format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException nodeHaveDifferentAttNumber();
 
-   @Message(id = 119049, value = "attribute {0}={1} doesn't match", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119049, value = "attribute {0}={1} does not match", format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException attsDontMatch(String name, String value);
 
-   @Message(id = 119050, value = "one node has children and the other doesn't" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119050, value = "one node has children and the other does not" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException oneNodeHasChildren();
 
    @Message(id = 119051, value = "nodes hava a different number of children" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException nodeHasDifferentChildNumber();
 
-   @Message(id = 119052, value = "Element {0} requires a valid Boolean value, but '{1}' cannot be parsed as a Boolean" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119052, value = "Element {0} requires a valid Boolean value, but ''{1}'' cannot be parsed as a Boolean" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException mustBeBoolean(Node elem, String value);
 
-   @Message(id = 119053, value = "Element {0} requires a valid Double value, but '{1}' cannot be parsed as a Double" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119053, value = "Element {0} requires a valid Double value, but ''{1}'' cannot be parsed as a Double" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException mustBeDouble(Node elem, String value);
 
-   @Message(id = 119054, value = "Element {0} requires a valid Integer value, but '{1}' cannot be parsed as a Integer" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119054, value = "Element {0} requires a valid Integer value, but ''{1}'' cannot be parsed as a Integer" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException mustBeInteger(Node elem, String value);
 
-   @Message(id = 119055, value = "Element {0} requires a valid Long value, but '{1}' cannot be parsed as a Long" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119055, value = "Element {0} requires a valid Long value, but ''{1}'' cannot be parsed as a Long" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException mustBeLong(Node elem, String value);
 
    @Message(id = 119056, value = "Failed to get decoder" , format = Message.Format.MESSAGE_FORMAT)

--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQJMSClientBundle.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQJMSClientBundle.java
@@ -82,7 +82,7 @@ public interface HornetQJMSClientBundle
             format = Message.Format.MESSAGE_FORMAT)
    IllegalStateException onlyValidForByteOrStreamMessages();
 
-   @Message(id = 129012, value = "The property name \'{0}\' is not a valid java identifier.",
+   @Message(id = 129012, value = "The property name ''{0}'' is not a valid java identifier.",
             format = Message.Format.MESSAGE_FORMAT)
    JMSRuntimeException invalidJavaIdentifier(String propertyName);
 

--- a/hornetq-journal/src/main/java/org/hornetq/journal/HornetQJournalBundle.java
+++ b/hornetq-journal/src/main/java/org/hornetq/journal/HornetQJournalBundle.java
@@ -39,7 +39,7 @@ public interface HornetQJournalBundle
    @Message(id = 149001, value =  "Journal data belong to a different version", format = Message.Format.MESSAGE_FORMAT)
    HornetQIOErrorException journalDifferentVersion();
 
-   @Message(id = 149002, value =  "Journal files version mismatch. You should export the data from the previous version and import it as explained on the user's manual",
+   @Message(id = 149002, value =  "Journal files version mismatch. You should export the data from the previous version and import it as explained on the user''s manual",
          format = Message.Format.MESSAGE_FORMAT)
    HornetQIOErrorException journalFileMisMatch();
 

--- a/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/HornetQStompProtocolMessageBundle.java
+++ b/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/HornetQStompProtocolMessageBundle.java
@@ -39,7 +39,7 @@ public interface HornetQStompProtocolMessageBundle
    @Message(id = 339000, value = "Stomp Connection TTL cannot be negative: {0}", format = Message.Format.MESSAGE_FORMAT)
    IllegalStateException negativeConnectionTTL(Long ttl);
 
-   @Message(id = 339001, value = "Destination doesn't exist: {0}", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339001, value = "Destination does not exist: {0}", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException destinationNotExist(String destination);
 
    @Message(id = 339002, value = "Stomp versions not supported: {0}", format = Message.Format.MESSAGE_FORMAT)
@@ -51,16 +51,16 @@ public interface HornetQStompProtocolMessageBundle
    @Message(id = 339004, value = "Cannot accept null as host", format = Message.Format.MESSAGE_FORMAT)
    String hostCannotBeNull();
 
-   @Message(id = 339005, value = "Header host doesn't match server host", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339005, value = "Header host does not match server host", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException hostNotMatch();
 
-   @Message(id = 339006, value = "host {0} doesn't match server host name", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339006, value = "host {0} does not match server host name", format = Message.Format.MESSAGE_FORMAT)
    String hostNotMatchDetails(String host);
 
    @Message(id = 339007, value = "Connection was destroyed.", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException connectionDestroyed();
 
-   @Message(id = 339008, value = "Connection hasn't been established.", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339008, value = "Connection has not been established.", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException connectionNotEstablished();
 
    @Message(id = 339009, value = "Exception getting session", format = Message.Format.MESSAGE_FORMAT)
@@ -141,10 +141,10 @@ public interface HornetQStompProtocolMessageBundle
    @Message(id = 339034, value = "This method should not be called", format = Message.Format.MESSAGE_FORMAT)
    IllegalStateException invalidCall();
 
-   @Message(id = 339035, value = "Must specify the subscription's id or the destination you are unsubscribing from", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339035, value = "Must specify the subscription''s id or the destination you are unsubscribing from", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException needIDorDestination();
 
-   @Message(id = 339037, value = "Must specify the subscription's id", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 339037, value = "Must specify the subscription''s id", format = Message.Format.MESSAGE_FORMAT)
    HornetQStompException needSubscriptionID();
 
    @Message(id = 339039, value = "No id header in ACK/NACK frame.", format = Message.Format.MESSAGE_FORMAT)

--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQMessageBundle.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQMessageBundle.java
@@ -73,7 +73,7 @@ public interface HornetQMessageBundle
    @Message(id = 119005, value = "connections for {0} closed by management" , format = Message.Format.MESSAGE_FORMAT)
    HornetQInternalErrorException connectionsClosedByManagement(String ipAddress);
 
-   @Message(id = 119006, value = "journals are not JournalImpl. You can't set a replicator!" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119006, value = "journals are not JournalImpl. You can''t set a replicator!" , format = Message.Format.MESSAGE_FORMAT)
    HornetQInternalErrorException notJournalImpl();
 
    @Message(id = 119007, value = "unhandled error during replication" , format = Message.Format.MESSAGE_FORMAT)
@@ -145,10 +145,10 @@ public interface HornetQMessageBundle
    @Message(id = 119027, value =  "Could not find reference on consumer ID={0}, messageId = {1} queue = {2}", format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException consumerNoReference(Long id, Long messageID, SimpleString name);
 
-   @Message(id = 119028, value =  "Consumer {0} doesn't exist on the server" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119028, value =  "Consumer {0} doesn''t exist on the server" , format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException consumerDoesntExist(long consumerID);
 
-   @Message(id = 119029, value =  "No address configured on the Server's Session" , format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119029, value =  "No address configured on the Server''s Session" , format = Message.Format.MESSAGE_FORMAT)
    HornetQIllegalStateException noAddress();
 
    @Message(id = 119030, value =  "large-message not initialized on server", format = Message.Format.MESSAGE_FORMAT)
@@ -157,7 +157,7 @@ public interface HornetQMessageBundle
    @Message(id = 119031, value =  "Unable to validate user: {0}", format = Message.Format.MESSAGE_FORMAT)
    HornetQSecurityException unableToValidateUser(String user);
 
-   @Message(id = 119032, value =  "User: {0} doesn't have permission='{1}' on address {2}", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119032, value =  "User: {0} does not have permission=''{1}'' on address {2}", format = Message.Format.MESSAGE_FORMAT)
    HornetQSecurityException userNoPermissions(String username, CheckType checkType, String saddress);
 
    @Message(id = 119033, value =  "Server and client versions incompatible", format = Message.Format.MESSAGE_FORMAT)
@@ -286,11 +286,11 @@ public interface HornetQMessageBundle
    @Message(id = 119074, value = "Error instantiating transformer class {0}" , format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException errorCreatingTransformerClass(@Cause Exception e, String transformerClassName);
 
-   @Message(id = 119075, value = "method autoEncode doesn't know how to convert {0} yet", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119075, value = "method autoEncode doesn''t know how to convert {0} yet", format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException autoConvertError(Class<? extends Object> aClass);
 
    /** Message used on on {@link org.hornetq.core.server.impl.HornetQServerImpl#destroyConnectionWithSessionMetadata(String, String)} */
-   @Message(id = 119076, value = "Executing destroyConnection with {0}={1} through management's request", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119076, value = "Executing destroyConnection with {0}={1} through management''s request", format = Message.Format.MESSAGE_FORMAT)
    String destroyConnectionWithSessionMetadataHeader(String key, String value);
 
    /** Message used on on {@link org.hornetq.core.server.impl.HornetQServerImpl#destroyConnectionWithSessionMetadata(String, String)} */
@@ -298,7 +298,7 @@ public interface HornetQMessageBundle
    String destroyConnectionWithSessionMetadataClosingConnection(String serverSessionString);
 
    /** Exception used on on {@link org.hornetq.core.server.impl.HornetQServerImpl#destroyConnectionWithSessionMetadata(String, String)} */
-   @Message(id = 119078, value = "Disconnected per admin's request on {0}={1}", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 119078, value = "Disconnected per admin''s request on {0}={1}", format = Message.Format.MESSAGE_FORMAT)
    HornetQDisconnectedException destroyConnectionWithSessionMetadataSendException(String key, String value);
 
    /** Message used on on {@link org.hornetq.core.server.impl.HornetQServerImpl#destroyConnectionWithSessionMetadata(String, String)} */

--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -235,7 +235,7 @@ public interface HornetQServerLogger extends BasicLogger
    void messageWithDuplicateID(Object duplicateProperty, SimpleString toAddress, SimpleString address, SimpleString simpleString);
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 221037, value = "{0} to become \''live\''", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 221037, value = "{0} to become ''live''", format = Message.Format.MESSAGE_FORMAT)
    void becomingLive(HornetQServer server);
 
    @LogMessage(level = Logger.Level.INFO)
@@ -989,12 +989,12 @@ public interface HornetQServerLogger extends BasicLogger
    void groupingQueueRemoved(int size, SimpleString clusterName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222168, value = "The 'protocol' property is deprecated, if you want this Acceptor to support multiple protocols use the 'protocols' property, i.e. 'CORE,AMQP,STOMP'",
+   @Message(id = 222168, value = "The ''protocol'' property is deprecated, if you want this Acceptor to support multiple protocols use the ''protocols'' property, i.e. ''CORE,AMQP,STOMP''",
             format = Message.Format.MESSAGE_FORMAT)
    void warnDeprecatedProtocol();
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222169, value = "You have old legacy clients connected to the queue {0} and we can't disconnect them, these clients may just hang",
+   @Message(id = 222169, value = "You have old legacy clients connected to the queue {0} and we can''t disconnect them, these clients may just hang",
             format = Message.Format.MESSAGE_FORMAT)
    void warnDisconnectOldClient(String queueName);
 


### PR DESCRIPTION
A user on IRC reported seeing a log message like this:

```
HornetQSecurityException[errorType=SECURITY_EXCEPTION message=HQ119032: User: myUser doesnt have permission=CONSUME on address {2}]
```

This commit fixes that along with all other apostrophe related problems
