### PR TITLE
[HORNETQ-1165] On failover ChannelImpl logs confusing warnings.

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/ChannelImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/protocol/core/impl/ChannelImpl.java
@@ -668,7 +668,10 @@ public final class ChannelImpl implements Channel
 
          if (packet == null)
          {
-            HornetQClientLogger.LOGGER.cannotFindPacketToClear(lastReceivedCommandID, firstStoredCommandID);
+            if (lastReceivedCommandID > 0)
+            {
+               HornetQClientLogger.LOGGER.cannotFindPacketToClear(lastReceivedCommandID, firstStoredCommandID);
+            }
             firstStoredCommandID = lastReceivedCommandID + 1;
             return;
          }


### PR DESCRIPTION
The warning will be logged only if the id of the last received command is greater than 0.
