### PR TITLE
format the XSD consistently

### DIFF
--- a/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
+++ b/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
@@ -1,1817 +1,2010 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="urn:hornetq" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:hq="urn:org.hornetq"
-  attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:hornetq"
-  version="1.0">
+            attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:hornetq"
+            version="1.0">
 
-  <xsd:element name="configuration" type="configurationType" hq:schema="hornetq-configuration"/>
+   <xsd:element name="configuration" type="configurationType" hq:schema="hornetq-configuration"/>
 
-    <xsd:complexType name="configurationType">
+   <xsd:complexType name="configurationType">
       <xsd:all>
-        <xsd:element name="name" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              Node name. If set, it will be used in topology notifications.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="resolve-protocols" type="xsd:boolean" default="true" maxOccurs="1"
-                       minOccurs="0">
-           <xsd:annotation hq:linkend="resolveProtocols" hq:field_name="DEFAULT_RESOLVE_PROTOCOLS">
-             <xsd:documentation>
-               If true then the HornetQ Server will make use of any Protocol Managers that
-               are in available on the classpath. If false then only the core protocol will
-               be available, unless in Embedded mode where users can inject their own
-               Protocol Managers.
-             </xsd:documentation>
-           </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="clustered" type="xsd:boolean" default="false" maxOccurs="1"
-                     minOccurs="0">
-          <xsd:annotation hq:linkend="clusters">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated and its value will be ignored (HQ221038).
-              A HornetQ server will be "clustered" when its configuration contain a
-              cluster-configuration.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="check-for-live-server" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="hq.check-for-live-server">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if
-              &lt;ha-policy&gt; is not also used. Whether to check the cluster for a (live)
-              server using our own server ID when starting up. This option is only necessary
-              for performing 'fail-back' on replicating servers. Strictly speaking this
-              setting only applies to live servers and not to backups.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="file-deployment-enabled" type="xsd:boolean" default="false"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="using-server.configuration"
-                          hq:field_name="DEFAULT_FILE_DEPLOYMENT_ENABLED">
-            <xsd:documentation>
-              true means that the server will load configuration from the configuration files
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="persistence-enabled" type="xsd:boolean" default="true"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="persistence.enabled" hq:field_name="DEFAULT_PERSISTENCE_ENABLED">
-            <xsd:documentation>
-              true means that the server will use the file based journal for persistence.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="scheduled-thread-pool-max-size" type="xsd:int" default="5"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="server.scheduled.thread.pool"
-                          hq:field_name="DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE">
-            <xsd:documentation>
-              Maximum number of threads to use for the scheduled thread pool
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="thread-pool-max-size" type="xsd:int" default="30" maxOccurs="1"
-                     minOccurs="0">
-          <xsd:annotation hq:linkend="server.scheduled.thread.pool"
-                          hq:field_name="DEFAULT_THREAD_POOL_MAX_SIZE">
-            <xsd:documentation>
-              Maximum number of threads to use for the thread pool. -1 means 'no limits'.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="security-enabled" type="xsd:boolean" default="true"
-          maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="security" hq:field_name="DEFAULT_SECURITY_ENABLED" >
-            <xsd:documentation>
-              true means that security is enabled</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="security-invalidation-interval" type="xsd:long" default="10000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="security" hq:field_name="DEFAULT_SECURITY_INVALIDATION_INTERVAL">
-            <xsd:documentation>
-              how long (in ms) to wait before invalidating the security cache
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="journal-lock-acquisition-timeout" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="using-server.configuration" hq:field_name="DEFAULT_JOURNAL_LOCK_ACQUISITION_TIMEOUT">
-            <xsd:documentation>
-              how long (in ms) to wait to acquire a file lock on the journal
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="wild-card-routing-enabled" type="xsd:boolean" default="true"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="wildcard-routing" hq:field_name="DEFAULT_WILDCARD_ROUTING_ENABLED">
-            <xsd:documentation>
-              true means that the server supports wild card routing
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="management-address" type="xsd:string" default="jms.queue.hornetq.management"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="management.core.configuration"
-                          hq:field_name="DEFAULT_MANAGEMENT_ADDRESS"
-                          hq:type="SimpleString">
-            <xsd:documentation>
-              the name of the management address to send management messages to. It is prefixed with
-              "jms.queue" so that JMS clients can send messages to it.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="management-notification-address" type="xsd:string" default="hornetq.notifications"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="management.notifications.core.configuration"
-                          hq:field_name="DEFAULT_MANAGEMENT_NOTIFICATION_ADDRESS"
-                          hq:type="SimpleString">
-            <xsd:documentation>
-              the name of the address that consumers bind to receive management notifications
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="cluster-user" type="xsd:string" default="HORNETQ.CLUSTER.ADMIN.USER"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters" hq:field_name="DEFAULT_CLUSTER_USER">
-            <xsd:documentation>
-              Cluster username. It applies to all cluster configurations.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="cluster-password" maxOccurs="1" minOccurs="0" type="xsd:string"
-                     default="CHANGE ME!!">
-          <xsd:annotation hq:linkend="clusters" hq:field_name="DEFAULT_CLUSTER_PASSWORD">
-            <xsd:documentation>
-              Cluster password. It applies to all cluster configurations.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="replication-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if
-              &lt;ha-policy&gt; is not also used. Name of the cluster configuration to use for
-              replication. This setting is only necessary in case you configure multiple cluster
-              connections. It is used by a replicating backups and by live servers that may
-              attempt fail-back.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="scale-down-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if
-              &lt;ha-policy&gt; is not also used. Name of the cluster configuration to use for
-              scaling down. This setting is only necessary in case you configure multiple cluster
-              connections.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if
-              &lt;ha-policy&gt; is not also used. This specifies how many times a replicated
-              backup server can restart after moving its files on start. Once there are this
-              number of backup journal files the server will stop permanently after if fails
-              back.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="password-codec" type="xsd:string"
-                     default="org.hornetq.utils.DefaultSensitiveStringCodec" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuration.masked-password">
-            <xsd:documentation>
-              Class name and its parameters for the Decoder used to decode the masked password.
-              Ignored if mask-password is false. The format of this property is a full qualified
-              class name optionally followed by key/value pairs.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="mask-password" type="xsd:boolean" default="false" maxOccurs="1"
-                     minOccurs="0">
-          <xsd:annotation hq:linkend="configuration.masked-password" hq:field_name="DEFAULT_MASK_PASSWORD">
-            <xsd:documentation>
-              This option controls whether passwords in server configuration need be masked.  If set
-              to "true" the passwords are masked.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="log-delegate-factory-class-name" type="xsd:string" maxOccurs="1"
-                     minOccurs="0">
-          <xsd:annotation hq:linkend="XXX">
-            <xsd:documentation>XXX</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="jmx-management-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="management.jmx.configuration"
-                           hq:field_name="DEFAULT_JMX_MANAGEMENT_ENABLED">
-            <xsd:documentation>
-              true means that the management API is available via JMX
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="jmx-domain" type="xsd:string" default="org.hornetq" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="management.jmx.configuration" hq:field_name="DEFAULT_JMX_DOMAIN">
-            <xsd:documentation>
-              the JMX domain used to registered HornetQ MBeans in the MBeanServer
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="message-counter-enabled" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.counters" hq:field_name="DEFAULT_MESSAGE_COUNTER_ENABLED">
-            <xsd:documentation>
-              true means that message counters are enabled</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="message-counter-sample-period" type="xsd:long" default="10000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.counters" hq:field_name="DEFAULT_MESSAGE_COUNTER_SAMPLE_PERIOD">
-            <xsd:documentation>
-              the sample period (in ms) to use for message counters
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="message-counter-max-day-history" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.counters" hq:default="(days)" hq:field_name="DEFAULT_MESSAGE_COUNTER_MAX_DAY_HISTORY">
-            <xsd:documentation>
-              how many days to keep message counter history
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="connection-ttl-override" type="xsd:long" default="-1"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="connection-ttl.override"
-                          hq:field_name="DEFAULT_CONNECTION_TTL_OVERRIDE">
-            <xsd:documentation>
-              if set, this will override how long (in ms) to keep a connection alive without
-              receiving a ping. -1 disables this setting.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="async-connection-execution-enabled" type="xsd:boolean"
-                     default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="connection-ttl.async-connection-execution"
-                          hq:field_name="DEFAULT_ASYNC_CONNECTION_EXECUTION_ENABLED">
-            <xsd:documentation>should certain incoming packets on the server be handed off to a thread from
-              the thread pool for processing or should they be handled on the remoting thread?
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="transaction-timeout" type="xsd:long" default="300000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="transaction-config" hq:field_name="DEFAULT_TRANSACTION_TIMEOUT">
-            <xsd:documentation>
-              how long (in ms) before a transaction can be removed from the resource manager after
-              create time
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="transaction-timeout-scan-period" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="transaction-config" hq:field_name="DEFAULT_TRANSACTION_TIMEOUT_SCAN_PERIOD">
-            <xsd:documentation>
-              how often (in ms) to scan for timeout transactions
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="message-expiry-scan-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.expiry.reaper" hq:field_name="DEFAULT_MESSAGE_EXPIRY_SCAN_PERIOD">
-            <xsd:documentation>
-              how often (in ms) to scan for expired messages
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="message-expiry-thread-priority" type="xsd:int" default="3" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.expiry.reaper" hq:field_name="DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY">
-            <xsd:documentation>
-              the priority of the thread expiring messages
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="id-cache-size" type="xsd:int" default="20000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="duplicate.id.cache" hq:field_name="DEFAULT_ID_CACHE_SIZE">
-            <xsd:documentation>
-              the size of the cache for pre-creating message ID's
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="persist-id-cache" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="duplicate.id.cache" hq:field_name="DEFAULT_PERSIST_ID_CACHE">
-            <xsd:documentation>
-              true means that ID's are persisted to the journal
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="remoting-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="intercepting-operations">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored. Any interceptor
-              specified here will be considered an "incoming" interceptor. See
-              &lt;remoting-incoming-interceptors&gt; and &lt;remoting-outgoing-interceptors&gt;.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="remoting-incoming-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="intercepting-operations">
-            <xsd:documentation>a list of &lt;class-name/&gt; elements with the names of classes to
-              use for interceptor incoming remoting packets
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="remoting-outgoing-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="intercepting-operations">
-            <xsd:documentation>a list of &lt;class-name/&gt; elements with the names of classes to
-              use for interceptor outcoming remoting packets
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="backup" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha" hq:field_name="DEFAULT_BACKUP">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. It indicates whether this server is a backup server
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.allow-fail-back">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. Whether a server will automatically stop when a another places a
-              request to take over its place.  The use case is when a regular server stops and its
-              backup takes over its duties, later the main server restarts and requests the server
-              (the former backup) to stop operating.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="backup-group-name" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. used for replication, if set, (remote) backup servers will only pair
-              with live servers with matching backup-group-name
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="scale-down-group-name" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. used for scaling down, if set, a live server will only send messages
-              to another live server with matching scale-down-group-name
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.allow-fail-back">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. The delay to wait before fail-back occurs on (live's) restart.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="failover-on-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.allow-fail-back">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. Will this backup server come live on a normal server shutdown.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="scale-down" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.scale-down">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt;
-              is not also used. Will this server send its messages to another live server in the
-              cluster when shut-down cleanly.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="shared-store" type="xsd:boolean" default="false"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.mode.shared" hq:field_name="DEFAULT_SHARED_STORE">
-            <xsd:documentation>
-              DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not
-              also used. 'shared-store' applies to live and backup pairs, and it indicates if the live/backup
-              pair share storage or if the data is replicated among them.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="persist-delivery-count-before-delivery" type="xsd:boolean" default="false"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.delivery.count.persistence"
-                          hq:field_name="DEFAULT_PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY">
-            <xsd:documentation>True means that the delivery count is persisted before delivery.
-            False means that this only happens after a message has been cancelled.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="connectors" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring-transports.connectors">
-            <xsd:documentation>a list of remoting connectors configurations to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="connector" maxOccurs="unbounded" minOccurs="0">
-                <xsd:complexType>
-                  <xsd:sequence>
-                    <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">
-                      <xsd:annotation>
-                        <xsd:documentation>Name of the ConnectorFactory implementation</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                    <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
-                      <xsd:annotation>
-                        <xsd:documentation>A key-value pair used to configure the connector. A connector
-                        can have many param's</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                  </xsd:sequence>
-                  <xsd:attribute name="name" type="xsd:ID" use="required">
-                  <xsd:annotation>
-                    <xsd:documentation>Name of the connector</xsd:documentation>
-                  </xsd:annotation>
-                  </xsd:attribute>
-                </xsd:complexType>
-              </xsd:element>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-        <xsd:element maxOccurs="1" minOccurs="0" name="acceptors">
-          <xsd:annotation hq:linkend="configuring-transports.acceptors">
-            <xsd:documentation>a list of remoting acceptors to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="acceptor" maxOccurs="unbounded" minOccurs="1">
-                <xsd:complexType>
-                  <xsd:sequence>
-                    <xsd:element name="factory-class" type="xsd:string" maxOccurs="1" minOccurs="1">
-                      <xsd:annotation>
-                        <xsd:documentation>Name of the AcceptorFactory implementation</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                    <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
-                      <xsd:annotation>
-                        <xsd:documentation>
-                          A key-value pair used to configure the acceptor. An acceptor can have many
-                        param</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                  </xsd:sequence>
-                  <xsd:attribute name="name" type="xsd:string" use="optional">
-                    <xsd:annotation>
-                      <xsd:documentation>Name of the acceptor</xsd:documentation>
-                    </xsd:annotation>
-                  </xsd:attribute>
-                </xsd:complexType>
-              </xsd:element>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-        <xsd:element maxOccurs="1" minOccurs="0" name="broadcast-groups">
-          <xsd:annotation hq:linkend="clusters">
-            <xsd:documentation>a list of broadcast groups to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element ref="broadcast-group" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-        <xsd:element maxOccurs="1" minOccurs="0" name="discovery-groups">
-          <xsd:annotation hq:linkend="clusters">
-            <xsd:documentation>a list of discovery groups to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element maxOccurs="unbounded" minOccurs="0" ref="discovery-group">
-                <xsd:annotation>
-                  <xsd:documentation>a discovery group specification element</xsd:documentation>
-                </xsd:annotation>
-              </xsd:element>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-        <xsd:element name="diverts" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="diverts">
-            <xsd:documentation>a list of diverts to use
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="divert" type="divertType" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-
-        <!-- QUEUES -->
-        <xsd:element name="queues" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="predefined.queues">
-            <xsd:documentation>a list of pre configured queues to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="queue" maxOccurs="unbounded" minOccurs="0">
-                <xsd:complexType>
-                  <xsd:all>
-                    <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
-                      <xsd:annotation>
-                        <xsd:documentation>address for the queue</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                    <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
-                    <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-                      <xsd:annotation>
-                        <xsd:documentation>whether the queue is durable (persistent)</xsd:documentation>
-                      </xsd:annotation>
-                    </xsd:element>
-                  </xsd:all>
-                  <xsd:attribute name="name" type="xsd:ID" use="required">
-                      <xsd:annotation>
-                        <xsd:documentation>unique name of this queue</xsd:documentation>
-                      </xsd:annotation>
-                  </xsd:attribute>
-               </xsd:complexType>
-              </xsd:element>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-        <xsd:element name="bridges" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="core-bridges">
-            <xsd:documentation>a list of bridges to create
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="bridge" type="bridgeType" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-
-         <xsd:element name="ha-policy" type="haPolicyType" maxOccurs="1" minOccurs="0">
-            <xsd:annotation hq:linkend="ha-policy">
-               <xsd:documentation>The HA policy of this server
+         <xsd:element name="name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Node name. If set, it will be used in topology notifications.
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
 
