### PR TITLE
HORNETQ-1125 Added InjectObjectRegistry to Server

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ConnectorsService.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ConnectorsService.java
@@ -51,15 +51,19 @@ public final class ConnectorsService implements HornetQComponent
 
    private final Set<ConnectorService> connectors = new HashSet<ConnectorService>();
 
+   private final InjectedObjectRegistry injectedObjectRegistry;
+
    public ConnectorsService(final Configuration configuration,
                             final StorageManager storageManager,
                             final ScheduledExecutorService scheduledPool,
-                            final PostOffice postOffice)
+                            final PostOffice postOffice,
+                            final InjectedObjectRegistry injectedObjectRegistry)
    {
       this.configuration = configuration;
       this.storageManager = storageManager;
       this.scheduledPool = scheduledPool;
       this.postOffice = postOffice;
+      this.injectedObjectRegistry = injectedObjectRegistry;
    }
 
    public void start() throws Exception
@@ -68,7 +72,11 @@ public final class ConnectorsService implements HornetQComponent
 
       for (ConnectorServiceConfiguration info : configurationList)
       {
-         ConnectorServiceFactory factory = (ConnectorServiceFactory)ClassloadingUtil.newInstanceFromClassLoader(info.getFactoryClassName());
+         ConnectorServiceFactory factory = injectedObjectRegistry.getConnectorServiceFactory(info.getFactoryClassName());
+         if (factory == null)
+         {
+            factory = (ConnectorServiceFactory) ClassloadingUtil.newInstanceFromClassLoader(info.getFactoryClassName());
+         }
 
          if (info.getParams() != null)
          {

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -325,6 +325,8 @@ public class HornetQServerImpl implements HornetQServer
 
    private boolean scheduledPoolSupplied = false;
 
+   private InjectedObjectRegistry injectedObjectRegistry;
+
    // Constructors
    // ---------------------------------------------------------------------------------
 
@@ -365,6 +367,15 @@ public class HornetQServerImpl implements HornetQServer
                             final HornetQSecurityManager securityManager,
                             final HornetQServer parentServer)
    {
+      this(configuration, mbeanServer, securityManager, parentServer, null);
+   }
+
+   public HornetQServerImpl(Configuration configuration,
+                            MBeanServer mbeanServer,
+                            final HornetQSecurityManager securityManager,
+                            final HornetQServer parentServer,
+                            final InjectedObjectRegistry injectedObjectRegistry)
+   {
       if (configuration == null)
       {
          configuration = new ConfigurationImpl();
@@ -396,39 +407,7 @@ public class HornetQServerImpl implements HornetQServer
 
       this.parentServer = parentServer;
 
-   }
-
-
-   public HornetQServerImpl(Configuration configuration,
-                            MBeanServer mbeanServer,
-                            final HornetQSecurityManager securityManager,
-                            final HornetQServer parentServer,
-                            final ExecutorService threadPool,
-                            final ScheduledExecutorService scheduledPool)
-   {
-      this(configuration, mbeanServer, securityManager, parentServer);
-
-      if (threadPool != null)
-      {
-         this.threadPool = threadPool;
-         this.executorFactory = new OrderedExecutorFactory(threadPool);
-         this.threadPoolSupplied = true;
-      }
-
-      if (scheduledPool != null)
-      {
-         this.scheduledPool = scheduledPool;
-         this.scheduledPoolSupplied = true;
-      }
-   }
-
-   public HornetQServerImpl(Configuration configuration,
-                            MBeanServer mbeanServer,
-                            final HornetQSecurityManager securityManager,
-                            final ExecutorService threadPool,
-                            final ScheduledExecutorService scheduledPool)
-   {
-      this(configuration, mbeanServer, securityManager, null, threadPool, scheduledPool);
+      this.injectedObjectRegistry = injectedObjectRegistry == null ?  new InjectedObjectRegistry() : injectedObjectRegistry;
    }
 
    // life-cycle methods
@@ -537,7 +516,7 @@ public class HornetQServerImpl implements HornetQServer
                                                      identity != null ? identity : "");
          }
          // start connector service
-         connectorsService = new ConnectorsService(configuration, storageManager, scheduledPool, postOffice);
+         connectorsService = new ConnectorsService(configuration, storageManager, scheduledPool, postOffice, injectedObjectRegistry);
          connectorsService.start();
       }
       finally
