### PR TITLE
[HORNETQ-1302] Embedded server without persistence creates a server.lock file

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -392,7 +392,11 @@ public class HornetQServerImpl implements HornetQServer
    protected NodeManager createNodeManager(final String directory, String nodeGroupName, boolean replicatingBackup)
    {
       NodeManager manager;
-      if (configuration.getJournalType() == JournalType.ASYNCIO && AsynchronousFileImpl.isLoaded())
+      if (!configuration.isPersistenceEnabled())
+      {
+         manager = new InVMNodeManager(replicatingBackup);
+      }
+      else if (configuration.getJournalType() == JournalType.ASYNCIO && AsynchronousFileImpl.isLoaded())
       {
          manager = new AIOFileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout());
       }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/InVMNodeManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/InVMNodeManager.java
@@ -12,6 +12,11 @@
  */
 package org.hornetq.core.server.impl;
 
+import static org.hornetq.core.server.impl.InVMNodeManager.State.LIVE;
+import static org.hornetq.core.server.impl.InVMNodeManager.State.FAILING_BACK;
+import static org.hornetq.core.server.impl.InVMNodeManager.State.NOT_STARTED;
+import static org.hornetq.core.server.impl.InVMNodeManager.State.PAUSED;
+
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 
@@ -20,16 +25,11 @@ import org.hornetq.api.core.SimpleString;
 import org.hornetq.core.server.NodeManager;
 import org.hornetq.utils.UUIDGenerator;
 
-import static org.hornetq.core.server.impl.InVMNodeManager.State.FAILING_BACK;
-import static org.hornetq.core.server.impl.InVMNodeManager.State.LIVE;
-import static org.hornetq.core.server.impl.InVMNodeManager.State.NOT_STARTED;
-import static org.hornetq.core.server.impl.InVMNodeManager.State.PAUSED;
-
 /**
  * NodeManager used to run multiple servers in the same VM.
  * <p/>
- * We use the {@link InVMNodeManager} instead of {@link FileLockNodeManager} because in the
- * unit-tests multiple servers are run inside the same VM and File Locks can not be shared in the
+ * We use the {@link org.hornetq.core.server.impl.InVMNodeManager} instead of {@link org.hornetq.core.server.impl.FileLockNodeManager} when
+ * multiple servers are run inside the same VM and File Locks can not be shared in the
  * same VM (it would cause a shared lock violation).
  *
  * @author <a href="mailto:andy.taylor@jboss.com">Andy Taylor</a> Date: Oct 13, 2010 Time: 3:55:47

--- a/hornetq-server/src/test/java/org/hornetq/core/server/impl/EmbeddedServerTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/server/impl/EmbeddedServerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.hornetq.core.server.impl;
+
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.hornetq.core.server.HornetQServer;
+import org.hornetq.core.server.HornetQServers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class EmbeddedServerTest
+{
+   private static final String SERVER_LOCK_NAME = "server.lock";
+   private static final String SERVER_JOURNAL_DIR = "target/data/journal";
+
+   private HornetQServer server;
+   private Configuration configuration;
+
+   @Before
+   public void setup()
+   {
+      configuration = new ConfigurationImpl();
+      configuration.setJournalDirectory(SERVER_JOURNAL_DIR);
+      configuration.setPersistenceEnabled(false);
+      configuration.setSecurityEnabled(false);
+      configuration.getAcceptorConfigurations().add(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+
+      server = HornetQServers.newHornetQServer(configuration);
+      try
+      {
+         server.start();
+      }
+      catch (Exception e)
+      {
+         Assert.fail();
+      }
+   }
+
+   @After
+   public void teardown()
+   {
+      try
+      {
+         server.stop();
+      }
+      catch (Exception e)
+      {
+         // Do Nothing
+      }
+   }
+
+   @Test
+   public void testNoLockFileWithPersistenceFalse()
+   {
+      Path journalDir = Paths.get(SERVER_JOURNAL_DIR, SERVER_LOCK_NAME);
+      boolean lockExists = Files.exists(journalDir);
+      Assert.assertFalse(lockExists);
+   }
+}


### PR DESCRIPTION
Brought InVMNodeManager from test scope to distribution and instantiate it, in case the configuration is set with no persistence.
