### PR TITLE
HORNETQ-1342 - Clean up DuplicateIDCache on queue removal

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/postoffice/DuplicateIDCache.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/postoffice/DuplicateIDCache.java
@@ -37,4 +37,6 @@ public interface DuplicateIDCache
    void load(List<Pair<byte[], Long>> theIds) throws Exception;
 
    void load(final Transaction tx, final byte[] duplID);
+
+   void clear() throws Exception;
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/postoffice/impl/DuplicateIDCacheImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/postoffice/impl/DuplicateIDCacheImpl.java
@@ -33,7 +33,7 @@ import org.hornetq.core.transaction.TransactionOperationAbstract;
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  *
- * Created 8 Dec 2008 16:35:55
+ *         Created 8 Dec 2008 16:35:55
  */
 public class DuplicateIDCacheImpl implements DuplicateIDCache
 {
@@ -117,7 +117,7 @@ public class DuplicateIDCacheImpl implements DuplicateIDCache
    }
 
 
-   public void deleteFromCache(byte [] duplicateID) throws Exception
+   public void deleteFromCache(byte[] duplicateID) throws Exception
    {
       ByteArrayHolder bah = new ByteArrayHolder(duplicateID);
 
@@ -241,6 +241,23 @@ public class DuplicateIDCacheImpl implements DuplicateIDCache
       }
    }
 
+   public void clear() throws Exception
+   {
+      synchronized (this)
+      {
+         long tx = storageManager.generateUniqueID();
+         for (Pair<ByteArrayHolder, Long> id : ids)
+         {
+            storageManager.deleteDuplicateIDTransactional(tx, id.getB());
+         }
+         storageManager.commit(tx);
+
+         ids.clear();
+         cache.clear();
+         pos = 0;
+      }
+   }
+
    private final class AddDuplicateIDOperation extends TransactionOperationAbstract
    {
       final byte[] duplID;
@@ -296,7 +313,7 @@ public class DuplicateIDCacheImpl implements DuplicateIDCache
       {
          if (other instanceof ByteArrayHolder)
          {
-            ByteArrayHolder s = (ByteArrayHolder)other;
+            ByteArrayHolder s = (ByteArrayHolder) other;
 
             if (bytes.length != s.bytes.length)
             {

--- a/hornetq-server/src/main/java/org/hornetq/core/postoffice/impl/PostOfficeImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/postoffice/impl/PostOfficeImpl.java
@@ -500,6 +500,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          pagingManager.deletePageStore(binding.getAddress());
 
          managementService.unregisterAddress(binding.getAddress());
+
+         deleteDuplicateCache(binding.getAddress());
       }
 
       if (binding.getType() == BindingType.LOCAL_QUEUE)
@@ -540,6 +542,16 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       binding.close();
 
       return binding;
+   }
+
+   private void deleteDuplicateCache(SimpleString address) throws Exception
+   {
+      DuplicateIDCache cache = duplicateIDCaches.remove(address);
+
+      if (cache != null)
+      {
+         cache.clear();
+      }
    }
 
    @Override
@@ -823,6 +835,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       }
 
       return cache;
+   }
+
+   public ConcurrentMap<SimpleString, DuplicateIDCache> getDuplicateIDCaches()
+   {
+      return duplicateIDCaches;
    }
 
    public Object getNotificationLock()

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/DuplicateDetectionTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/DuplicateDetectionTest.java
@@ -29,6 +29,7 @@ import org.hornetq.api.core.client.ClientSessionFactory;
 import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.core.config.Configuration;
+import org.hornetq.core.postoffice.impl.PostOfficeImpl;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.transaction.impl.XidImpl;
 import org.hornetq.tests.util.ServiceTestBase;
@@ -124,6 +125,105 @@ public class DuplicateDetectionTest extends ServiceTestBase
       sf.close();
 
       locator.close();
