### PR TITLE
updating to latest of UPS java client

### DIFF
--- a/integration/hornetq-aerogear-integration/pom.xml
+++ b/integration/hornetq-aerogear-integration/pom.xml
@@ -39,7 +39,7 @@
       <dependency>
          <groupId>org.jboss.aerogear</groupId>
          <artifactId>unifiedpush-java-client</artifactId>
-         <version>0.4.0</version>
+         <version>1.0.0</version>
       </dependency>
       <!-- RestEasy's Jackson Plugin -->
       <dependency>

--- a/integration/hornetq-aerogear-integration/src/main/java/org/hornetq/integration/aerogear/AeroGearConnectorService.java
+++ b/integration/hornetq-aerogear-integration/src/main/java/org/hornetq/integration/aerogear/AeroGearConnectorService.java
@@ -62,6 +62,10 @@ public class AeroGearConnectorService implements ConnectorService, Consumer, Mes
 
    private final String sound;
 
+   private final boolean contentAvailable;
+
+   private final String actionCategory;
+
    private String[] variants;
 
    private String[] aliases;
@@ -96,6 +100,8 @@ public class AeroGearConnectorService implements ConnectorService, Consumer, Mes
       this.ttl = ConfigurationHelper.getIntProperty(AeroGearConstants.TTL_NAME, AeroGearConstants.DEFAULT_TTL, configuration);
       this.badge = ConfigurationHelper.getStringProperty(AeroGearConstants.BADGE_NAME, null, configuration);
       this.sound = ConfigurationHelper.getStringProperty(AeroGearConstants.SOUND_NAME, AeroGearConstants.DEFAULT_SOUND, configuration);
+      this.contentAvailable = ConfigurationHelper.getBooleanProperty(AeroGearConstants.CONTENT_AVAILABLE_NAME, false, configuration);
+      this.actionCategory = ConfigurationHelper.getStringProperty(AeroGearConstants.ACTION_CATEGORY_NAME, null, configuration);
       this.filterString = ConfigurationHelper.getStringProperty(AeroGearConstants.FILTER_NAME, null, configuration);
       this.retryInterval = ConfigurationHelper.getIntProperty(AeroGearConstants.RETRY_INTERVAL_NAME, AeroGearConstants.DEFAULT_RETRY_INTERVAL, configuration);
       this.retryAttempts = ConfigurationHelper.getIntProperty(AeroGearConstants.RETRY_ATTEMPTS_NAME, AeroGearConstants.DEFAULT_RETRY_ATTEMPTS, configuration);
@@ -202,7 +208,7 @@ public class AeroGearConnectorService implements ConnectorService, Consumer, Mes
 
       String alert = message.getTypedProperties().getProperty(AeroGearConstants.AEROGEAR_ALERT).toString();
 
-      JavaSender sender = new SenderClient(endpoint);
+      JavaSender sender = new SenderClient.Builder(endpoint).build();
 
       UnifiedMessage.Builder builder = new UnifiedMessage.Builder();
 
@@ -222,6 +228,20 @@ public class AeroGearConnectorService implements ConnectorService, Consumer, Mes
       if (badge != null)
       {
          builder.badge(badge);
+      }
+
+      boolean contentAvailable = message.containsProperty(AeroGearConstants.AEROGEAR_CONTENT_AVAILABLE) ? message.getBooleanProperty(AeroGearConstants.AEROGEAR_CONTENT_AVAILABLE) : this.contentAvailable;
+
+      if (contentAvailable)
+      {
+         builder.contentAvailable();
+      }
+
+      String actionCategory = message.containsProperty(AeroGearConstants.AEROGEAR_ACTION_CATEGORY) ? message.getStringProperty(AeroGearConstants.AEROGEAR_ACTION_CATEGORY) : this.actionCategory;
+
+      if (actionCategory != null)
+      {
+         builder.actionCategory(actionCategory);
       }
 
       Integer ttl = message.containsProperty(AeroGearConstants.AEROGEAR_TTL) ? message.getIntProperty(AeroGearConstants.AEROGEAR_TTL) : this.ttl;

--- a/integration/hornetq-aerogear-integration/src/main/java/org/hornetq/integration/aerogear/AeroGearConstants.java
+++ b/integration/hornetq-aerogear-integration/src/main/java/org/hornetq/integration/aerogear/AeroGearConstants.java
@@ -29,6 +29,8 @@ public class AeroGearConstants
    public static final String TTL_NAME = "ttl";
    public static final String BADGE_NAME = "badge";
    public static final String SOUND_NAME = "sound";
+   public static final String CONTENT_AVAILABLE_NAME = "content-available";
+   public static final String ACTION_CATEGORY_NAME = "action-category";
    public static final String FILTER_NAME = "filter";
    public static final String RETRY_INTERVAL_NAME = "retry-interval";
    public static final String RETRY_ATTEMPTS_NAME = "retry-attempts";
@@ -39,6 +41,8 @@ public class AeroGearConstants
 
    public static final SimpleString AEROGEAR_ALERT = new SimpleString("AEROGEAR_ALERT");
    public static final SimpleString AEROGEAR_SOUND = new SimpleString("AEROGEAR_SOUND");
+   public static final SimpleString AEROGEAR_CONTENT_AVAILABLE = new SimpleString("AEROGEAR_CONTENT_AVAILABLE");
+   public static final SimpleString AEROGEAR_ACTION_CATEGORY = new SimpleString("AEROGEAR_ACTION_CATEGORY");
    public static final SimpleString AEROGEAR_BADGE = new SimpleString("AEROGEAR_BADGE");
    public static final SimpleString AEROGEAR_TTL = new SimpleString("AEROGEAR_TTL");
    public static final SimpleString AEROGEAR_VARIANTS = new SimpleString("AEROGEAR_VARIANTS");
@@ -59,6 +63,8 @@ public class AeroGearConstants
       ALLOWABLE_PROPERTIES.add(TTL_NAME);
       ALLOWABLE_PROPERTIES.add(BADGE_NAME);
       ALLOWABLE_PROPERTIES.add(SOUND_NAME);
+      ALLOWABLE_PROPERTIES.add(CONTENT_AVAILABLE_NAME);
+      ALLOWABLE_PROPERTIES.add(ACTION_CATEGORY_NAME);
       ALLOWABLE_PROPERTIES.add(FILTER_NAME);
       ALLOWABLE_PROPERTIES.add(RETRY_INTERVAL_NAME);
       ALLOWABLE_PROPERTIES.add(RETRY_ATTEMPTS_NAME);


### PR DESCRIPTION
- using version 1.0.0 (including updating the instantiation of JavaSender/SenderClient)
- using new (iOS specific) properties on the UnifiedPush message (content-available, action-category)
