### PR TITLE
Synchronize netty version to 3.6.9.Final for EAP 6.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
    </prerequisites>
 
    <properties>
-      <netty.version>3.6.7.Final</netty.version>
+      <netty.version>3.6.9.Final</netty.version>
 
       <hornetq.version.versionName>2.3.14.1 (Branch 2.3.eap6_2)</hornetq.version.versionName>
       <hornetq.version.majorVersion>2</hornetq.version.majorVersion>


### PR DESCRIPTION
Synchronize netty version to 3.6.9.Final for EAP 6.2.4 to complete issue https://bugzilla.redhat.com/show_bug.cgi?id=1084639
