### PR TITLE
No need to do a memory copy when using netty >= 4.0.19.

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/HornetQFrameDecoder2.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/HornetQFrameDecoder2.java
@@ -34,6 +34,9 @@ public class HornetQFrameDecoder2 extends LengthFieldBasedFrameDecoder
    @Override
    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length)
    {
-      return super.extractFrame(ctx, buffer, index, length).skipBytes(DataConstants.SIZE_INT);
+      // Only slice out buffer and retain it to eliminate memory copy
+      ByteBuf frame = buffer.slice(index, length);
+      frame.skipBytes(DataConstants.SIZE_INT);
+      return frame.retain();
    }
 }


### PR DESCRIPTION
Just slice out the frame and call retain() on it, this will eliminate the need of memory copy for each frame and so improve the overall performance.

Originally done by Norman at https://github.com/hornetq/hornetq/pull/1629