@@ -1694,6 +1673,48 @@ public class HornetQServerImpl implements HornetQServer
 
 
    /**
+    * Sets up HornetQ Executor Services.
+    */
+   private void initializeExecutorServices()
+   {
+      /* We check to see if a Thread Pool is supplied in the InjectedObjectRegistry.  If so we created a new Ordered
+       * Executor based on the provided Thread pool.  Otherwise we create a new ThreadPool.
+       */
+      if (injectedObjectRegistry.getExecutorService() == null)
+      {
+         ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-server-" + this.toString(), false, getThisClassLoader());
+         if (configuration.getThreadPoolMaxSize() == -1)
+         {
+            threadPool = Executors.newCachedThreadPool(tFactory);
+         }
+         else
+         {
+            threadPool = Executors.newFixedThreadPool(configuration.getThreadPoolMaxSize(), tFactory);
+         }
+      }
+      else
+      {
+         threadPool = injectedObjectRegistry.getExecutorService();
+         this.threadPoolSupplied = true;
+      }
+      this.executorFactory = new OrderedExecutorFactory(threadPool);
+
+       /* We check to see if a Scheduled Executor Service is provided in the InjectedObjectRegistry.  If so we use this
+       * Scheduled ExecutorService otherwise we create a new one.
+       */
+      if (injectedObjectRegistry.getScheduledExecutorService() == null)
+      {
+         ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-scheduled-threads", false, getThisClassLoader());
+         scheduledPool = new ScheduledThreadPoolExecutor(configuration.getScheduledThreadPoolMaxSize(), tFactory);
+      }
+      else
+      {
+         this.scheduledPoolSupplied = true;
+         this.scheduledPool = injectedObjectRegistry.getScheduledExecutorService();
+      }
+   }
+
+   /**
     * Starts everything apart from RemotingService and loading the data.
     * <p/>
     * After optional intermediary steps, Part 1 is meant to be followed by part 2
@@ -1704,38 +1725,14 @@ public class HornetQServerImpl implements HornetQServer
    {
       if (state == SERVER_STATE.STOPPED)
          return false;
+
       // Create the pools - we have two pools - one for non scheduled - and another for scheduled
-
-      ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-server-" + this.toString(),
-                                                        false,
-                                                        getThisClassLoader());
-
+      initializeExecutorServices();
 
       if (configuration.getJournalType() == JournalType.ASYNCIO && !AIOSequentialFileFactory.isSupported())
       {
          HornetQServerLogger.LOGGER.switchingNIO();
          configuration.setJournalType(JournalType.NIO);
-      }
-
-      if (!threadPoolSupplied)
-      {
-         if (configuration.getThreadPoolMaxSize() == -1)
-         {
-            threadPool = Executors.newCachedThreadPool(tFactory);
-         }
-         else
-         {
-            threadPool = Executors.newFixedThreadPool(configuration.getThreadPoolMaxSize(), tFactory);
-         }
-         executorFactory = new OrderedExecutorFactory(threadPool);
-      }
-
-      if (!scheduledPoolSupplied)
-      {
-         scheduledPool = new ScheduledThreadPoolExecutor(configuration.getScheduledThreadPoolMaxSize(),
-                                                         new HornetQThreadFactory("HornetQ-scheduled-threads",
-                                                                                  false,
-                                                                                  getThisClassLoader()));
       }
 
       managementService = new ManagementServiceImpl(mbeanServer, configuration);
@@ -1802,7 +1799,14 @@ public class HornetQServerImpl implements HornetQServer
 
       clusterManager.deploy();
 
-      remotingService = new RemotingServiceImpl(clusterManager, configuration, this, managementService, scheduledPool, protocolManagerFactories,  executorFactory.getExecutor());
+      remotingService = new RemotingServiceImpl(clusterManager,
+                                                configuration,
+                                                this,
+                                                managementService,
+                                                scheduledPool,
+                                                protocolManagerFactories,
+                                                executorFactory.getExecutor(),
+                                                injectedObjectRegistry);
 
       messagingServerControl = managementService.registerServer(postOffice,
                                                                 storageManager,

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/InjectedObjectRegistry.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/InjectedObjectRegistry.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.core.server.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.core.server.ConnectorServiceFactory;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class InjectedObjectRegistry
+{
+   private ExecutorService executorService;
+
+   private ScheduledExecutorService scheduledExecutorService;
+
+   /* We are using a List rather than HashMap here as HornetQ allows multiple instances of the same class to be added
+   * to the interceptor list
+   */
+   private List<Interceptor> incomingInterceptors;
+
+   private List<Interceptor> outgoingInterceptors;
+
+   private Map<String, ConnectorServiceFactory> connectorServiceFactories;
+
+   public InjectedObjectRegistry()
+   {
+      this.incomingInterceptors = Collections.synchronizedList(new ArrayList<Interceptor>());
+      this.outgoingInterceptors = Collections.synchronizedList(new ArrayList<Interceptor>());
+      this.connectorServiceFactories = new ConcurrentHashMap<String, ConnectorServiceFactory>();
+   }
+
+   public ExecutorService getExecutorService()
+   {
+      return executorService;
+   }
+
+   public void setExecutorService(ExecutorService executorService)
+   {
+      this.executorService = executorService;
+   }
+
+   public ScheduledExecutorService getScheduledExecutorService()
+   {
+      return scheduledExecutorService;
+   }
+
+   public void setScheduledExecutorService(ScheduledExecutorService scheduledExecutorService)
+   {
+      this.scheduledExecutorService = scheduledExecutorService;
+   }
+
+   public void addConnectorServiceFactory(ConnectorServiceFactory connectorServiceFactory)
+   {
+      connectorServiceFactories.put(connectorServiceFactory.getClass().getCanonicalName(), connectorServiceFactory);
+   }
+
+   public void removeConnectorServiceFactory(String className)
+   {
+      connectorServiceFactories.remove(className);
+   }
+
+   public ConnectorServiceFactory getConnectorServiceFactory(String className)
+   {
+      return connectorServiceFactories.get(className);
+   }
+
+   public Map<String, ConnectorServiceFactory> getConnectorServiceFactories()
+   {
+      return Collections.unmodifiableMap(connectorServiceFactories);
+   }
+
+   public void addIncomingInterceptor(Interceptor interceptor)
+   {
+      incomingInterceptors.add(interceptor);
+   }
+
+   public void removeIncomingInterceptor(Interceptor interceptor)
+   {
+      incomingInterceptors.remove(interceptor);
+   }
+
+   public List<Interceptor> getIncomingInterceptors()
+   {
+      return Collections.unmodifiableList(incomingInterceptors);
+   }
+
+   public void addOutgoingInterceptor(Interceptor interceptor)
+   {
+      outgoingInterceptors.add(interceptor);
+   }
+
+   public void removeOutgoingInterceptor(Interceptor interceptor)
+   {
+      outgoingInterceptors.remove(interceptor);
+   }
+
+   public List<Interceptor> getOutgoingInterceptors()
+   {
+      return Collections.unmodifiableList(outgoingInterceptors);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/SuppliedThreadPoolTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/SuppliedThreadPoolTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.impl.HornetQServerImpl;
+import org.hornetq.core.server.impl.InjectedObjectRegistry;
 import org.hornetq.tests.util.UnitTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -36,18 +37,16 @@ public class SuppliedThreadPoolTest extends UnitTestCase
 {
    private HornetQServer server;
 
-   private ExecutorService threadPool;
-
-   private ScheduledExecutorService scheduledExecutorService;
-
    private Thread serverThread;
 
+   private InjectedObjectRegistry injectedObjectRegistry;
    @Before
    public void setup() throws Exception
    {
-      threadPool = Executors.newFixedThreadPool(1);
-      scheduledExecutorService = Executors.newScheduledThreadPool(1);
-      server = new HornetQServerImpl(null, null, null, null, threadPool, scheduledExecutorService);
+      injectedObjectRegistry = new InjectedObjectRegistry();
+      injectedObjectRegistry.setExecutorService(Executors.newFixedThreadPool(1));
+      injectedObjectRegistry.setScheduledExecutorService(Executors.newScheduledThreadPool(1));
+      server = new HornetQServerImpl(null, null, null, null, injectedObjectRegistry);
       server.start();
       server.waitForActivation(100, TimeUnit.MILLISECONDS);
    }
@@ -64,12 +63,12 @@ public class SuppliedThreadPoolTest extends UnitTestCase
    @Test
    public void testSuppliedThreadPoolsAreCorrectlySet() throws Exception
    {
-      assertEquals(scheduledExecutorService, server.getScheduledPool());
+      assertEquals(injectedObjectRegistry.getScheduledExecutorService(), server.getScheduledPool());
 
       // To check the Executor is what we expect we must reflectively inspect the OrderedExecutorFactory.
       Field field = server.getExecutorFactory().getClass().getDeclaredField("parent");
       field.setAccessible(true);
-      assertEquals(threadPool, field.get(server.getExecutorFactory()));
+      assertEquals(injectedObjectRegistry.getExecutorService(), field.get(server.getExecutorFactory()));
    }
 
    @Test

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/ConnectorsServiceTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/ConnectorsServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.ConnectorServiceConfiguration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.server.ConnectorService;
+import org.hornetq.core.server.ConnectorServiceFactory;
+import org.hornetq.core.server.impl.ConnectorsService;
+import org.hornetq.core.server.impl.InjectedObjectRegistry;
+import org.hornetq.tests.unit.core.config.impl.fakes.FakeConnectorService;
+import org.hornetq.tests.unit.core.config.impl.fakes.FakeConnectorServiceFactory;
+import org.hornetq.tests.util.UnitTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class ConnectorsServiceTest extends UnitTestCase
+{
+   private Configuration configuration;
+
+   private ConnectorServiceConfiguration connectorServiceConfiguration;
+
+   private InjectedObjectRegistry injectedObjectRegistry;
+
+   private ConnectorService connectorService;
+
+   @Before
+   public void setUp() throws Exception
+   {
+      // Setup Configuration
+      connectorServiceConfiguration = new ConnectorServiceConfiguration(FakeConnectorServiceFactory.class.getCanonicalName(),
+                                                                        new HashMap<String, Object>(), null);
+      List<ConnectorServiceConfiguration> connectorServiceConfigurations = new ArrayList<ConnectorServiceConfiguration>();
+      connectorServiceConfigurations.add(connectorServiceConfiguration);
+      configuration = new ConfigurationImpl();
+      configuration.setConnectorServiceConfigurations(connectorServiceConfigurations);
+
+      connectorService = new FakeConnectorService();
+      injectedObjectRegistry = new InjectedObjectRegistry();
+   }
+
+   @Test
+   public void testConnectorsServiceUsesInjectedConnectorServiceFactory() throws Exception
+   {
+      ConnectorService connectorService = new FakeConnectorService();
+      ConnectorServiceFactory connectorServiceFactory = new FakeConnectorServiceFactory(connectorService);
+      injectedObjectRegistry.addConnectorServiceFactory(connectorServiceFactory);
+      ConnectorsService connectorsService = new ConnectorsService(configuration, null, null, null, injectedObjectRegistry);
+      connectorsService.start();
+
+      assertTrue(connectorsService.getConnectors().size() == 1);
+      assertTrue(connectorsService.getConnectors().contains(connectorService));
+   }
+
+   @Test
+   public void testConnectorServiceCreatesNewConnectorServiceFactoryWhenNoInjectedOnesExists() throws Exception
+   {
+      ConnectorsService connectorsService = new ConnectorsService(configuration, null, null, null, injectedObjectRegistry);
+      connectorsService.start();
+
+      assertTrue(connectorsService.getConnectors().size() == 1);
+      assertFalse(connectorsService.getConnectors().contains(connectorService));
+   }
+
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorService.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl.fakes;
+
+import org.hornetq.core.server.ConnectorService;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeConnectorService implements ConnectorService
+{
+   @Override
+   public String getName()
+   {
+      return null;
+   }
+
+   @Override
+   public void start() throws Exception
+   {
+   }
+
+   @Override
+   public void stop() throws Exception
+   {
+   }
+
+   @Override
+   public boolean isStarted()
+   {
+      return false;
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorServiceFactory.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorServiceFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl.fakes;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hornetq.core.persistence.StorageManager;
+import org.hornetq.core.postoffice.PostOffice;
+import org.hornetq.core.server.ConnectorService;
+import org.hornetq.core.server.ConnectorServiceFactory;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeConnectorServiceFactory implements ConnectorServiceFactory
+{
+   private ConnectorService connectorService;
+
+   public FakeConnectorServiceFactory()
+   {
+   }
+
+   public FakeConnectorServiceFactory(ConnectorService connectorService)
+   {
+      this.connectorService = connectorService;
+   }
+
+   @Override
+   public ConnectorService createConnectorService(String connectorName, Map<String, Object> configuration, StorageManager storageManager, PostOffice postOffice, ScheduledExecutorService scheduledThreadPool)
+   {
+      if (connectorService == null)
+      {
+         return new FakeConnectorService();
+      }
+      return connectorService;
+   }
+
+   @Override
+   public Set<String> getAllowableProperties()
+   {
+      return new HashSet<String>();
+   }
+
+   @Override
+   public Set<String> getRequiredProperties()
+   {
+      return new HashSet<String>();
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/RemotingServiceImplTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/RemotingServiceImplTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.remoting.server.impl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.remoting.server.impl.RemotingServiceImpl;
+import org.hornetq.core.server.impl.InjectedObjectRegistry;
+import org.hornetq.tests.unit.core.remoting.server.impl.fake.FakeInterceptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class RemotingServiceImplTest
+{
+   private InjectedObjectRegistry injectedObjectRegistry;
+
+   private RemotingServiceImpl remotingService;
+
+   private Configuration configuration;
+
+   @Before
+   public void setUp() throws Exception
+   {
+      injectedObjectRegistry = new InjectedObjectRegistry();
+      configuration = new ConfigurationImpl();
+      configuration.setAcceptorConfigurations(new HashSet<TransportConfiguration>());
+      remotingService = new RemotingServiceImpl(null, configuration, null, null, null, null, null, injectedObjectRegistry);
+   }
+
+   /**
+    * This test ensures that RemotingServiceImpl.getInterceptorImplementation returns an *existing* interceptor instance
+    * if there is one available in the injectObjectRegistry that has not already been added to incoming
+    * @throws Exception
+    */
+   @Test
+   public void testGetInterceptorImplementationReturnsInjectedInterceptor() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("getInterceptorImplementation", List.class, List.class, String.class);
+      method.setAccessible(true);
+
+      Interceptor incomingInterceptor = new FakeInterceptor();
+      List<Interceptor> injectedInterceptors = new ArrayList<Interceptor>();
+      injectedInterceptors.add(incomingInterceptor);
+
+      Interceptor interceptor = (Interceptor) method.invoke(remotingService,
+                                                            injectedInterceptors,
+                                                            new ArrayList<Interceptor>(),
+                                                            FakeInterceptor.class.getCanonicalName());
+      assertTrue(interceptor == incomingInterceptor);
+   }
+
+   /**
+    * This test ensures that RemotingServiceImpl.getInterceptorImplementation returns a *new* interceptor instance
+    * if there is one in the injectObjectRegistry but it has already been added to incoming interceptors.
+    * @throws Exception
+    */
+   @Test
+   public void testGetInterceptorImplementationReturnsNewInterceptorWhenInjectedAlreadyExists() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("getInterceptorImplementation", List.class, List.class, String.class);
+      method.setAccessible(true);
+
+      Interceptor incomingInterceptor = new FakeInterceptor();
+      List<Interceptor> injectedInterceptors = new ArrayList<Interceptor>();
+      injectedInterceptors.add(incomingInterceptor);
+
+      Interceptor interceptor = (Interceptor) method.invoke(remotingService,
+                                                            injectedInterceptors,
+                                                            injectedInterceptors,
+                                                            FakeInterceptor.class.getCanonicalName());
+      assertNotNull(interceptor);
+      assertFalse(interceptor == incomingInterceptor);
+   }
+
+   /**
+    * This test ensures that RemotingServiceImpl.getInterceptorImplementation returns a *new* interceptor instance
+    * if there is not one in the injectObjectRegistry.
+    * @throws Exception
+    */
+   @Test
+   public void testGetInterceptorImplementationReturnsNewInterceptorWhenInjectedDoesNotContainInstace() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("getInterceptorImplementation", List.class, List.class, String.class);
+      method.setAccessible(true);
+
+      Interceptor interceptor = (Interceptor) method.invoke(remotingService,
+                                                            new ArrayList<Interceptor>(),
+                                                            new ArrayList<Interceptor>(),
+                                                            FakeInterceptor.class.getCanonicalName());
+      assertTrue(interceptor instanceof FakeInterceptor);
+   }
+
+   /**
+    * This test ensures that setInterceptors sets all interceptors instances for each class name added in the config and
+    * uses the instances provided by injectedObjectRegistry.
+    */
+   @Test
+   public void testSetInterceptorsUsesProvidedInterceptorsFromInjectedObjectRegistry() throws Exception
+   {
+      // In order to test that the interceptors are properly set we need a handle on the interceptor list.
+      Field incomingInterceptorsField = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      incomingInterceptorsField.setAccessible(true);
+
+      Field outgoingInterceptorsField = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      outgoingInterceptorsField.setAccessible(true);
+
+      outgoingInterceptorsField = RemotingServiceImpl.class.getDeclaredField("outgoingInterceptors");
+      outgoingInterceptorsField.setAccessible(true);
+
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("setInterceptors", Configuration.class);
+      method.setAccessible(true);
+
+      List<String> interceptorClassNames = new ArrayList<String>();
+      List<Interceptor> interceptors = new ArrayList<>();
+      for (int i = 0; i < 5; i++)
+      {
+         interceptorClassNames.add(FakeInterceptor.class.getCanonicalName());
+         Interceptor interceptor = new FakeInterceptor();
+         interceptors.add(interceptor);
+         injectedObjectRegistry.addIncomingInterceptor(interceptor);
+         injectedObjectRegistry.addOutgoingInterceptor(interceptor);
+      }
+
+      configuration.setIncomingInterceptorClassNames(interceptorClassNames);
+      configuration.setOutgoingInterceptorClassNames(interceptorClassNames);
+
+      method.invoke(remotingService, configuration);
+      assertEquals(interceptors, incomingInterceptorsField.get(remotingService));
+      assertEquals(interceptors, outgoingInterceptorsField.get(remotingService));
+   }
+
+   /**
+    * This test ensures that setInterceptors does not add the same instance of the interceptor available in the
+    * injected object registrty more than once.
+    */
+   @Test
+   public void testSetInterceptorsDoesNotAddInstanceFromInjectedObjectRegistryMoreThanOnce() throws Exception
+   {
+      // In order to test that the interceptors are properly set we need a handle on the interceptor list.
+      Field incomingInterceptorsField = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      incomingInterceptorsField.setAccessible(true);
+
+      Field outgoingInterceptorsField = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      outgoingInterceptorsField.setAccessible(true);
+
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("setInterceptors", Configuration.class);
+      method.setAccessible(true);
+
+      List<String> interceptorClassNames = new ArrayList<String>();
+      List<Interceptor> interceptors = new ArrayList<>();
+      Interceptor interceptor = new FakeInterceptor();
+      for (int i = 0; i < 2; i++)
+      {
+         interceptorClassNames.add(FakeInterceptor.class.getCanonicalName());
+         interceptors.add(interceptor);
+         injectedObjectRegistry.addIncomingInterceptor(interceptor);
+         injectedObjectRegistry.addOutgoingInterceptor(interceptor);
+      }
+
+      configuration.setIncomingInterceptorClassNames(interceptorClassNames);
+      configuration.setOutgoingInterceptorClassNames(interceptorClassNames);
+
+      method.invoke(remotingService, configuration);
+      assertTrue(((List) incomingInterceptorsField.get(remotingService)).size() == 2);
+      assertFalse(interceptors.equals(outgoingInterceptorsField.get(remotingService)));
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/fake/FakeInterceptor.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/fake/FakeInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.remoting.server.impl.fake;
+
+import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.core.protocol.core.Packet;
+import org.hornetq.spi.core.protocol.RemotingConnection;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeInterceptor implements Interceptor
+{
+
+   @Override
+   public boolean intercept(Packet packet, RemotingConnection connection) throws HornetQException
+   {
+      return false;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1125

This patch adds an InjectedObjectRegistry which stores references to
objects that are intended to be injected into HornetQ server.  This
allows WildFly to inject objects that Wildfly is responsible for
managing such as ExecutorServices. In addition Wildfly is able to create
objects in it's own class loader such as Intercepors and
ConnectorServiceFactories and inject them into HornetQ.  This means that
the HornetQ class loader does not need to be aware of the various
dependencies require to instantiate these objects.
