### PR TITLE
HORNETQ-1340 - Documentation Updates

### DIFF
--- a/docs/user-manual/en/appserver-integration.xml
+++ b/docs/user-manual/en/appserver-integration.xml
@@ -799,13 +799,21 @@ private ConnectionFactory connectionFactory;</programlisting>
                                 <entry>DestinationType</entry>
                                 <entry>String</entry>
                                 <entry>type of the destination, either <literal>javax.jms.Queue</literal> or <literal>javax.jms.Topic</literal>
-                                 (default is javax.jms.Queue)</entry>
+                                   (default is javax.jms.Queue)</entry>
                             </row>
                             <row>
                                 <entry>AcknowledgeMode</entry>
                                 <entry>String</entry>
                                 <entry>The Acknowledgment mode, either <literal>Auto-acknowledge</literal> or <literal>Dups-ok-acknowledge</literal>
-                                (default is Auto-acknowledge). <literal>AUTO_ACKNOWLEDGE</literal> and <literal>DUPS_OK_ACKNOWLEDGE</literal> are acceptable values.</entry>
+                                   (default is Auto-acknowledge). <literal>AUTO_ACKNOWLEDGE</literal> and <literal>DUPS_OK_ACKNOWLEDGE</literal> are acceptable values.</entry>
+                            </row>
+                            <row>
+                                <entry>JndiParams</entry>
+                                <entry>String</entry>
+                                <entry>A semicolon (';') delimited string of name=value pairs which represent the properties to be used for the destination JNDI
+                                   look up. The properties depends on the JNDI implementation of the server hosting HornetQ. Typically only be used when the MDB is
+                                   configured to consume from a remote destination and needs to look up a JNDI reference rather than the HornetQ name of the
+                                   destination. Only relevant when <literal>useJNDI</literal> is <literal>true</literal> (default is an empty string).</entry>
                             </row>
                             <row>
                                 <entry>MaxSession</entry>

--- a/docs/user-manual/en/connection-ttl.xml
+++ b/docs/user-manual/en/connection-ttl.xml
@@ -168,16 +168,36 @@ java.lang.Exception
     </section>
     <section id="connection-ttl.async-connection-execution">
         <title>Configuring Asynchronous Connection Execution</title>
-        <para>By default, packets received on the server side are executed on the remoting
-            thread.</para>
-        <para>It is possible instead to use a thread from a thread pool to handle some packets so
-            that the remoting thread is not tied up for too long. However, please note that
-            processing operations asynchronously on another thread adds a little more latency.
-            Please note that most short running operations are always handled on the remoting thread for performance reasons.
-           
-            To enable asynchronous connection execution, set the parameter <literal
-                >async-connection-execution-enabled</literal> in <literal
-                >hornetq-configuration.xml</literal> to <literal>true</literal> (default value is
-                <literal>true</literal>).</para>
+        <para>Most packets received on the server side are executed on the remoting thread. These packets
+            represent short-running operations and are always executed on the remoting thread for
+            performance reasons.</para>
+        <para>However, by default some kinds of packets are executed using a thread from a
+            thread pool so that the remoting thread is not tied up for too long. Please note that
+            processing operations asynchronously on another thread adds a little more latency. These packets
+            are:</para>
+        <itemizedlist>
+            <listitem>
+                <para><literal>org.hornetq.core.protocol.core.impl.wireformat.RollbackMessage</literal></para>
+            </listitem>
+            <listitem>
+               <para><literal>org.hornetq.core.protocol.core.impl.wireformat.SessionCloseMessage</literal></para>
+            </listitem>
+            <listitem>
+               <para><literal>org.hornetq.core.protocol.core.impl.wireformat.SessionCommitMessage</literal></para>
+            </listitem>
+            <listitem>
+               <para><literal>org.hornetq.core.protocol.core.impl.wireformat.SessionXACommitMessage</literal></para>
+            </listitem>
+            <listitem>
+                <para><literal>org.hornetq.core.protocol.core.impl.wireformat.SessionXAPrepareMessage</literal></para>
+            </listitem>
+            <listitem>
+               <para><literal>org.hornetq.core.protocol.core.impl.wireformat.SessionXARollbackMessage</literal></para>
+            </listitem>
+        </itemizedlist>
+        <para>To disable asynchronous connection execution, set the parameter
+           <literal>async-connection-execution-enabled</literal> in
+           <literal>hornetq-configuration.xml</literal> to <literal>false</literal> (default value is
+           <literal>true</literal>).</para>
     </section>
 </chapter>

--- a/docs/user-manual/en/large-messages.xml
+++ b/docs/user-manual/en/large-messages.xml
@@ -61,6 +61,13 @@
         <para>Any message larger than a certain size is considered a large message. Large messages
             will be split up and sent in fragments. This is determined by the parameter <literal
                 >min-large-message-size</literal></para>
+        <note>
+           <para>HornetQ messages are encoded using 2 bytes per character so if the message data is filled
+              with ASCII characters (which are 1 byte) the size of the resulting HornetQ message would roughly
+              double. This is important when calculating the size of a "large" message as it may appear to be
+              less than the <literal>min-large-message-size</literal> before it is sent, but it then turns into
+              a "large" message once it is encoded.</para>
+        </note>
         <para>The default value is 100KiB.</para>
         <section id="large-messages.core.config">
             <title>Using Core API</title>

--- a/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
+++ b/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
@@ -260,7 +260,7 @@
                      default="true" maxOccurs="1" minOccurs="0">
           <xsd:annotation hq:linkend="connection-ttl.async-connection-execution"
                           hq:field_name="DEFAULT_ASYNC_CONNECTION_EXECUTION_ENABLED">
-            <xsd:documentation>Should incoming packets on the server be handed off to a thread from
+            <xsd:documentation>should certain incoming packets on the server be handed off to a thread from
             the thread pool for processing or should they be handled on the remoting thread?
             </xsd:documentation>
           </xsd:annotation>


### PR DESCRIPTION
Improve documentation around:
- 2-byte encoding and impact on large messages
- jndiParams JCA activation configuration property
- default value for asynchronous-connection-execution