-        <xsd:element name="cluster-connections" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters">
-            <xsd:documentation>a list of cluster connections
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="cluster-connection" type="cluster-connectionType" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
+         <xsd:element name="resolve-protocols" type="xsd:boolean" default="true" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="resolveProtocols" hq:field_name="DEFAULT_RESOLVE_PROTOCOLS">
+               <xsd:documentation>
+                  If true then the HornetQ Server will make use of any Protocol Managers that are in available on the
+                  classpath. If false then only the core protocol will be available, unless in Embedded mode where users
+                  can inject their own Protocol Managers.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="grouping-handler" type="groupingHandlerType" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="message-grouping">
-            <xsd:documentation>Message Group configuration</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="clustered" type="xsd:boolean" default="false" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="clusters">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated and its value will be ignored (HQ221038). A HornetQ server will
+                  be "clustered" when its configuration contain a cluster-configuration.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="paging-directory" type="xsd:string" default="data/paging"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="paging.main.config" hq:field_name="DEFAULT_PAGING_DIR">
-            <xsd:documentation>the directory to store paged messages in</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="check-for-live-server" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="hq.check-for-live-server">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Whether to check the cluster for a (live) server using our own server ID when starting up. This
+                  option is only necessary for performing 'fail-back' on replicating servers. Strictly speaking this
+                  setting only applies to live servers and not to backups.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="bindings-directory" type="xsd:string" default="data/bindings" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.bindings.journal"
-                          hq:field_name="DEFAULT_BINDINGS_DIRECTORY">
-            <xsd:documentation>the directory to store the persisted bindings to</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="file-deployment-enabled" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="using-server.configuration"
+                            hq:field_name="DEFAULT_FILE_DEPLOYMENT_ENABLED">
+               <xsd:documentation>
+                  true means that the server will load configuration from the configuration files
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="create-bindings-dir" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.bindings.journal"
-                          hq:field_name="DEFAULT_CREATE_BINDINGS_DIR">
-            <xsd:documentation>true means that the server will create the bindings directory on
-            start up
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="persistence-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="persistence.enabled" hq:field_name="DEFAULT_PERSISTENCE_ENABLED">
+               <xsd:documentation>
+                  true means that the server will use the file based journal for persistence.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="page-max-concurrent-io" type="xsd:int" default="5" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="paging.mode" hq:field_name="DEFAULT_MAX_CONCURRENT_PAGE_IO">
-            <xsd:documentation>The max number of concurrent reads allowed on paging
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="scheduled-thread-pool-max-size" type="xsd:int" default="5" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="server.scheduled.thread.pool"
+                            hq:field_name="DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE">
+               <xsd:documentation>
+                  Maximum number of threads to use for the scheduled thread pool
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-directory" type="xsd:string" default="data/journal"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-directory"
-                          hq:field_name="DEFAULT_JOURNAL_DIR">
-            <xsd:documentation>the directory to store the journal files in</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="thread-pool-max-size" type="xsd:int" default="30" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="server.scheduled.thread.pool"
+                            hq:field_name="DEFAULT_THREAD_POOL_MAX_SIZE">
+               <xsd:documentation>
+                  Maximum number of threads to use for the thread pool. -1 means 'no limits'.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="create-journal-dir" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.create-journal-dir"
-                          hq:field_name="DEFAULT_CREATE_JOURNAL_DIR">
-            <xsd:documentation>true means that the journal directory will be created
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="security-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="security" hq:field_name="DEFAULT_SECURITY_ENABLED">
+               <xsd:documentation>
+                  true means that security is enabled
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-type" default="ASYNCIO" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-type">
-            <xsd:documentation>the type of journal to use
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:simpleType>
-            <xsd:restriction base="xsd:string">
-              <xsd:enumeration value="ASYNCIO" />
-              <xsd:enumeration value="NIO" />
-            </xsd:restriction>
-          </xsd:simpleType>
-        </xsd:element>
+         <xsd:element name="security-invalidation-interval" type="xsd:long" default="10000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="security" hq:field_name="DEFAULT_SECURITY_INVALIDATION_INTERVAL">
+               <xsd:documentation>
+                  how long (in ms) to wait before invalidating the security cache
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-buffer-timeout" type="xsd:long" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-buffer-timeout">
-            <xsd:documentation>The timeout (in nanoseconds) used to flush internal buffers on the
-            journal. The exact default value depend on whether the
-            journal is ASYNCIO or NIO.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="journal-lock-acquisition-timeout" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="using-server.configuration"
+                            hq:field_name="DEFAULT_JOURNAL_LOCK_ACQUISITION_TIMEOUT">
+               <xsd:documentation>
+                  how long (in ms) to wait to acquire a file lock on the journal
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-buffer-size" type="xsd:long" default="501760" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-buffer-size"
-                          hq:default="(490 KiB)">
-            <xsd:documentation>The size of the internal buffer on the journal in KiB.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="wild-card-routing-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="wildcard-routing" hq:field_name="DEFAULT_WILDCARD_ROUTING_ENABLED">
+               <xsd:documentation>
+                  true means that the server supports wild card routing
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-sync-transactional" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-sync-transactional"
-                          hq:field_name="DEFAULT_JOURNAL_SYNC_TRANSACTIONAL">
-            <xsd:documentation>if true wait for transaction data to be synchronized to the journal
-            before returning response to client
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="management-address" type="xsd:string" default="jms.queue.hornetq.management" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="management.core.configuration"
+                            hq:field_name="DEFAULT_MANAGEMENT_ADDRESS"
+                            hq:type="SimpleString">
+               <xsd:documentation>
+                  the name of the management address to send management messages to. It is prefixed with "jms.queue" so
+                  that JMS clients can send messages to it.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-sync-non-transactional" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-sync-non-transactional"
-                          hq:field_name="DEFAULT_JOURNAL_SYNC_NON_TRANSACTIONAL">
-            <xsd:documentation>if true wait for non transaction data to be synced to the journal
-            before returning response to client.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="management-notification-address" type="xsd:string" default="hornetq.notifications"
+                      maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="management.notifications.core.configuration"
+                            hq:field_name="DEFAULT_MANAGEMENT_NOTIFICATION_ADDRESS"
+                            hq:type="SimpleString">
+               <xsd:documentation>
+                  the name of the address that consumers bind to receive management notifications
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="log-journal-write-rate" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:field_name="DEFAULT_JOURNAL_LOG_WRITE_RATE">
-            <xsd:documentation>Whether to log messages about the journal write rate</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="cluster-user" type="xsd:string" default="HORNETQ.CLUSTER.ADMIN.USER" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="clusters" hq:field_name="DEFAULT_CLUSTER_USER">
+               <xsd:documentation>
+                  Cluster username. It applies to all cluster configurations.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-file-size" default="10485760" type="xsd:int" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-file-size"
-                          hq:default="(10 * 1024 * 1024 - 10 MiB)"
-                          hq:field_name="DEFAULT_JOURNAL_FILE_SIZE">
-            <xsd:documentation>the size (in bytes) of each journal file
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="cluster-password" maxOccurs="1" minOccurs="0" type="xsd:string" default="CHANGE ME!!">
+            <xsd:annotation hq:linkend="clusters" hq:field_name="DEFAULT_CLUSTER_PASSWORD">
+               <xsd:documentation>
+                  Cluster password. It applies to all cluster configurations.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-min-files" type="xsd:int" default="2"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-min-files"
-                          hq:field_name="DEFAULT_JOURNAL_MIN_FILES">
-            <xsd:documentation>how many journal files to pre-create
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="replication-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Name of the cluster configuration to use for replication. This setting is only necessary in case
+                  you configure multiple cluster connections. It is used by a replicating backups and by live servers
+                  that may attempt fail-back.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-compact-percentage" type="xsd:int" default="30" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-compact-percentage"
-                          hq:field_name="DEFAULT_JOURNAL_COMPACT_PERCENTAGE">
-            <xsd:documentation>The percentage of live data on which we consider compacting the
-            journal
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="scale-down-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Name of the cluster configuration to use for scaling down. This setting is only necessary in
+                  case you configure multiple cluster connections.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-compact-min-files" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-compact-min-files"
-                          hq:field_name="DEFAULT_JOURNAL_COMPACT_MIN_FILES">
-            <xsd:documentation>The minimal number of data files before we can start compacting
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. This specifies how many times a replicated backup server can restart after moving its files on
+                  start. Once there are this number of backup journal files the server will stop permanently after if
+                  fails back.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="journal-max-io" type="xsd:int" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuring.message.journal.journal-max-io">
-            <xsd:documentation>the maximum number of write requests that can be in the AIO queue at
-            any one time. Default is 500 for AIO and 1 for NIO.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="password-codec" type="xsd:string"
+                      default="org.hornetq.utils.DefaultSensitiveStringCodec" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuration.masked-password">
+               <xsd:documentation>
+                  Class name and its parameters for the Decoder used to decode the masked password. Ignored if
+                  mask-password is false. The format of this property is a full qualified class name optionally followed
+                  by key/value pairs.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="perf-blast-pages" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="XXX" hq:field_name="DEFAULT_JOURNAL_PERF_BLAST_PAGES">
-            <xsd:documentation>XXX Only meant to be used by project developers</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="mask-password" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuration.masked-password" hq:field_name="DEFAULT_MASK_PASSWORD">
+               <xsd:documentation>
+                  This option controls whether passwords in server configuration need be masked. If set to "true" the
+                  passwords are masked.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="run-sync-speed-test" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="XXX" hq:field_name="DEFAULT_RUN_SYNC_SPEED_TEST">
-            <xsd:documentation>XXX Only meant to be used by project developers</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="log-delegate-factory-class-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="XXX">
+               <xsd:documentation>
+                  XXX
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="server-dump-interval" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="XXX" hq:default="(ms)"
-                          hq:field_name="DEFAULT_SERVER_DUMP_INTERVAL">
-            <xsd:documentation>Interval to log server specific information (e.g. memory usage
-            etc)</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="jmx-management-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="management.jmx.configuration"
+                            hq:field_name="DEFAULT_JMX_MANAGEMENT_ENABLED">
+               <xsd:documentation>
+                  true means that the management API is available via JMX
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="memory-warning-threshold" type="xsd:int" default="25" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="perf-tuning.memory"
-                          hq:field_name="DEFAULT_MEMORY_WARNING_THRESHOLD">
-            <xsd:documentation>Percentage of available memory which will trigger a warning log
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="jmx-domain" type="xsd:string" default="org.hornetq" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="management.jmx.configuration" hq:field_name="DEFAULT_JMX_DOMAIN">
+               <xsd:documentation>
+                  the JMX domain used to registered HornetQ MBeans in the MBeanServer
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="memory-measure-interval" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="perf-tuning.memory" hq:default="(ms)"
-                          hq:field_name="DEFAULT_MEMORY_MEASURE_INTERVAL">
-            <xsd:documentation>frequency to sample JVM memory in ms (or -1 to disable memory sampling)</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="message-counter-enabled" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.counters" hq:field_name="DEFAULT_MESSAGE_COUNTER_ENABLED">
+               <xsd:documentation>
+                  true means that message counters are enabled
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="large-messages-directory" type="xsd:string" default="data/largemessages"
-                     maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="large.message.configuring" hq:field_name="DEFAULT_LARGE_MESSAGES_DIR">
-            <xsd:documentation>the directory to store large messages
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="message-counter-sample-period" type="xsd:long" default="10000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.counters"
+                            hq:field_name="DEFAULT_MESSAGE_COUNTER_SAMPLE_PERIOD">
+               <xsd:documentation>
+                  the sample period (in ms) to use for message counters
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="security-settings" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="security.settings.roles">
-            <xsd:documentation>a list of security settings
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="security-setting" maxOccurs="unbounded" minOccurs="0">
-                <xsd:complexType>
-                  <xsd:annotation>
-                    <xsd:documentation>a permission to add to the matched addresses</xsd:documentation>
-                  </xsd:annotation>
-                  <xsd:sequence>
-                    <xsd:element name="permission" maxOccurs="unbounded" minOccurs="0">
-                      <xsd:complexType>
-                        <xsd:attribute name="type" type="xsd:string" use="required">
-                          <xsd:annotation>
-                            <xsd:documentation>the type of permission</xsd:documentation>
-                          </xsd:annotation>
+         <xsd:element name="message-counter-max-day-history" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.counters" hq:default="(days)"
+                            hq:field_name="DEFAULT_MESSAGE_COUNTER_MAX_DAY_HISTORY">
+               <xsd:documentation>
+                  how many days to keep message counter history
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="connection-ttl-override" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl.override"
+                            hq:field_name="DEFAULT_CONNECTION_TTL_OVERRIDE">
+               <xsd:documentation>
+                  if set, this will override how long (in ms) to keep a connection alive without receiving a ping. -1
+                  disables this setting.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="async-connection-execution-enabled" type="xsd:boolean" default="true" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl.async-connection-execution"
+                            hq:field_name="DEFAULT_ASYNC_CONNECTION_EXECUTION_ENABLED">
+               <xsd:documentation>
+                  should certain incoming packets on the server be handed off to a thread from the thread pool for
+                  processing or should they be handled on the remoting thread?
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="transaction-timeout" type="xsd:long" default="300000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="transaction-config" hq:field_name="DEFAULT_TRANSACTION_TIMEOUT">
+               <xsd:documentation>
+                  how long (in ms) before a transaction can be removed from the resource manager after create time
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="transaction-timeout-scan-period" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="transaction-config" hq:field_name="DEFAULT_TRANSACTION_TIMEOUT_SCAN_PERIOD">
+               <xsd:documentation>
+                  how often (in ms) to scan for timeout transactions
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="message-expiry-scan-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.expiry.reaper" hq:field_name="DEFAULT_MESSAGE_EXPIRY_SCAN_PERIOD">
+               <xsd:documentation>
+                  how often (in ms) to scan for expired messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="message-expiry-thread-priority" type="xsd:int" default="3" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.expiry.reaper"
+                            hq:field_name="DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY">
+               <xsd:documentation>
+                  the priority of the thread expiring messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="id-cache-size" type="xsd:int" default="20000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="duplicate.id.cache" hq:field_name="DEFAULT_ID_CACHE_SIZE">
+               <xsd:documentation>
+                  the size of the cache for pre-creating message ID's
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="persist-id-cache" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="duplicate.id.cache" hq:field_name="DEFAULT_PERSIST_ID_CACHE">
+               <xsd:documentation>
+                  true means that ID's are persisted to the journal
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="remoting-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="intercepting-operations">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored. Any interceptor specified here
+                  will be considered an "incoming" interceptor. See &lt;remoting-incoming-interceptors&gt; and &lt;remoting-outgoing-interceptors&gt;.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="remoting-incoming-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="intercepting-operations">
+               <xsd:documentation>
+                  a list of &lt;class-name/&gt; elements with the names of classes to use for interceptor incoming
+                  remoting packets
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="remoting-outgoing-interceptors" type="class-name-sequenceType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="intercepting-operations">
+               <xsd:documentation>
+                  a list of &lt;class-name/&gt; elements with the names of classes to use for interceptor outcoming
+                  remoting packets
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="backup" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha" hq:field_name="DEFAULT_BACKUP">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. It indicates whether this server is a backup server
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Whether a server will automatically stop when a another places a request to take over its place.
+                  The use case is when a regular server stops and its backup takes over its duties, later the main
+                  server restarts and requests the server (the former backup) to stop operating.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="backup-group-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. used for replication, if set, (remote) backup servers will only pair with live servers with
+                  matching backup-group-name
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="scale-down-group-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. used for scaling down, if set, a live server will only send messages to another live server with
+                  matching scale-down-group-name
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. The delay to wait before fail-back occurs on (live's) restart.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="failover-on-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Will this backup server come live on a normal server shutdown.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="scale-down" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.scale-down">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. Will this server send its messages to another live server in the
+                  cluster when shut-down cleanly.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="shared-store" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.mode.shared" hq:field_name="DEFAULT_SHARED_STORE">
+               <xsd:documentation>
+                  DEPRECATED. This option is deprecated, but it will still be honored if &lt;ha-policy&gt; is not also
+                  used. 'shared-store' applies to live and backup pairs, and it indicates if the live/backup pair share
+                  storage or if the data is replicated among them.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="persist-delivery-count-before-delivery" type="xsd:boolean" default="false" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.delivery.count.persistence"
+                            hq:field_name="DEFAULT_PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY">
+               <xsd:documentation>
+                  True means that the delivery count is persisted before delivery. False means that this only happens
+                  after a message has been cancelled.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring-transports.connectors">
+               <xsd:documentation>
+                  a list of remoting connectors configurations to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="connector" maxOccurs="unbounded" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:sequence>
+                           <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    Name of the ConnectorFactory implementation
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                           <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    A key-value pair used to configure the connector. A connector can have many param's
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                        </xsd:sequence>
+                        <xsd:attribute name="name" type="xsd:ID" use="required">
+                           <xsd:annotation>
+                              <xsd:documentation>
+                                 Name of the connector
+                              </xsd:documentation>
+                           </xsd:annotation>
                         </xsd:attribute>
-                        <xsd:attribute name="roles" type="xsd:string" use="required">
-                          <xsd:annotation>
-                            <xsd:documentation>a comma-separated list of roles to apply the
-                            permission to</xsd:documentation>
-                          </xsd:annotation>
+                     </xsd:complexType>
+                  </xsd:element>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element maxOccurs="1" minOccurs="0" name="acceptors">
+            <xsd:annotation hq:linkend="configuring-transports.acceptors">
+               <xsd:documentation>
+                  a list of remoting acceptors to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="acceptor" maxOccurs="unbounded" minOccurs="1">
+                     <xsd:complexType>
+                        <xsd:sequence>
+                           <xsd:element name="factory-class" type="xsd:string" maxOccurs="1" minOccurs="1">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    Name of the AcceptorFactory implementation
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                           <xsd:element name="param" type="paramType" maxOccurs="unbounded" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    A key-value pair used to configure the acceptor. An acceptor can have many param
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                        </xsd:sequence>
+                        <xsd:attribute name="name" type="xsd:string" use="optional">
+                           <xsd:annotation>
+                              <xsd:documentation>
+                                 Name of the acceptor
+                              </xsd:documentation>
+                           </xsd:annotation>
                         </xsd:attribute>
-                      </xsd:complexType>
-                    </xsd:element>
-                  </xsd:sequence>
-                  <xsd:attribute name="match" type="xsd:string" use="required">
-                  <xsd:annotation>
-                    <xsd:documentation>regular expression for matching security roles against
-                    addresses</xsd:documentation>
-                  </xsd:annotation>
-                  </xsd:attribute>
-                </xsd:complexType>
-              </xsd:element>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
+                     </xsd:complexType>
+                  </xsd:element>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
 
-        <xsd:element name="address-settings" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="queue-attributes.address-settings">
-            <xsd:documentation>a list of address settings
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element ref="address-setting" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
+         <xsd:element maxOccurs="1" minOccurs="0" name="broadcast-groups">
+            <xsd:annotation hq:linkend="clusters">
+               <xsd:documentation>
+                  a list of broadcast groups to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element ref="broadcast-group" maxOccurs="unbounded" minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
 
-        <xsd:element name="connector-services" maxOccurs="1" minOccurs="0">
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="connector-service" type="connector-serviceType" maxOccurs="unbounded" minOccurs="0" />
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
+         <xsd:element maxOccurs="1" minOccurs="0" name="discovery-groups">
+            <xsd:annotation hq:linkend="clusters">
+               <xsd:documentation>
+                  a list of discovery groups to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element maxOccurs="unbounded" minOccurs="0" ref="discovery-group">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           a discovery group specification element
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:element>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="diverts" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="diverts">
+               <xsd:documentation>
+                  a list of diverts to use
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="divert" type="divertType" maxOccurs="unbounded" minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+
+         <!-- QUEUES -->
+         <xsd:element name="queues" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="predefined.queues">
+               <xsd:documentation>
+                  a list of pre configured queues to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="queue" maxOccurs="unbounded" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:all>
+                           <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    address for the queue
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                           <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
+                           <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    whether the queue is durable (persistent)
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                        </xsd:all>
+                        <xsd:attribute name="name" type="xsd:ID" use="required">
+                           <xsd:annotation>
+                              <xsd:documentation>
+                                 unique name of this queue
+                              </xsd:documentation>
+                           </xsd:annotation>
+                        </xsd:attribute>
+                     </xsd:complexType>
+                  </xsd:element>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="bridges" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="core-bridges">
+               <xsd:documentation>
+                  a list of bridges to create
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="bridge" type="bridgeType" maxOccurs="unbounded" minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="ha-policy" type="haPolicyType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha-policy">
+               <xsd:documentation>
+                  The HA policy of this server
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="cluster-connections" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="clusters">
+               <xsd:documentation>
+                  a list of cluster connections
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="cluster-connection" type="cluster-connectionType" maxOccurs="unbounded"
+                               minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="grouping-handler" type="groupingHandlerType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="message-grouping">
+               <xsd:documentation>
+                  Message Group configuration
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="paging-directory" type="xsd:string" default="data/paging" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="paging.main.config" hq:field_name="DEFAULT_PAGING_DIR">
+               <xsd:documentation>
+                  the directory to store paged messages in
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="bindings-directory" type="xsd:string" default="data/bindings" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.bindings.journal"
+                            hq:field_name="DEFAULT_BINDINGS_DIRECTORY">
+               <xsd:documentation>
+                  the directory to store the persisted bindings to
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="create-bindings-dir" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.bindings.journal"
+                            hq:field_name="DEFAULT_CREATE_BINDINGS_DIR">
+               <xsd:documentation>
+                  true means that the server will create the bindings directory on start up
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="page-max-concurrent-io" type="xsd:int" default="5" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="paging.mode" hq:field_name="DEFAULT_MAX_CONCURRENT_PAGE_IO">
+               <xsd:documentation>
+                  The max number of concurrent reads allowed on paging
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-directory" type="xsd:string" default="data/journal" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-directory"
+                            hq:field_name="DEFAULT_JOURNAL_DIR">
+               <xsd:documentation>
+                  the directory to store the journal files in
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="create-journal-dir" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.create-journal-dir"
+                            hq:field_name="DEFAULT_CREATE_JOURNAL_DIR">
+               <xsd:documentation>
+                  true means that the journal directory will be created
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-type" default="ASYNCIO" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-type">
+               <xsd:documentation>
+                  the type of journal to use
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="ASYNCIO"/>
+                  <xsd:enumeration value="NIO"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+
+         <xsd:element name="journal-buffer-timeout" type="xsd:long" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-buffer-timeout">
+               <xsd:documentation>
+                  The timeout (in nanoseconds) used to flush internal buffers on the journal. The exact default value
+                  depend on whether the journal is ASYNCIO or NIO.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-buffer-size" type="xsd:long" default="501760" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-buffer-size"
+                            hq:default="(490 KiB)">
+               <xsd:documentation>
+                  The size of the internal buffer on the journal in KiB.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-sync-transactional" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-sync-transactional"
+                            hq:field_name="DEFAULT_JOURNAL_SYNC_TRANSACTIONAL">
+               <xsd:documentation>
+                  if true wait for transaction data to be synchronized to the journal before returning response to
+                  client
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-sync-non-transactional" type="xsd:boolean" default="true" maxOccurs="1"
+                      minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-sync-non-transactional"
+                            hq:field_name="DEFAULT_JOURNAL_SYNC_NON_TRANSACTIONAL">
+               <xsd:documentation>
+                  if true wait for non transaction data to be synced to the journal before returning response to client.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="log-journal-write-rate" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_JOURNAL_LOG_WRITE_RATE">
+               <xsd:documentation>
+                  Whether to log messages about the journal write rate
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-file-size" default="10485760" type="xsd:int" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-file-size"
+                            hq:default="(10 * 1024 * 1024 - 10 MiB)"
+                            hq:field_name="DEFAULT_JOURNAL_FILE_SIZE">
+               <xsd:documentation>
+                  the size (in bytes) of each journal file
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-min-files" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-min-files"
+                            hq:field_name="DEFAULT_JOURNAL_MIN_FILES">
+               <xsd:documentation>
+                  how many journal files to pre-create
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-compact-percentage" type="xsd:int" default="30" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-compact-percentage"
+                            hq:field_name="DEFAULT_JOURNAL_COMPACT_PERCENTAGE">
+               <xsd:documentation>
+                  The percentage of live data on which we consider compacting the journal
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-compact-min-files" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-compact-min-files"
+                            hq:field_name="DEFAULT_JOURNAL_COMPACT_MIN_FILES">
+               <xsd:documentation>
+                  The minimal number of data files before we can start compacting
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="journal-max-io" type="xsd:int" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="configuring.message.journal.journal-max-io">
+               <xsd:documentation>
+                  the maximum number of write requests that can be in the AIO queue at any one time. Default is 500 for
+                  AIO and 1 for NIO.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="perf-blast-pages" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="XXX" hq:field_name="DEFAULT_JOURNAL_PERF_BLAST_PAGES">
+               <xsd:documentation>
+                  XXX Only meant to be used by project developers
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="run-sync-speed-test" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="XXX" hq:field_name="DEFAULT_RUN_SYNC_SPEED_TEST">
+               <xsd:documentation>
+                  XXX Only meant to be used by project developers
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="server-dump-interval" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="XXX" hq:default="(ms)"
+                            hq:field_name="DEFAULT_SERVER_DUMP_INTERVAL">
+               <xsd:documentation>
+                  Interval to log server specific information (e.g. memory usage etc)
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="memory-warning-threshold" type="xsd:int" default="25" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="perf-tuning.memory"
+                            hq:field_name="DEFAULT_MEMORY_WARNING_THRESHOLD">
+               <xsd:documentation>
+                  Percentage of available memory which will trigger a warning log
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="memory-measure-interval" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="perf-tuning.memory" hq:default="(ms)"
+                            hq:field_name="DEFAULT_MEMORY_MEASURE_INTERVAL">
+               <xsd:documentation>
+                  frequency to sample JVM memory in ms (or -1 to disable memory sampling)
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="large-messages-directory" type="xsd:string" default="data/largemessages"
+                      maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="large.message.configuring" hq:field_name="DEFAULT_LARGE_MESSAGES_DIR">
+               <xsd:documentation>
+                  the directory to store large messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="security-settings" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="security.settings.roles">
+               <xsd:documentation>
+                  a list of security settings
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="security-setting" maxOccurs="unbounded" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:annotation>
+                           <xsd:documentation>
+                              a permission to add to the matched addresses
+                           </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:sequence>
+                           <xsd:element name="permission" maxOccurs="unbounded" minOccurs="0">
+                              <xsd:complexType>
+                                 <xsd:attribute name="type" type="xsd:string" use="required">
+                                    <xsd:annotation>
+                                       <xsd:documentation>
+                                          the type of permission
+                                       </xsd:documentation>
+                                    </xsd:annotation>
+                                 </xsd:attribute>
+                                 <xsd:attribute name="roles" type="xsd:string" use="required">
+                                    <xsd:annotation>
+                                       <xsd:documentation>
+                                          a comma-separated list of roles to apply the permission to
+                                       </xsd:documentation>
+                                    </xsd:annotation>
+                                 </xsd:attribute>
+                              </xsd:complexType>
+                           </xsd:element>
+                        </xsd:sequence>
+                        <xsd:attribute name="match" type="xsd:string" use="required">
+                           <xsd:annotation>
+                              <xsd:documentation>
+                                 regular expression for matching security roles against addresses
+                              </xsd:documentation>
+                           </xsd:annotation>
+                        </xsd:attribute>
+                     </xsd:complexType>
+                  </xsd:element>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="address-settings" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="queue-attributes.address-settings">
+               <xsd:documentation>
+                  a list of address settings
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element ref="address-setting" maxOccurs="unbounded" minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+
+         <xsd:element name="connector-services" maxOccurs="1" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="connector-service" type="connector-serviceType" maxOccurs="unbounded"
+                               minOccurs="0"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
       </xsd:all>
-    </xsd:complexType>
+   </xsd:complexType>
 
-  <xsd:element name="local-bind-address" type="xsd:string">
-    <xsd:annotation hq:default="wildcard IP address chosen by the kernel">
-      <xsd:documentation>local bind address that the datagram socket is bound to</xsd:documentation>
-    </xsd:annotation>
-  </xsd:element>
+   <xsd:element name="local-bind-address" type="xsd:string">
+      <xsd:annotation hq:default="wildcard IP address chosen by the kernel">
+         <xsd:documentation>
+            local bind address that the datagram socket is bound to
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
 
-  <xsd:element name="local-bind-port" type="xsd:int" default="-1">
-    <xsd:annotation hq:default="(anonymous port)">
-      <xsd:documentation>
-        local port to which the datagram socket is bound to
-      </xsd:documentation>
-    </xsd:annotation>
-  </xsd:element>
+   <xsd:element name="local-bind-port" type="xsd:int" default="-1">
+      <xsd:annotation hq:default="(anonymous port)">
+         <xsd:documentation>
+            local port to which the datagram socket is bound to
+         </xsd:documentation>
+      </xsd:annotation>
+   </xsd:element>
 
-  <!-- BROADCAST GROUP CONFIGURATION -->
-  <xsd:element name="broadcast-group">
-    <xsd:complexType>
+   <!-- BROADCAST GROUP CONFIGURATION -->
+   <xsd:element name="broadcast-group">
+      <xsd:complexType>
+         <xsd:sequence>
+            <!-- XXX these 2 local-* here...-->
+            <xsd:element ref="local-bind-address" maxOccurs="1" minOccurs="0"/>
+            <xsd:element ref="local-bind-port" maxOccurs="1" minOccurs="0"/>
+            <xsd:element name="group-address" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     multicast address to which the data will be broadcast
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="group-port" type="xsd:int" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     UDP port number used for broadcasting
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="broadcast-period" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:default="(in milliseconds)" hq:field_name="DEFAULT_BROADCAST_PERIOD">
+                  <xsd:documentation>
+                     period in milliseconds between consecutive broadcasts
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="jgroups-file" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="clusters.jgroups-file">
+                  <xsd:documentation>
+                     Name of JGroups configuration file. If specified, the server uses JGroups for broadcasting.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="jgroups-channel" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="clusters.jgroups-example">
+                  <xsd:documentation>
+                     Name of JGroups Channel. If specified, the server uses the named channel for broadcasting.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
+         </xsd:sequence>
+
+         <xsd:attribute name="name" type="xsd:ID" use="required">
+            <xsd:annotation>
+               <xsd:documentation>
+                  a unique name for the broadcast group
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:element name="discovery-group">
+      <xsd:complexType>
+         <xsd:all>
+            <!-- XXX -->
+            <xsd:element name="group-address" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Multicast IP address of the group to listen on
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="group-port" type="xsd:int" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     UDP port number of the multi cast group
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="jgroups-file" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="clusters.jgroups-file">
+                  <xsd:documentation>
+                     Name of a JGroups configuration file. If specified, the server uses JGroups for discovery.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="jgroups-channel" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="clusters.jgroups-example">
+                  <xsd:documentation>
+                     Name of a JGroups Channel. If specified, the server uses the named channel for discovery.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="refresh-timeout" type="xsd:int" default="10000" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="configuration.discovery-group.refresh-timeout"
+                               hq:default="(in milliseconds)"
+                               hq:field_name="DEFAULT_BROADCAST_REFRESH_TIMEOUT">
+                  <xsd:documentation>
+                     Period the discovery group waits after receiving the last broadcast from a particular server before
+                     removing that servers connector pair entry from its list.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element ref="local-bind-address" maxOccurs="1" minOccurs="0"/>
+            <xsd:element ref="local-bind-port" maxOccurs="1" minOccurs="0"/>
+            <xsd:element name="initial-wait-timeout" type="xsd:int" default="10000" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:default="(milliseconds)" hq:linkend="XXX">
+                  <xsd:documentation>
+                     time to wait for an initial broadcast to give us at least one node in the cluster
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+         </xsd:all>
+
+         <xsd:attribute name="name" type="xsd:ID" use="required">
+            <xsd:annotation>
+               <xsd:documentation>
+                  a unique name for the discovery group
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:element name="discovery-group-ref">
+      <xsd:complexType>
+         <xsd:attribute name="discovery-group-name" type="xsd:IDREF"/>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:complexType name="class-name-sequenceType">
+      <xsd:annotation>
+         <xsd:documentation>
+            unlimited sequence of &lt;class-name/&gt;
+         </xsd:documentation>
+      </xsd:annotation>
       <xsd:sequence>
-        <!-- XXX these 2 local-* here...-->
-        <xsd:element ref="local-bind-address"  maxOccurs="1" minOccurs="0" />
-        <xsd:element ref="local-bind-port" maxOccurs="1" minOccurs="0"/>
-        <xsd:element name="group-address" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>multicast address to which the data will be broadcast</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xsd:string">
+            <xsd:annotation>
+               <xsd:documentation>
+                  the fully qualified name of the interceptor class
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:sequence>
+   </xsd:complexType>
 
-        <xsd:element name="group-port" type="xsd:int" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>UDP port number used for broadcasting</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+   <xsd:complexType name="paramType">
+      <xsd:attribute name="key" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               Key of a configuration parameter
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="value" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               Value of a configuration parameter
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
 
-        <xsd:element name="broadcast-period" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:default="(in milliseconds)" hq:field_name="DEFAULT_BROADCAST_PERIOD">
-            <xsd:documentation>period in milliseconds between consecutive broadcasts</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+   <!-- BRIDGE CONFIGURATION -->
+   <xsd:complexType name="bridgeType">
+      <xsd:sequence>
+         <xsd:element name="queue-name" type="xsd:IDREF" maxOccurs="1" minOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  name of queue that this bridge consumes from
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="jgroups-file" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters.jgroups-file">
-            <xsd:documentation>Name of JGroups configuration file. If specified, the server uses JGroups for broadcasting.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="forwarding-address" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  address to forward to. If omitted original address is used
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="jgroups-channel" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters.jgroups-example">
-            <xsd:documentation>Name of JGroups Channel. If specified, the server uses the named
-            channel for broadcasting.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="ha" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  whether this bridge supports fail-over
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
+         <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
+
+         <xsd:element name="transformer-class-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  optional name of transformer class
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="min-large-message-size" type="xsd:int" default="102400" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(bytes)">
+               <xsd:documentation>
+                  Any message larger than this size is considered a large message (to be sent in
+                  chunks)
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="check-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)">
+               <xsd:documentation>
+                  The period (in milliseconds) a bridge's client will check if it failed to receive a ping from the
+                  server. -1 disables this check.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="connection-ttl" type="xsd:long" default="60000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)" hq:field_name="DEFAULT_CONNECTION_TTL">
+               <xsd:documentation>
+                  how long to keep a connection alive in the absence of any data arriving from the client. This should
+                  be greater than the ping period.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(in milliseconds)">
+               <xsd:documentation>
+                  period (in ms) between successive retries
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="retry-interval-multiplier" type="xsd:double" default="1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_RETRY_INTERVAL_MULTIPLIER">
+               <xsd:documentation>
+                  multiplier to apply to successive retry intervals
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="max-retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_MAX_RETRY_INTERVAL">
+               <xsd:documentation>
+                  Limit to the retry-interval growth (due to retry-interval-multiplier)
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="initial-connect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_BRIDGE_INITIAL_CONNECT_ATTEMPTS">
+               <xsd:documentation>
+                  maximum number of initial connection attempts, -1 means 'no limits'
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="reconnect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_BRIDGE_RECONNECT_ATTEMPTS">
+               <xsd:documentation>
+                  maximum number of retry attempts, -1 means 'no limits'
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="failover-on-server-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  should failover be prompted if target server is cleanly shutdown?
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="use-duplicate-detection" type="xsd:boolean" default="true"
+                      maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_BRIDGE_DUPLICATE_DETECTION">
+               <xsd:documentation>
+                  should duplicate detection headers be inserted in forwarded messages?
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="confirmation-window-size" type="xsd:int" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(bytes, 1024 * 1024)">
+               <xsd:documentation>
+                  Once the bridge has received this many bytes, it sends a confirmation
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  username, if unspecified the cluster-user is used
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="password" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  password, if unspecified the cluster-password is used
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="reconnect-attempts-same-node" default="10" type="xsd:int"
+                      maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(int, 10)" hq:field_name="DEFAULT_BRIDGE_CONNECT_SAME_NODE">
+               <xsd:documentation>
+                  Upon reconnection this configures the number of time the same node on the topology will be retried
+                  before reseting the server locator and using the initial connectors
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:choice>
+            <xsd:element name="static-connectors" maxOccurs="1" minOccurs="1">
+               <xsd:complexType>
+                  <xsd:sequence>
+                     <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
+                  </xsd:sequence>
+               </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="1">
+               <xsd:complexType>
+                  <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           name of discovery group used by this bridge
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:attribute>
+               </xsd:complexType>
+            </xsd:element>
+         </xsd:choice>
       </xsd:sequence>
 
       <xsd:attribute name="name" type="xsd:ID" use="required">
-        <xsd:annotation>
-          <xsd:documentation>a unique name for the broadcast group</xsd:documentation>
-        </xsd:annotation>
+         <xsd:annotation>
+            <xsd:documentation>
+               unique name for this bridge
+            </xsd:documentation>
+         </xsd:annotation>
       </xsd:attribute>
+   </xsd:complexType>
 
-    </xsd:complexType>
-  </xsd:element>
 
-  <xsd:element name="discovery-group">
-    <xsd:complexType>
+   <!-- CLUSTER CONNECTION CONFIGURATION -->
+
+   <xsd:complexType name="cluster-connectionType">
+      <xsd:sequence>
+         <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  name of the address this cluster connection applies to
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="connector-ref" type="xsd:string" maxOccurs="1" minOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of the connector reference to use.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="check-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)"
+                            hq:field_name="DEFAULT_CLUSTER_FAILURE_CHECK_PERIOD">
+               <xsd:documentation>
+                  The period (in milliseconds) used to check if the cluster connection has failed to receive pings from
+                  another server
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="connection-ttl" type="xsd:long" default="60000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)"
+                            hq:field_name="DEFAULT_CLUSTER_CONNECTION_TTL">
+               <xsd:documentation>
+                  how long to keep a connection alive in the absence of any data arriving from the client
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="min-large-message-size" type="xsd:int" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="large-messages" hq:default="(bytes)">
+               <xsd:documentation>
+                  Messages larger than this are considered large-messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="call-timeout" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(ms)">
+               <xsd:documentation>
+                  How long to wait for a reply
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="retry-interval" type="xsd:long" default="500" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RETRY_INTERVAL">
+               <xsd:documentation>
+                  period (in ms) between successive retries
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="retry-interval-multiplier" type="xsd:double" default="1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RETRY_INTERVAL_MULTIPLIER">
+               <xsd:documentation>
+                  multiplier to apply to the retry-interval
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="max-retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_MAX_RETRY_INTERVAL">
+               <xsd:documentation>
+                  Maximum value for retry-interval
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="initial-connect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_INITIAL_CONNECT_ATTEMPTS">
+               <xsd:documentation>
+                  How many attempts should be made to connect initially
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="reconnect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RECONNECT_ATTEMPTS">
+               <xsd:documentation>
+                  How many attempts should be made to reconnect after failure
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="use-duplicate-detection" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_DUPLICATE_DETECTION">
+               <xsd:documentation>
+                  should duplicate detection headers be inserted in forwarded messages?
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="forward-when-no-consumers" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_FORWARD_WHEN_NO_CONSUMERS">
+               <xsd:documentation>
+                  should messages be load balanced if there are no matching consumers on target?
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="max-hops" type="xsd:int" default="1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_MAX_HOPS">
+               <xsd:documentation>
+                  maximum number of hops cluster topology is propagated
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="confirmation-window-size" type="xsd:int" default="1048576" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="client-reconnection">
+               <xsd:documentation>
+                  The size (in bytes) of the window used for confirming data from the server connected to.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="call-failover-timeout" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="clusters.cluster-connections" hq:default="(ms)">
+               <xsd:documentation>
+                  How long to wait for a reply if in the middle of a fail-over. -1 means wait forever.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="notification-interval" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(ms)" hq:field_name="DEFAULT_CLUSTER_NOTIFICATION_INTERVAL">
+               <xsd:documentation>
+                  how often the cluster connection will notify the cluster of its existence right after joining the
+                  cluster
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="notification-attempts" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_CLUSTER_NOTIFICATION_ATTEMPTS">
+               <xsd:documentation>
+                  how many times this cluster connection will notify the cluster of its existence right after joining
+                  the cluster
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="scale-down-connector" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The connector to use for scaling down or when as backup in SCALE_DOWN mode
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:choice>
+            <xsd:element name="static-connectors" maxOccurs="1" minOccurs="0">
+               <xsd:complexType>
+                  <xsd:sequence>
+                     <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
+                  </xsd:sequence>
+                  <xsd:attribute name="allow-direct-connections-only" default="false" type="xsd:boolean"
+                                 use="optional">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           restricts cluster connections to the listed connector-ref's
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:attribute>
+               </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="0">
+               <xsd:complexType>
+                  <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           XXX -- this is a duplicate...
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:attribute>
+               </xsd:complexType>
+            </xsd:element>
+         </xsd:choice>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:ID" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               unique name for this cluster connection
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
+
+   <!-- DIVERT CONFIGURATION TYPE -->
+   <xsd:complexType name="divertType">
       <xsd:all>
-        <!-- XXX -->
-        <xsd:element name="group-address" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>Multicast IP address of the group to listen on</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-        <xsd:element name="group-port" type="xsd:int" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>UDP port number of the multi cast group</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="transformer-class-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  an optional class name of a transformer
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="jgroups-file" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters.jgroups-file">
-            <xsd:documentation>Name of a JGroups configuration file. If specified, the server uses JGroups for discovery.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="exclusive" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_DIVERT_EXCLUSIVE">
+               <xsd:documentation>
+                  whether this is an exclusive divert
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="jgroups-channel" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters.jgroups-example">
-            <xsd:documentation>Name of a JGroups Channel. If specified, the server uses the named channel for discovery.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="routing-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  the routing name for the divert
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element name="refresh-timeout" type="xsd:int" default="10000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="configuration.discovery-group.refresh-timeout"
-                          hq:default="(in milliseconds)"
-                          hq:field_name="DEFAULT_BROADCAST_REFRESH_TIMEOUT">
-            <xsd:documentation>Period the discovery group waits after receiving the last broadcast
-            from a particular server before removing that servers connector pair entry from its
-            list.</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  the address this divert will divert from
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
 
-        <xsd:element ref="local-bind-address"   maxOccurs="1" minOccurs="0" />
-        <xsd:element ref="local-bind-port"   maxOccurs="1" minOccurs="0" />
-        <xsd:element name="initial-wait-timeout" type="xsd:int" default="10000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:default="(milliseconds)" hq:linkend="XXX">
-            <xsd:documentation>time to wait for an initial broadcast to give us at least one node in the cluster</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="forwarding-address" type="xsd:string" maxOccurs="1" minOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  the forwarding address for the divert
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
       </xsd:all>
 
       <xsd:attribute name="name" type="xsd:ID" use="required">
-        <xsd:annotation>
-          <xsd:documentation>a unique name for the discovery group</xsd:documentation>
-        </xsd:annotation>
+         <xsd:annotation>
+            <xsd:documentation>
+               a unique name for the divert
+            </xsd:documentation>
+         </xsd:annotation>
       </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
 
-  <xsd:element name="discovery-group-ref">
-    <xsd:complexType>
-      <xsd:attribute name="discovery-group-name" type="xsd:IDREF" />
-    </xsd:complexType>
-  </xsd:element>
+   </xsd:complexType>
 
-  <xsd:complexType name="class-name-sequenceType">
-    <xsd:annotation>
-      <xsd:documentation>unlimited sequence of &lt;class-name/&gt;</xsd:documentation>
-    </xsd:annotation>
-    <xsd:sequence>
-      <xsd:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xsd:string">
-        <xsd:annotation>
-          <xsd:documentation>the fully qualified name of the interceptor class</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-    </xsd:sequence>
-  </xsd:complexType>
-
-  <xsd:complexType name="paramType">
-    <xsd:attribute name="key" type="xsd:string" use="required">
-      <xsd:annotation>
-        <xsd:documentation>Key of a configuration parameter</xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-    <xsd:attribute name="value" type="xsd:string" use="required">
-      <xsd:annotation>
-      <xsd:documentation>Value of a configuration parameter</xsd:documentation>
-    </xsd:annotation>
-    </xsd:attribute>
-  </xsd:complexType>
-
-  <!-- BRIDGE CONFIGURATION -->
-  <xsd:complexType name="bridgeType">
-    <xsd:sequence>
-      <xsd:element name="queue-name" type="xsd:IDREF" maxOccurs="1" minOccurs="1"  >
-        <xsd:annotation>
-          <xsd:documentation>name of queue that this bridge consumes from
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="forwarding-address" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>address to forward to. If omitted original address is
-          used</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="ha" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>whether this bridge supports fail-over</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
-
-      <xsd:element name="transformer-class-name" type="xsd:string"    maxOccurs="1" minOccurs="0"    >
-        <xsd:annotation>
-          <xsd:documentation>optional name of transformer class</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="min-large-message-size" type="xsd:int" default="102400" maxOccurs="1" minOccurs="0">
-      <xsd:annotation hq:default="(bytes)">
-        <xsd:documentation>Any message larger than this size is considered a large message (to be sent in
-        chunks)</xsd:documentation>
-      </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="check-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)">
-          <xsd:documentation>The period (in milliseconds) a bridge's client will check if it failed
-          to receive a ping from the server. -1 disables this check.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="connection-ttl" type="xsd:long" default="60000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)" hq:field_name="DEFAULT_CONNECTION_TTL">
-          <xsd:documentation>how long to keep a connection alive in the absence of any data arriving
-          from the client. This should be greater than the ping period.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(in milliseconds)">
-          <xsd:documentation>period (in ms) between successive retries</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="retry-interval-multiplier" type="xsd:double" default="1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_RETRY_INTERVAL_MULTIPLIER">
-          <xsd:documentation>multiplier to apply to successive retry intervals</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="max-retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_MAX_RETRY_INTERVAL">
-          <xsd:documentation>Limit to the retry-interval growth (due to retry-interval-multiplier)</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="initial-connect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_BRIDGE_INITIAL_CONNECT_ATTEMPTS">
-          <xsd:documentation>maximum number of initial connection attempts, -1 means 'no limits'</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="reconnect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_BRIDGE_RECONNECT_ATTEMPTS">
-          <xsd:documentation>maximum number of retry attempts, -1 means 'no limits'</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="failover-on-server-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>should failover be prompted if target server is cleanly
-          shutdown?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="use-duplicate-detection" type="xsd:boolean" default="true"
-                   maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_BRIDGE_DUPLICATE_DETECTION">
-          <xsd:documentation>should duplicate detection headers be inserted in forwarded
-          messages?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="confirmation-window-size" type="xsd:int"     maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(bytes, 1024 * 1024)">
-          <xsd:documentation>Once the bridge has received this many
-          bytes, it sends a confirmation</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>username, if unspecified the cluster-user is used</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="password" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>password, if unspecified the cluster-password is used</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="reconnect-attempts-same-node" default="10" type="xsd:int"
-                   maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(int, 10)" hq:field_name="DEFAULT_BRIDGE_CONNECT_SAME_NODE">
-          <xsd:documentation>
-            Upon reconnection this configures the number of time the same node on the topology will
-            be retried before reseting the server locator and using the initial
-            connectors</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:choice>
-        <xsd:element name="static-connectors" maxOccurs="1" minOccurs="1">
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
-            </xsd:sequence>
-          </xsd:complexType>
-        </xsd:element>
-        <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="1">
-          <xsd:complexType>
-            <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
-              <xsd:annotation>
-                <xsd:documentation>name of discovery group used by this bridge</xsd:documentation>
-              </xsd:annotation>
-            </xsd:attribute>
-          </xsd:complexType>
-        </xsd:element>
-      </xsd:choice>
-    </xsd:sequence>
-
-    <xsd:attribute name="name" type="xsd:ID" use="required">
-      <xsd:annotation>
-        <xsd:documentation>unique name for this bridge
-        </xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-  </xsd:complexType>
-
-
-  <!-- CLUSTER CONNECTION CONFIGURATION -->
-
-  <xsd:complexType  name="cluster-connectionType">
-    <xsd:sequence>
-      <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>name of the address this cluster connection applies
-          to</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="connector-ref" type="xsd:string" maxOccurs="1" minOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>Name of the connector reference to use.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="check-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)"
-                        hq:field_name="DEFAULT_CLUSTER_FAILURE_CHECK_PERIOD">
-          <xsd:documentation>The period (in milliseconds) used to check if the cluster connection
-          has failed to receive pings from another server</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="connection-ttl" type="xsd:long" default="60000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="connection-ttl" hq:default="(ms)"
-                        hq:field_name="DEFAULT_CLUSTER_CONNECTION_TTL">
-          <xsd:documentation>how long to keep a connection alive in the absence of any data arriving
-          from the client</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="min-large-message-size" type="xsd:int" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="large-messages" hq:default="(bytes)">
-          <xsd:documentation>Messages larger than this are considered large-messages</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="call-timeout" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(ms)">
-          <xsd:documentation>How long to wait for a reply</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="retry-interval" type="xsd:long" default="500" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RETRY_INTERVAL">
-          <xsd:documentation>period (in ms) between successive retries</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="retry-interval-multiplier" type="xsd:double" default="1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RETRY_INTERVAL_MULTIPLIER">
-          <xsd:documentation>multiplier to apply to the retry-interval</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="max-retry-interval" type="xsd:long" default="2000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_MAX_RETRY_INTERVAL">
-          <xsd:documentation>Maximum value for retry-interval</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="initial-connect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_INITIAL_CONNECT_ATTEMPTS">
-          <xsd:documentation>How many attempts should be made to connect initially</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="reconnect-attempts" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_RECONNECT_ATTEMPTS">
-          <xsd:documentation>How many attempts should be made to
-          reconnect after failure</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="use-duplicate-detection" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_DUPLICATE_DETECTION">
-          <xsd:documentation>should duplicate detection headers be inserted in forwarded
-          messages?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="forward-when-no-consumers" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_FORWARD_WHEN_NO_CONSUMERS">
-          <xsd:documentation>should messages be load balanced if there are no matching consumers on
-          target?</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="max-hops" type="xsd:int" default="1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_MAX_HOPS">
-          <xsd:documentation>maximum number of hops cluster topology is
-          propagated</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="confirmation-window-size" type="xsd:int" default="1048576" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="client-reconnection">
-          <xsd:documentation>The size (in bytes) of the window used for confirming data from
-          the server connected to.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="call-failover-timeout" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="clusters.cluster-connections" hq:default="(ms)">
-          <xsd:documentation>How long to wait for a reply if in the middle of a fail-over. -1 means
-          wait forever.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="notification-interval" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(ms)" hq:field_name="DEFAULT_CLUSTER_NOTIFICATION_INTERVAL">
-          <xsd:documentation>
-            how often the cluster connection will notify the cluster of its existence right after joining the cluster
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="notification-attempts" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_CLUSTER_NOTIFICATION_ATTEMPTS">
-          <xsd:documentation>
-            how many times this cluster connection will notify the cluster of its existence right after joining the cluster
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="scale-down-connector" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>The connector to use for scaling down or when as backup in SCALE_DOWN mode</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:choice>
-        <xsd:element name="static-connectors" maxOccurs="1" minOccurs="0">
-          <xsd:complexType>
-            <xsd:sequence>
-              <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
-            </xsd:sequence>
-            <xsd:attribute name="allow-direct-connections-only" default="false" type="xsd:boolean"
-                           use="optional">
-              <xsd:annotation>
-                <xsd:documentation>restricts cluster connections to the
-                listed connector-ref's</xsd:documentation>
-              </xsd:annotation>
-            </xsd:attribute>
-          </xsd:complexType>
-        </xsd:element>
-        <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="0">
-          <xsd:complexType>
-            <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
-              <xsd:annotation>
-                <xsd:documentation>XXX -- this is a duplicate... </xsd:documentation>
-              </xsd:annotation>
-            </xsd:attribute>
-          </xsd:complexType>
-        </xsd:element>
-      </xsd:choice>
-    </xsd:sequence>
-    <xsd:attribute name="name" type="xsd:ID" use="required">
-      <xsd:annotation>
-        <xsd:documentation>unique name for this cluster connection</xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-  </xsd:complexType>
-
-  <!-- DIVERT CONFIGURATION TYPE -->
-  <xsd:complexType name="divertType">
-    <xsd:all>
-      <xsd:element name="transformer-class-name" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>an optional class name of a transformer</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="exclusive" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_DIVERT_EXCLUSIVE">
-          <xsd:documentation>whether this is an exclusive divert</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="routing-name" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>the routing name for the divert</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="address" type="xsd:string"            maxOccurs="1" minOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>the address this divert will divert from</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element name="forwarding-address" type="xsd:string" maxOccurs="1" minOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>the forwarding address for the divert</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-
-      <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
-    </xsd:all>
-
-    <xsd:attribute name="name" type="xsd:ID" use="required">
-      <xsd:annotation>
-        <xsd:documentation>a unique name for the divert</xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-
-  </xsd:complexType>
-
-  <xsd:complexType name="haPolicyType">
-    <xsd:all>
-      <xsd:element name="policy-type" minOccurs="0" maxOccurs="1" default="NONE">
-        <xsd:annotation>
-          <xsd:documentation>
-            what kind of HA Policy should we use
-          </xsd:documentation>
-        </xsd:annotation>
-        <xsd:simpleType>
-          <xsd:restriction base="xsd:string">
-            <xsd:enumeration value="NONE"/>
-            <xsd:enumeration value="REPLICATED"/>
-            <xsd:enumeration value="SHARED_STORE"/>
-            <xsd:enumeration value="BACKUP_REPLICATED"/>
-            <xsd:enumeration value="BACKUP_SHARED_STORE"/>
-            <xsd:enumeration value="COLOCATED_REPLICATED"/>
-            <xsd:enumeration value="COLOCATED_SHARED_STORE"/>
-          </xsd:restriction>
-        </xsd:simpleType>
-      </xsd:element>
-      <xsd:element name="request-backup" type="xsd:boolean" minOccurs="0" maxOccurs="1" default="false">
-        <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_REQUEST_BACKUP">
-          <xsd:documentation>
-            If true then the server will request a backup on another node
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="backup-request-retries" type="xsd:int" minOccurs="0" maxOccurs="1" default="-1">
-        <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_REQUEST_RETRIES">
-          <xsd:documentation>
-            How many times the live server will try to request a backup, -1 means for ever.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="backup-request-retry-interval" type="xsd:long" minOccurs="0" maxOccurs="1" default="5000">
-        <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_REQUEST_RETRY_INTERVAL">
-          <xsd:documentation>
-            How long to wait for retries between attempts to request a backup server.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="max-backups" type="xsd:int" minOccurs="0" maxOccurs="1" default="1">
-        <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_MAX_BACKUPS">
-          <xsd:documentation>
-            Whether or not this live server will accept backup requests from other live servers.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="backup-port-offset" type="xsd:int" minOccurs="0" maxOccurs="1" default="100">
-        <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_PORT_OFFSET">
-          <xsd:documentation>
-            The offset to use for the Connectors and Acceptors when creating a new backup server.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="backup-strategy" minOccurs="0" maxOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>
-            The backup strategy to use if we are a backup or for any colocated backups.
-          </xsd:documentation>
-        </xsd:annotation>
-        <xsd:simpleType>
-          <xsd:restriction base="xsd:string">
-            <xsd:enumeration value="FULL" />
-            <xsd:enumeration value="SCALE_DOWN"/>
-          </xsd:restriction>
-        </xsd:simpleType>
-      </xsd:element>
-      <xsd:element name="scale-down-connectors" minOccurs="0" maxOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>
-            A list of connectors to use for scaling down, if not supplied then the scale-down-discovery-group or first invm connector will be used
-          </xsd:documentation>
-        </xsd:annotation>
-        <xsd:complexType>
-          <xsd:sequence>
-            <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
-          </xsd:sequence>
-        </xsd:complexType>
-      </xsd:element>
-      <xsd:element name="scale-down-discovery-group" type="xsd:string" minOccurs="0" maxOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>The discovery group to use for scale down, if not supplied then the scale-down-connectors or first invm connector will be used</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="scale-down-group-name" type="xsd:string" minOccurs="0" maxOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>The scale down group to scale down to, a server will only scale down to a server within the same group</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="backup-group-name" type="xsd:string" minOccurs="0" maxOccurs="1">
-        <xsd:annotation>
-          <xsd:documentation>used for replication, if set, (remote) backup servers will only pair with live servers with matching backup-group-name</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="remote-connectors" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>the remote connectors that shouldn't have their ports offset, typically remote connectors or the connector used in the cluster connection if scalinmg down</xsd:documentation>
-        </xsd:annotation>
-        <xsd:complexType>
-          <xsd:sequence>
-            <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
-          </xsd:sequence>
-        </xsd:complexType>
-      </xsd:element>
-      <xsd:element name="check-for-live-server" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="hq.check-for-live-server" hq:field_name="DEFAULT_CHECK_FOR_LIVE_SERVER">
-          <xsd:documentation>
-            Whether to check the cluster for a (live) server using our own server ID when starting
-            up. This option is only necessary for performing 'fail-back' on replicating
-            servers. Strictly speaking this setting only applies to live servers and not to
-            backups.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_ALLOW_AUTO_FAILBACK">
-          <xsd:documentation>
-            Whether a server will automatically stop when a another places a request to take over
-            its place.  The use case is when a regular server stops and its backup takes over its
-            duties, later the main server restarts and requests the server (the former backup) to
-            stop operating.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="ha.allow-fail-back" hq:default="(in milliseconds)"
-                          hq:field_name="DEFAULT_FAILBACK_DELAY">
-          <xsd:documentation>delay to wait before fail-back occurs on (live's) restart</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="failover-on-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_FAILOVER_ON_SERVER_SHUTDOWN">
-          <xsd:documentation>
-            Will this backup server come live on a normal server shutdown
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="replication-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>
-            Name of the cluster configuration to use for replication. This setting is only
-            necessary in case you configure multiple cluster connections. It is used by a
-            replicating backups and by live servers that may attempt fail-back.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="scale-down-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation>
-            Name of the cluster configuration to use for scaling down. This setting is only
-            necessary in case you configure multiple cluster connections.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:field_name="DEFAULT_MAX_SAVED_REPLICATED_JOURNALS_SIZE">
-          <xsd:documentation>
-            This specifies how many times a replicated backup server can restart after moving
-            its files on start. Once there are this number of backup journal files the server
-            will stop permanently after if fails back.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="scale-down" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:linkend="ha.scale-down" hq:field_name="DEFAULT_SCALE_DOWN">
-          <xsd:documentation>
-            Will this server send its messages to another live server in the cluster when
-            shut-down cleanly.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-    </xsd:all>
-    <xsd:attribute name="template" use="optional">
-      <xsd:annotation>
-        <xsd:documentation>if true then the backup will use the same configuration as the live server.</xsd:documentation>
-      </xsd:annotation>
-      <xsd:simpleType>
-        <xsd:restriction base="xsd:string">
-          <xsd:enumeration value="NONE"/>
-          <xsd:enumeration value="REPLICATED"/>
-          <xsd:enumeration value="SHARED_STORE"/>
-          <xsd:enumeration value="BACKUP_REPLICATED"/>
-          <xsd:enumeration value="BACKUP_SHARED_STORE"/>
-          <xsd:enumeration value="COLOCATED_REPLICATED"/>
-          <xsd:enumeration value="COLOCATED_SHARED_STORE"/>
-        </xsd:restriction>
-      </xsd:simpleType>
-    </xsd:attribute>
-  </xsd:complexType>
-  <xsd:complexType name="groupingHandlerType">
-    <xsd:all>
-      <xsd:element name="type" maxOccurs="1" minOccurs="1">
-        <xsd:annotation hq:linkend="message-grouping.type">
-          <xsd:documentation>Each cluster should choose 1 node to
-         have a LOCAL grouping handler and all the other nodes should
-         have REMOTE handlers</xsd:documentation>
-        </xsd:annotation>
-        <xsd:simpleType>
-          <xsd:restriction base="xsd:string">
-            <xsd:enumeration value="LOCAL" />
-            <xsd:enumeration value="REMOTE" />
-          </xsd:restriction>
-        </xsd:simpleType>
-      </xsd:element>
-      <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
-        <xsd:annotation hq:linkend="message-grouping.address">
-          <xsd:documentation>A reference to a cluster connection address</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="timeout" type="xsd:int" default="5000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(ms)">
-          <xsd:documentation>How long to wait for a decision</xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="group-timeout" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(ms)">
-          <xsd:documentation>
-            How long a group binding will be used, -1 means for ever. Bindings are removed after this wait
-            elapses. On the remote node this is used to determine how often you should re-query the main
-            coordinator in order to update the last time used accordingly.
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="reaper-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
-        <xsd:annotation hq:default="(ms)">
-          <xsd:documentation>
-            How often the reaper will be run to check for timed out group bindings. Only valid for LOCAL handlers
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-    </xsd:all>
-    <xsd:attribute name="name" type="xsd:string" use="required">
-      <xsd:annotation>
-        <xsd:documentation>
-          A name identifying this grouping-handler
-        </xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-  </xsd:complexType>
-
-  <xsd:element name="address-setting">
-  <xsd:complexType>
-    <xsd:annotation hq:linkend="queue-attributes.address-settings">
-      <xsd:documentation>
-        Complex type element to configure an address.
-      </xsd:documentation>
-    </xsd:annotation>
+   <xsd:complexType name="haPolicyType">
       <xsd:all>
-        <xsd:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xsd:string">
-          <xsd:annotation hq:linkend="undelivered-messages.configuring">
-            <xsd:documentation>
-              the address to send dead messages to
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="expiry-address" type="xsd:string" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="message-expiry.configuring">
-            <xsd:documentation>
-              the address to send expired messages to
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="expiry-delay" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              Overrides the expiration time for messages using the default value for
-              expiration time. "-1" disables this setting.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="redelivery-delay" type="xsd:long" default="0" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="undelivered-messages.delay">
-            <xsd:documentation>
-              the time (in ms) to wait before redelivering a cancelled message.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="redelivery-delay-multiplier" type="xsd:double"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              multipler to apply to the "redelivery-delay"
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="max-redelivery-delay" type="xsd:long"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              Maximum value for the redelivery-delay
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="max-delivery-attempts" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="undelivered-messages.configuring">
-            <xsd:documentation>
-              how many times to attempt to deliver a message before sending to dead
-              letter address
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="max-size-bytes" type="xsd:long" default="-1"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="paging">
-            <xsd:documentation>the maximum size (in bytes) to use in paging for an
-            address (-1 means no limits)</xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="page-size-bytes" type="xsd:long" default="10485760" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="paging" hq:default="(10 * 1024 * 1024)">
-            <xsd:documentation>
-              the page size (in bytes) to use for an address
-           </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element  name="page-max-cache-size" default="5" type="xsd:int"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="paging">
-            <xsd:documentation>
-              Number of paging files to cache in memory to avoid IO during paging navigation
-           </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="address-full-policy" maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              what happens when an address where "max-size-bytes" is specified becomes full
-            </xsd:documentation>
-          </xsd:annotation>
-          <xsd:simpleType>
-            <xsd:restriction base="xsd:string">
-              <xsd:enumeration value="DROP" />
-              <xsd:enumeration value="FAIL" />
-              <xsd:enumeration value="PAGE" />
-              <xsd:enumeration value="BLOCK" />
-            </xsd:restriction>
-          </xsd:simpleType>
-        </xsd:element>
-
-        <xsd:element name="message-counter-history-day-limit" type="xsd:int" default="0" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:default="(days)">
-            <xsd:documentation>
-              how many days to keep message counter history for this address
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="last-value-queue" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="last-value-queues">
-            <xsd:documentation>
-              whether to treat the queue as a last value queue
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="redistribution-delay" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
-          <xsd:annotation hq:linkend="clusters">
-            <xsd:documentation>
-              how long (in ms) to wait after the last consumer is closed on a queue before redistributing messages.
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-
-        <xsd:element name="send-to-dla-on-no-route" type="xsd:boolean"  maxOccurs="1" minOccurs="0">
-          <xsd:annotation>
-            <xsd:documentation>
-              if there are no queues matching this address, whether to forward message to DLA (if it exists for this address)
-            </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
+         <xsd:element name="policy-type" minOccurs="0" maxOccurs="1" default="NONE">
+            <xsd:annotation>
+               <xsd:documentation>
+                  what kind of HA Policy should we use
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="NONE"/>
+                  <xsd:enumeration value="REPLICATED"/>
+                  <xsd:enumeration value="SHARED_STORE"/>
+                  <xsd:enumeration value="BACKUP_REPLICATED"/>
+                  <xsd:enumeration value="BACKUP_SHARED_STORE"/>
+                  <xsd:enumeration value="COLOCATED_REPLICATED"/>
+                  <xsd:enumeration value="COLOCATED_SHARED_STORE"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="request-backup" type="xsd:boolean" minOccurs="0" maxOccurs="1" default="false">
+            <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_REQUEST_BACKUP">
+               <xsd:documentation>
+                  If true then the server will request a backup on another node
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="backup-request-retries" type="xsd:int" minOccurs="0" maxOccurs="1" default="-1">
+            <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_REQUEST_RETRIES">
+               <xsd:documentation>
+                  How many times the live server will try to request a backup, -1 means for ever.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="backup-request-retry-interval" type="xsd:long" minOccurs="0" maxOccurs="1" default="5000">
+            <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_REQUEST_RETRY_INTERVAL">
+               <xsd:documentation>
+                  How long to wait for retries between attempts to request a backup server.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="max-backups" type="xsd:int" minOccurs="0" maxOccurs="1" default="1">
+            <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_MAX_BACKUPS">
+               <xsd:documentation>
+                  Whether or not this live server will accept backup requests from other live servers.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="backup-port-offset" type="xsd:int" minOccurs="0" maxOccurs="1" default="100">
+            <xsd:annotation hq:field_name="DEFAULT_HAPOLICY_BACKUP_PORT_OFFSET">
+               <xsd:documentation>
+                  The offset to use for the Connectors and Acceptors when creating a new backup server.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="backup-strategy" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The backup strategy to use if we are a backup or for any colocated backups.
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="FULL"/>
+                  <xsd:enumeration value="SCALE_DOWN"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="scale-down-connectors" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  A list of connectors to use for scaling down, if not supplied then the scale-down-discovery-group or
+                  first invm connector will be used
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+         <xsd:element name="scale-down-discovery-group" type="xsd:string" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The discovery group to use for scale down, if not supplied then the scale-down-connectors or first
+                  invm connector will be used
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="scale-down-group-name" type="xsd:string" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The scale down group to scale down to, a server will only scale down to a server within the same group
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="backup-group-name" type="xsd:string" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  used for replication, if set, (remote) backup servers will only pair with live servers with matching
+                  backup-group-name
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="remote-connectors" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  the remote connectors that shouldn't have their ports offset, typically remote connectors or the
+                  connector used in the cluster connection if scalinmg down
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+         <xsd:element name="check-for-live-server" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="hq.check-for-live-server" hq:field_name="DEFAULT_CHECK_FOR_LIVE_SERVER">
+               <xsd:documentation>
+                  Whether to check the cluster for a (live) server using our own server ID when starting
+                  up. This option is only necessary for performing 'fail-back' on replicating
+                  servers. Strictly speaking this setting only applies to live servers and not to
+                  backups.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_ALLOW_AUTO_FAILBACK">
+               <xsd:documentation>
+                  Whether a server will automatically stop when a another places a request to take over
+                  its place. The use case is when a regular server stops and its backup takes over its
+                  duties, later the main server restarts and requests the server (the former backup) to
+                  stop operating.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:default="(in milliseconds)"
+                            hq:field_name="DEFAULT_FAILBACK_DELAY">
+               <xsd:documentation>
+                  delay to wait before fail-back occurs on (live's) restart
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="failover-on-shutdown" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_FAILOVER_ON_SERVER_SHUTDOWN">
+               <xsd:documentation>
+                  Will this backup server come live on a normal server shutdown
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="replication-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of the cluster configuration to use for replication. This setting is only necessary in case you
+                  configure multiple cluster connections. It is used by a replicating backups and by live servers that
+                  may attempt fail-back.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="scale-down-clustername" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of the cluster configuration to use for scaling down. This setting is only necessary in case you
+                  configure multiple cluster connections.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:field_name="DEFAULT_MAX_SAVED_REPLICATED_JOURNALS_SIZE">
+               <xsd:documentation>
+                  This specifies how many times a replicated backup server can restart after moving its files on start.
+                  Once there are this number of backup journal files the server will stop permanently after if fails
+                  back.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="scale-down" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.scale-down" hq:field_name="DEFAULT_SCALE_DOWN">
+               <xsd:documentation>
+                  Will this server send its messages to another live server in the cluster when shut-down cleanly.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
       </xsd:all>
-
-      <xsd:attribute name="match" type="xsd:string" use="required">
-        <xsd:annotation>
-          <xsd:documentation>
-            XXX
-          </xsd:documentation>
-        </xsd:annotation>
+      <xsd:attribute name="template" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               if true then the backup will use the same configuration as the live server.
+            </xsd:documentation>
+         </xsd:annotation>
+         <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+               <xsd:enumeration value="NONE"/>
+               <xsd:enumeration value="REPLICATED"/>
+               <xsd:enumeration value="SHARED_STORE"/>
+               <xsd:enumeration value="BACKUP_REPLICATED"/>
+               <xsd:enumeration value="BACKUP_SHARED_STORE"/>
+               <xsd:enumeration value="COLOCATED_REPLICATED"/>
+               <xsd:enumeration value="COLOCATED_SHARED_STORE"/>
+            </xsd:restriction>
+         </xsd:simpleType>
       </xsd:attribute>
-    </xsd:complexType>
-</xsd:element>
-
-  <xsd:element name="filter">
-    <xsd:complexType>
-      <xsd:annotation>
-        <xsd:documentation>
-          optional core filter expression (set through attribute)
-        </xsd:documentation>
-      </xsd:annotation>
-      <xsd:attribute name="string" type="xsd:string" use="required">
-        <xsd:annotation>
-          <xsd:documentation>
-            optional core filter expression
-          </xsd:documentation>
-        </xsd:annotation>
+   </xsd:complexType>
+   <xsd:complexType name="groupingHandlerType">
+      <xsd:all>
+         <xsd:element name="type" maxOccurs="1" minOccurs="1">
+            <xsd:annotation hq:linkend="message-grouping.type">
+               <xsd:documentation>
+                  Each cluster should choose 1 node to have a LOCAL grouping handler and all the other nodes should have
+                  REMOTE handlers
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="LOCAL"/>
+                  <xsd:enumeration value="REMOTE"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="1">
+            <xsd:annotation hq:linkend="message-grouping.address">
+               <xsd:documentation>
+                  A reference to a cluster connection address
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="timeout" type="xsd:int" default="5000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(ms)">
+               <xsd:documentation>
+                  How long to wait for a decision
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="group-timeout" type="xsd:int" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(ms)">
+               <xsd:documentation>
+                  How long a group binding will be used, -1 means for ever. Bindings are removed after this wait
+                  elapses. On the remote node this is used to determine how often you should re-query the main
+                  coordinator in order to update the last time used accordingly.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="reaper-period" type="xsd:long" default="30000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:default="(ms)">
+               <xsd:documentation>
+                  How often the reaper will be run to check for timed out group bindings. Only valid for LOCAL handlers
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:all>
+      <xsd:attribute name="name" type="xsd:string" use="required">
+         <xsd:annotation>
+            <xsd:documentation>
+               A name identifying this grouping-handler
+            </xsd:documentation>
+         </xsd:annotation>
       </xsd:attribute>
-    </xsd:complexType>
-  </xsd:element>
+   </xsd:complexType>
 
-  <xsd:complexType name="connector-serviceType">
-    <xsd:sequence>
-      <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">
-        <xsd:annotation>
-          <xsd:documentation>
-            Name of the factory class of the ConnectorService
-          </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
-    </xsd:sequence>
-    <xsd:attribute name="name" type="xsd:string" use="optional">
-      <xsd:annotation>
-        <xsd:documentation>
-          name of the connector service
-        </xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
-  </xsd:complexType>
+   <xsd:element name="address-setting">
+      <xsd:complexType>
+         <xsd:annotation hq:linkend="queue-attributes.address-settings">
+            <xsd:documentation>
+               Complex type element to configure an address.
+            </xsd:documentation>
+         </xsd:annotation>
+         <xsd:all>
+            <xsd:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xsd:string">
+               <xsd:annotation hq:linkend="undelivered-messages.configuring">
+                  <xsd:documentation>
+                     the address to send dead messages to
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="expiry-address" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="message-expiry.configuring">
+                  <xsd:documentation>
+                     the address to send expired messages to
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="expiry-delay" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Overrides the expiration time for messages using the default value for expiration time. "-1"
+                     disables this setting.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="redelivery-delay" type="xsd:long" default="0" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="undelivered-messages.delay">
+                  <xsd:documentation>
+                     the time (in ms) to wait before redelivering a cancelled message.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="redelivery-delay-multiplier" type="xsd:double" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     multipler to apply to the "redelivery-delay"
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="max-redelivery-delay" type="xsd:long" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Maximum value for the redelivery-delay
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="max-delivery-attempts" type="xsd:int" default="10" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="undelivered-messages.configuring">
+                  <xsd:documentation>
+                     how many times to attempt to deliver a message before sending to dead letter address
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="max-size-bytes" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="paging">
+                  <xsd:documentation>
+                     the maximum size (in bytes) to use in paging for an address (-1 means no limits)
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="page-size-bytes" type="xsd:long" default="10485760" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="paging" hq:default="(10 * 1024 * 1024)">
+                  <xsd:documentation>
+                     the page size (in bytes) to use for an address
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="page-max-cache-size" default="5" type="xsd:int" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="paging">
+                  <xsd:documentation>
+                     Number of paging files to cache in memory to avoid IO during paging navigation
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="address-full-policy" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     what happens when an address where "max-size-bytes" is specified becomes full
+                  </xsd:documentation>
+               </xsd:annotation>
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:string">
+                     <xsd:enumeration value="DROP"/>
+                     <xsd:enumeration value="FAIL"/>
+                     <xsd:enumeration value="PAGE"/>
+                     <xsd:enumeration value="BLOCK"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:element>
+
+            <xsd:element name="message-counter-history-day-limit" type="xsd:int" default="0" maxOccurs="1"
+                         minOccurs="0">
+               <xsd:annotation hq:default="(days)">
+                  <xsd:documentation>
+                     how many days to keep message counter history for this address
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="last-value-queue" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="last-value-queues">
+                  <xsd:documentation>
+                     whether to treat the queue as a last value queue
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="redistribution-delay" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+               <xsd:annotation hq:linkend="clusters">
+                  <xsd:documentation>
+                     how long (in ms) to wait after the last consumer is closed on a queue before redistributing
+                     messages.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="send-to-dla-on-no-route" type="xsd:boolean" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     if there are no queues matching this address, whether to forward message to DLA (if it exists for
+                     this address)
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+         </xsd:all>
+
+         <xsd:attribute name="match" type="xsd:string" use="required">
+            <xsd:annotation>
+               <xsd:documentation>
+                  XXX
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:element name="filter">
+      <xsd:complexType>
+         <xsd:annotation>
+            <xsd:documentation>
+               optional core filter expression (set through attribute)
+            </xsd:documentation>
+         </xsd:annotation>
+         <xsd:attribute name="string" type="xsd:string" use="required">
+            <xsd:annotation>
+               <xsd:documentation>
+                  optional core filter expression
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:complexType name="connector-serviceType">
+      <xsd:sequence>
+         <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Name of the factory class of the ConnectorService
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               name of the connector service
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+   </xsd:complexType>
 </xsd:schema>

--- a/hornetq-server/src/main/resources/schema/hornetq-users.xsd
+++ b/hornetq-server/src/main/resources/schema/hornetq-users.xsd
@@ -1,34 +1,29 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:hornetq" xmlns="urn:hornetq"
+            elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
 
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-   targetNamespace="urn:hornetq"
-   xmlns="urn:hornetq"
-   elementFormDefault="qualified"
-   attributeFormDefault="unqualified"
-   version="1.0">
-   
    <xsd:element name="configuration">
-   	<xsd:complexType>
-   		<xsd:sequence>
+      <xsd:complexType>
+         <xsd:sequence>
             <xsd:element name="mask-password" type="xsd:boolean" maxOccurs="1" minOccurs="0"></xsd:element>
             <xsd:element name="password-codec" type="xsd:string" maxOccurs="1" minOccurs="0"></xsd:element>
             <xsd:element name="defaultuser" type="userType" maxOccurs="1" minOccurs="0"></xsd:element>
             <xsd:element name="user" type="userType" maxOccurs="unbounded" minOccurs="0"></xsd:element>
-   		</xsd:sequence>
-   	</xsd:complexType>
+         </xsd:sequence>
+      </xsd:complexType>
    </xsd:element>
 
    <xsd:element name="role">
-   	<xsd:complexType>
-   		<xsd:attribute name="name" type="xsd:string" use="required"></xsd:attribute>
-   	</xsd:complexType>
+      <xsd:complexType>
+         <xsd:attribute name="name" type="xsd:string" use="required"></xsd:attribute>
+      </xsd:complexType>
    </xsd:element>
 
    <xsd:complexType name="userType">
-   	<xsd:sequence>
-   		<xsd:element ref="role" maxOccurs="unbounded" minOccurs="1"></xsd:element>
-   	</xsd:sequence>
-   	<xsd:attribute name="name" type="xsd:ID" use="required"></xsd:attribute>
-   	<xsd:attribute name="password" type="xsd:string"></xsd:attribute>
+      <xsd:sequence>
+         <xsd:element ref="role" maxOccurs="unbounded" minOccurs="1"></xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:ID" use="required"></xsd:attribute>
+      <xsd:attribute name="password" type="xsd:string"></xsd:attribute>
    </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
The XSDs used different tab/space sizes and were not formatted consistently internally (e.g. the xsd:documentation tag)