+   }
+
+   @Test
+   public void testDuplicateIDCacheMemoryRetentionForNonTemporaryQueues() throws Exception
+   {
+      testDuplicateIDCacheMemoryRetention(false);
+   }
+
+   @Test
+   public void testDuplicateIDCacheMemoryRetentionForTemporaryQueues() throws Exception
+   {
+      testDuplicateIDCacheMemoryRetention(true);
+   }
+
+   @Test
+   public void testDuplicateIDCacheJournalRetentionForNonTemporaryQueues() throws Exception
+   {
+      testDuplicateIDCacheMemoryRetention(false);
+
+      messagingService.stop();
+
+      messagingService.start();
+
+      Assert.assertEquals(0, ((PostOfficeImpl) messagingService.getPostOffice()).getDuplicateIDCaches().size());
+   }
+
+   @Test
+   public void testDuplicateIDCacheJournalRetentionForTemporaryQueues() throws Exception
+   {
+      testDuplicateIDCacheMemoryRetention(true);
+
+      messagingService.stop();
+
+      messagingService.start();
+
+      Assert.assertEquals(0, ((PostOfficeImpl) messagingService.getPostOffice()).getDuplicateIDCaches().size());
+   }
+
+   public void testDuplicateIDCacheMemoryRetention(boolean temporary) throws Exception
+   {
+      final int TEST_SIZE = 100;
+
+      ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(UnitTestCase.INVM_CONNECTOR_FACTORY));
+
+      ClientSessionFactory sf = createSessionFactory(locator);
+
+      ClientSession session = sf.createSession(false, true, true);
+
+      session.start();
+
+      Assert.assertEquals(0, ((PostOfficeImpl)messagingService.getPostOffice()).getDuplicateIDCaches().size());
+
+      final SimpleString addressName = new SimpleString("DuplicateDetectionTestAddress");
+
+      for (int i = 0; i < TEST_SIZE; i++)
+      {
+         final SimpleString queueName = new SimpleString("DuplicateDetectionTestQueue_" + i);
+
+         if (temporary)
+         {
+            session.createTemporaryQueue(addressName, queueName, null);
+         }
+         else
+         {
+            session.createQueue(addressName, queueName, null, true);
+         }
+
+         ClientProducer producer = session.createProducer(addressName);
+
+         ClientConsumer consumer = session.createConsumer(queueName);
+
+         ClientMessage message = createMessage(session, 1);
+         SimpleString dupID = new SimpleString("abcdefg");
+         message.putBytesProperty(Message.HDR_DUPLICATE_DETECTION_ID, dupID.getData());
+         producer.send(message);
+         ClientMessage message2 = consumer.receive(1000);
+         Assert.assertEquals(1, message2.getObjectProperty(propKey));
+
+         message = createMessage(session, 2);
+         message.putBytesProperty(Message.HDR_DUPLICATE_DETECTION_ID, dupID.getData());
+         producer.send(message);
+         message2 = consumer.receiveImmediate();
+         Assert.assertNull(message2);
+
+         producer.close();
+         consumer.close();
+
+         Assert.assertEquals(1, ((PostOfficeImpl)messagingService.getPostOffice()).getDuplicateIDCaches().size());
+         session.deleteQueue(queueName);
+         Assert.assertEquals(0, ((PostOfficeImpl)messagingService.getPostOffice()).getDuplicateIDCaches().size());
+      }
+
+      session.close();
+
+      sf.close();
+
+      locator.close();
+
+      Assert.assertEquals(0, ((PostOfficeImpl)messagingService.getPostOffice()).getDuplicateIDCaches().size());
    }
 
    @Test
@@ -556,7 +656,6 @@ public class DuplicateDetectionTest extends ServiceTestBase
       producer.send(message);
 
       session.commit();
-
 
 
       message = consumer.receive(5000);


### PR DESCRIPTION
Test-suite results: http://messaging-09.jbm.lab.bos.redhat.com:8080/job/hornetq-param/666/

org.hornetq.tests.integration.client.IncompatibleVersionTest.testCompatibleClientVersionWithRealConnection2 failed but succeeded locally.
