### PR TITLE
Update dependendencies to JTA 1,2

### DIFF
--- a/examples/jms/hornetq-ra-rar/pom.xml
+++ b/examples/jms/hornetq-ra-rar/pom.xml
@@ -32,7 +32,7 @@
             </exclusion>
             <exclusion>
                <groupId>org.jboss.spec.javax.transaction</groupId>
-               <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+               <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             </exclusion>
             <exclusion>
                <groupId>jboss.jbossts.jts</groupId>

--- a/examples/jms/xa-with-jta/pom.xml
+++ b/examples/jms/xa-with-jta/pom.xml
@@ -24,7 +24,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.jbossts</groupId>

--- a/hornetq-jms-server/pom.xml
+++ b/hornetq-jms-server/pom.xml
@@ -42,7 +42,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.jbossts.jts</groupId>

--- a/integration/hornetq-jboss-as-integration/pom.xml
+++ b/integration/hornetq-jboss-as-integration/pom.xml
@@ -45,7 +45,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
          </dependency>
          <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
             <version>1.0.0.Final</version>
          </dependency>
 

--- a/tests/byteman-tests/pom.xml
+++ b/tests/byteman-tests/pom.xml
@@ -132,7 +132,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge -->
       <dependency>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -92,7 +92,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge -->
       <dependency>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -76,7 +76,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge -->
       <dependency>

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -90,7 +90,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge-->
       <dependency>

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -109,7 +109,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge-->
       <dependency>

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -109,7 +109,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge-->
       <dependency>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -87,7 +87,7 @@
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
-         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       </dependency>
       <!--this specifically for the JMS Bridge-->
       <dependency>


### PR DESCRIPTION
JTA 1,2 has backwards compatibility with JTA 1.1 so this should be a
straight swap.
