### PR TITLE
change openwire cacheEnabled option to true as it is default option

### DIFF
--- a/docs/user-manual/en/interoperability.xml
+++ b/docs/user-manual/en/interoperability.xml
@@ -303,7 +303,5 @@ java.naming.factory.url.pkgs=org.jboss.naming:org.jnp.interfaces</programlisting
         <para>Please refer to the openwire example for more coding details.</para>
         <para>Currently we support ActiveMQ clients that using standard JMS APIs. In the future we will get more supports
         for some advanced, ActiveMQ specific features into HornetQ.</para>
-        <note><para>HornetQ now doesn't support 'cached' marshalling. 
-        To get a working connection you need to disable caching. Please see the openwire example.</para></note>
     </section>
 </chapter>

--- a/examples/jms/openwire/src/main/java/org/hornetq/jms/example/OpenWireExample.java
+++ b/examples/jms/openwire/src/main/java/org/hornetq/jms/example/OpenWireExample.java
@@ -47,7 +47,7 @@ public class OpenWireExample extends HornetQExample
 
       try
       {
-         String urlString = "tcp://" + OWHOST + ":" + OWPORT + "?wireFormat.cacheEnabled=false";
+         String urlString = "tcp://" + OWHOST + ":" + OWPORT;
 
          // Step 1. Create an ActiveMQ Connection Factory
          ConnectionFactory factory = new ActiveMQConnectionFactory(urlString);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/BasicOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/BasicOpenWireTest.java
@@ -38,7 +38,7 @@ public class BasicOpenWireTest extends OpenWireTestBase
 {
    @Rule public TestName name = new TestName();
 
-   protected String urlString = "tcp://" + OWHOST + ":" + OWPORT + "?wireFormat.cacheEnabled=false";
+   protected String urlString = "tcp://" + OWHOST + ":" + OWPORT + "?wireFormat.cacheEnabled=true";
    protected ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(urlString);
    protected ActiveMQConnection connection;
    protected String topicName = "amqTestTopic1";


### PR DESCRIPTION
We didn't enable it because it was not working when the openwire support was initially started. Now it's working. It must have been fixed during I fixed other issues.

Tests and example are now using the default openwire option. Document is also changed accordingly.
