### PR TITLE
HORNETQ-578: Destroy CF with null bindings

### DIFF
--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -1457,10 +1457,6 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
    {
       checkInitialised();
       List<String> jndiBindings = connectionFactoryJNDI.get(name);
-      if (jndiBindings == null || jndiBindings.size() == 0)
-      {
-         return false;
-      }
 
       if (registry != null)
       {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSServerControlTest.java
@@ -791,6 +791,23 @@ public class JMSServerControlTest extends ManagementTestBase
    }
 
    @Test
+   public void testDestroyConnectionFactoryWithNullBindings() throws Exception
+   {
+      // Create Connection Factory with Null Bindings
+      JMSServerControl control = createManagementControl();
+      control.createConnectionFactory("test-cf", // Name
+                                      false,     // HA
+                                      false,     // Use Discovery?
+                                      1,         // ConnectionFactory Type
+                                      "invm",    // Connector Names
+                                      null);     // JNDI Bindings
+
+      control.destroyConnectionFactory("test-cf");
+
+      assertTrue(control.getConnectionFactoryNames().length == 0);
+   }
+
+   @Test
    public void testListPreparedTransactionDetails() throws Exception
    {
       Xid xid = newXID();


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-578

Fixes issue where calling destory on JMS Connection Factory was failing
silently when Connection Factory bindings was empty or set to null.
