### PR TITLE
Update checkstyle plugin to 2.12

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -69,6 +69,7 @@
       <module name="Indentation">
          <property name="basicOffset" value="3"/>
          <property name="caseIndent" value="3"/>
+         <property name="throwsIndent" value="3"/>
       </module>
    </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.10</version>
+            <version>2.12</version>
             <configuration>
                <skip>${skipStyleCheck}</skip>
                <configLocation>${hornetq.basedir}/etc/checkstyle.xml</configLocation>
@@ -917,7 +917,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.10</version>
+            <version>2.12</version>
             <configuration>
                <configLocation>${hornetq.basedir}/etc/checkstyle.xml</configLocation>
                <failsOnError>false</failsOnError>


### PR DESCRIPTION
This is a successor to PR #1538, see previous discussion in it. checkstyle plugin version 2.12 now uses checkstyle 5.7.
