### PR TITLE
HORNETQ-1238 - Add server-side logging statements when address blocks and unblocks

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -271,6 +271,10 @@ public interface HornetQServerLogger extends BasicLogger
    @Message(id = 221045, value = "libaio is not available, switching the configuration into NIO", format = Message.Format.MESSAGE_FORMAT)
    void switchingNIO();
 
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 221046, value = "Unblocking message production on address ''{0}''; size is currently: {1} bytes; max-size-bytes: {2}", format = Message.Format.MESSAGE_FORMAT)
+   void unblockingMessageProduction(SimpleString addressName, long currentSize, long maxSize);
+
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222000, value = "HornetQServer is being finalized and has not been stopped. Please remember to stop the server before letting it go out of scope",
             format = Message.Format.MESSAGE_FORMAT)
@@ -436,12 +440,12 @@ public interface HornetQServerLogger extends BasicLogger
    void pageStoreStartIOError(@Cause Exception e);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222038, value = "Starting paging on {0}, size = {1}, maxSize={2}", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 222038, value = "Starting paging on address ''{0}''; size is currently: {1} bytes; max-size-bytes: {2}", format = Message.Format.MESSAGE_FORMAT)
    void pageStoreStart(SimpleString storeName, long addressSize, long maxSize);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222039, value = "Messages are being dropped on address {0}", format = Message.Format.MESSAGE_FORMAT)
-   void pageStoreDropMessages(SimpleString storeName);
+   @Message(id = 222039, value = "Messages sent to address ''{0}'' are being dropped; size is currently: {1} bytes; max-size-bytes: {2}", format = Message.Format.MESSAGE_FORMAT)
+   void pageStoreDropMessages(SimpleString storeName, long addressSize, long maxSize);
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222040, value = "Server is stopped", format = Message.Format.MESSAGE_FORMAT)
@@ -1049,6 +1053,10 @@ public interface HornetQServerLogger extends BasicLogger
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222182, value = "Missing cluster-configuration for scale-down-clustername {0}", format = Message.Format.MESSAGE_FORMAT)
    void missingClusterConfigForScaleDown(String scaleDownCluster);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222183, value = "Blocking message production on address ''{0}''; size is currently: {1} bytes; max-size-bytes: {2}", format = Message.Format.MESSAGE_FORMAT)
+   void blockingMessageProduction(SimpleString addressName, long currentSize, long maxSize);
 
 
    @LogMessage(level = Logger.Level.ERROR)

--- a/hornetq-server/src/test/java/org/hornetq/core/config/impl/WrongRoleFileConfigurationParserTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/config/impl/WrongRoleFileConfigurationParserTest.java
@@ -19,6 +19,7 @@ import org.hornetq.core.deployers.impl.FileConfigurationParser;
 import org.hornetq.tests.logging.AssertionLoggerHandler;
 import org.hornetq.tests.util.UnitTestCase;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,6 +37,11 @@ public class WrongRoleFileConfigurationParserTest extends UnitTestCase
    }
 
    @Test
+   /**
+    * When running this test from an IDE add this to the test command line so that the AssertionLoggerHandler works properly:
+    *
+    *   -Djava.util.logging.manager=org.jboss.logmanager.LogManager  -Dlogging.configuration=file:<path_to_source>/tests/config/logging.properties
+    */
    public void testParsingDefaultServerConfig() throws Exception
    {
       FileConfigurationParser parser = new FileConfigurationParser();
@@ -43,8 +49,7 @@ public class WrongRoleFileConfigurationParserTest extends UnitTestCase
       parser.parseMainConfig(input);
 
       // Using the code only because I don't want a test failing just for someone editing Log text
-      AssertionLoggerHandler.findText("HQ222177");
-      AssertionLoggerHandler.findText("HQ222177");
+      Assert.assertTrue("Expected to find \"HQ222177\" twice", AssertionLoggerHandler.findText(2, "HQ222177"));
    }
 
    @AfterClass

--- a/hornetq-server/src/test/java/org/hornetq/tests/logging/AssertionLoggerHandler.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/logging/AssertionLoggerHandler.java
@@ -73,25 +73,31 @@ public class AssertionLoggerHandler extends ExtHandler
 
    /**
     * Find a line that contains the parameters passed as an argument
+    *
     * @param text
     * @return
     */
