### PR TITLE
upgrade Netty version to 3.6.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
    </prerequisites>
 
    <properties>
-      <netty.version>3.6.7.Final</netty.version>
+      <netty.version>3.6.9.Final</netty.version>
 
       <hornetq.version.versionName>2.3.19</hornetq.version.versionName>
       <hornetq.version.majorVersion>2</hornetq.version.majorVersion>


### PR DESCRIPTION
upgrade Netty version to 3.6.9.Final to complete https://bugzilla.redhat.com/show_bug.cgi?id=1105076 for EAP 6.3.1
