### PR TITLE
HornetQTextMessage sets payload as SimpleString

### DIFF
--- a/integration/hornetq-vertx-integration/src/main/java/org/hornetq/integration/vertx/OutgoingVertxEventHandler.java
+++ b/integration/hornetq-vertx-integration/src/main/java/org/hornetq/integration/vertx/OutgoingVertxEventHandler.java
@@ -226,7 +226,8 @@ public class OutgoingVertxEventHandler implements Consumer, ConnectorService
          case VertxConstants.TYPE_PING:
          case VertxConstants.TYPE_STRING:
             bodyBuffer.resetReaderIndex();
-            vertxMsgBody = bodyBuffer.readString();
+            SimpleString simpleString = bodyBuffer.readNullableSimpleString();
+            vertxMsgBody = simpleString.toString();
             break;
          case VertxConstants.TYPE_BUFFER:
             int len = bodyBuffer.readInt();


### PR DESCRIPTION
When [HornetQTextMessage](https://github.com/hornetq/hornetq/blob/master/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQTextMessage.java) is created, method <code>setText</code> is used to set its payload. Internally it uses <code>writeNullableSimpleString</code>, when writing it to the buffer.

In case the message is sent to <code>OutgoingVertxEventHandler</code> with <code>VertxMessageType</code> set to <code>TYPE_STRING</code> we have to invoke <code>readNullableSimpleString</code> instead of <code>readString</code>, otherwise it will not be able to decode it properly, failing with an exception.