-   public static boolean findText(final String...text)
+   public static boolean findText(final String text)
    {
+      return findText(1, text);
+   }
+
+
+   public static boolean findText(int occurrences, final String text)
+   {
+      int foundCount = 0;
+
       for (String key : messages.keySet())
       {
          boolean found = true;
 
-         for (String txtCheck : text)
+         found = key.contains(text);
+         if (found)
          {
-            found = key.contains(txtCheck);
-            if (!found)
-            {
-               break;
-            }
+            foundCount++;
          }
 
-         if (found)
+         if (found && foundCount == occurrences)
          {
             return true;
          }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/AddressFullLoggingTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/AddressFullLoggingTest.java
@@ -1,0 +1,130 @@
+package org.hornetq.tests.integration.server;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.client.ClientConsumer;
+import org.hornetq.api.core.client.ClientMessage;
+import org.hornetq.api.core.client.ClientProducer;
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.api.core.client.ClientSessionFactory;
+import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.core.server.HornetQServer;
+import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
+import org.hornetq.core.settings.impl.AddressSettings;
+import org.hornetq.tests.logging.AssertionLoggerHandler;
+import org.hornetq.tests.util.ServiceTestBase;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AddressFullLoggingTest extends ServiceTestBase
+{
+   @BeforeClass
+   public static void prepareLogger()
+   {
+      AssertionLoggerHandler.startCapture();
+   }
+
+   @Test
+   /**
+    * When running this test from an IDE add this to the test command line so that the AssertionLoggerHandler works properly:
+    *
+    *   -Djava.util.logging.manager=org.jboss.logmanager.LogManager  -Dlogging.configuration=file:<path_to_source>/tests/config/logging.properties
+    */
+   public void testBlockLogging() throws Exception
+   {
+      final int MAX_MESSAGES = 200;
+      final String MY_ADDRESS = "myAddress";
+      final String MY_QUEUE = "myQueue";
+
+      HornetQServer server = createServer(false);
+
+      AddressSettings defaultSetting = new AddressSettings();
+      defaultSetting.setPageSizeBytes(10 * 1024);
+      defaultSetting.setMaxSizeBytes(20 * 1024);
+      defaultSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      server.getAddressSettingsRepository().addMatch("#", defaultSetting);
+      server.start();
+
+      ServerLocator locator = createInVMNonHALocator();
+      locator.setBlockOnNonDurableSend(true);
+      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnAcknowledge(true);
+
+      ClientSessionFactory factory = createSessionFactory(locator);
+      ClientSession session = factory.createSession(false, true, true);
+
+      session.createQueue(MY_ADDRESS, MY_QUEUE, true);
+
+      final ClientProducer producer = session.createProducer(MY_ADDRESS);
+
+      final ClientMessage message = session.createMessage(false);
+      message.getBodyBuffer().writeBytes(new byte[1024]);
+
+      ExecutorService executor = Executors.newFixedThreadPool(1);
+      Callable<Object> sendMessageTask = new Callable<Object>()
+      {
+         public Object call() throws HornetQException
+         {
+            producer.send(message);
+            return null;
+         }
+      };
+
+      int sendCount = 0;
+
+      for (int i = 0; i < MAX_MESSAGES; i++)
+      {
+         Future<Object> future = executor.submit(sendMessageTask);
+         try
+         {
+            future.get(3, TimeUnit.SECONDS);
+            sendCount++;
+         }
+         catch (TimeoutException ex)
+         {
+            // message sending has been blocked
+            break;
+         }
+         finally
+         {
+            future.cancel(true); // may or may not desire this
+         }
+      }
+
+      executor.shutdown();
+      session.close();
+
+      session = factory.createSession(false, true, true);
+      session.start();
+      ClientConsumer consumer = session.createConsumer(MY_QUEUE);
+      for (int i = 0; i < sendCount; i++)
+      {
+         ClientMessage msg = consumer.receive(250);
+         if (msg == null)
+            break;
+         msg.acknowledge();
+      }
+
+      session.close();
+      locator.close();
+      server.stop();
+
+      // Using the code only so the test doesn't fail just because someone edits the log text
+      Assert.assertTrue("Expected to find HQ222183", AssertionLoggerHandler.findText("HQ222183"));
+      Assert.assertTrue("Expected to find HQ221046", AssertionLoggerHandler.findText("HQ221046"));
+   }
+
+   @AfterClass
+   public static void clearLogger()
+   {
+      AssertionLoggerHandler.stopCapture();
+   }
+}


### PR DESCRIPTION
I also fixed org.hornetq.core.config.impl.WrongRoleFileConfigurationParserTest#testParsingDefaultServerConfig so that it actually tests what it needs to test.
