### PR TITLE
HornetQMessage does not allow dots in message properties

### DIFF
--- a/integration/hornetq-vertx-integration/src/main/java/org/hornetq/integration/vertx/VertxConstants.java
+++ b/integration/hornetq-vertx-integration/src/main/java/org/hornetq/integration/vertx/VertxConstants.java
@@ -49,8 +49,8 @@ public class VertxConstants
    public static final Set<String> ALLOWABLE_OUTGOING_CONNECTOR_KEYS;
    public static final Set<String> REQUIRED_OUTGOING_CONNECTOR_KEYS;
    public static final int INITIAL_MESSAGE_BUFFER_SIZE = 50;
-   public static final String VERTX_MESSAGE_REPLYADDRESS = "vertx.message.replyaddress";
-   public static final String VERTX_MESSAGE_TYPE = "vertx.message.type";
+   public static final String VERTX_MESSAGE_REPLYADDRESS = "VertxMessageReplyAddress";
+   public static final String VERTX_MESSAGE_TYPE = "VertxMessageType";
 
    static
    {


### PR DESCRIPTION
[HornetQMessage](https://github.com/hornetq/hornetq/blob/master/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQMessage.java) method <code>checkProperty</code> requires any JMS message property name should be a valid java identifier. No dots are allowed. Renaming vertx properties so that they comply to the rules.
The issue is similar to [this one](https://github.com/hibernate/hibernate-search/commit/e0042820192eae62586dea67bff16ba6b064c8b9) identified in hibernate-search integration.
