### PR TITLE
Fixing a few tests with issues on asynchronous .getMessageCount

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
@@ -367,4 +367,13 @@ public interface QueueControl
     */
    @Operation(desc = "Resets the MessagesAcknowledged property", impact = MBeanOperationInfo.ACTION)
    void resetMessagesAcknowledged() throws Exception;
+
+   /**
+    * it will flush one cycle on internal executors, so you would be sure that any pending tasks are done before you call
+    * any other measure.
+    * It is useful if you need the exact number of counts on a message
+    * @throws Exception
+    */
+   void flushExecutor();
+
 }

--- a/hornetq-jms-client/src/main/java/org/hornetq/api/jms/management/JMSQueueControl.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/api/jms/management/JMSQueueControl.java
@@ -277,4 +277,12 @@ public interface JMSQueueControl extends DestinationControl
    @Operation(desc = "List all the existent consumers on the Queue")
    String listConsumersAsJSON() throws Exception;
 
+   /**
+    * it will flush one cycle on internal executors, so you would be sure that any pending tasks are done before you call
+    * any other measure.
+    * It is useful if you need the exact number of counts on a message
+    * @throws Exception
+    */
+   void flushExecutor();
+
 }

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
@@ -362,6 +362,11 @@ public class JMSQueueControlImpl extends StandardMBean implements JMSQueueContro
       return coreQueueControl.getFilter();
    }
 
+   public void flushExecutor()
+   {
+      coreQueueControl.flushExecutor();
+   }
+
    @Override
    public MBeanInfo getMBeanInfo()
    {

--- a/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
@@ -941,6 +941,22 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
       }
    }
 
+
+   public void flushExecutor()
+   {
+      checkStarted();
+
+      clearIO();
+      try
+      {
+         queue.flushExecutor();
+      }
+      finally
+      {
+         blockOnIO();
+      }
+   }
+
    @Override
    public String listConsumersAsJSON() throws Exception
    {

--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1659,10 +1659,17 @@ public abstract class UnitTestCase extends CoreUnitTestCase
 
       for (QueueBinding qBinding : bindings)
       {
-         messageCount += qBinding.getQueue().getMessageCount();
+         qBinding.getQueue().flushExecutor();
+         messageCount += getMessageCount(qBinding.getQueue());
       }
 
       return messageCount;
+   }
+
+   protected int getMessageCount(final Queue queue)
+   {
+      queue.flushExecutor();
+      return (int)queue.getMessageCount();
    }
 
    protected List<QueueBinding> getLocalQueueBindings(final PostOffice postOffice, final String address) throws Exception

--- a/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/BMFailoverTest.java
+++ b/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/BMFailoverTest.java
@@ -170,7 +170,7 @@ public class BMFailoverTest extends FailoverTestBase
       //let's close the consumer so anything pending is handled
       consumer.close();
 
-      assertTrue("actual message count=" + inQ.getMessageCount(), inQ.getMessageCount() == 1);
+      assertEquals(1, getMessageCount(inQ));
    }
 
 
@@ -212,7 +212,7 @@ public class BMFailoverTest extends FailoverTestBase
       sendMessages(session, producer, 10);
       session.commit();
       Queue bindable = (Queue) backupServer.getServer().getPostOffice().getBinding(FailoverTestBase.ADDRESS).getBindable();
-      assertTrue(bindable.getMessageCount() == 10);
+      assertEquals(10, getMessageCount(bindable));
    }
 
    @Test
@@ -266,7 +266,8 @@ public class BMFailoverTest extends FailoverTestBase
          //pass
       }
       Queue bindable = (Queue) backupServer.getServer().getPostOffice().getBinding(FailoverTestBase.ADDRESS).getBindable();
-      assertTrue("messager count = " + bindable.getMessageCount(), bindable.getMessageCount() == 10);
+      assertEquals(10, getMessageCount(bindable));
+
    }
 
    @Override

--- a/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/HornetQMessageHandlerTest.java
+++ b/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/HornetQMessageHandlerTest.java
@@ -132,7 +132,7 @@ public class HornetQMessageHandlerTest extends HornetQRATestBase
       qResourceAdapter.stop();
 
       Binding binding = server.getPostOffice().getBinding(SimpleString.toSimpleString(MDBQUEUEPREFIXED));
-      assertEquals(1, ((Queue) binding.getBindable()).getMessageCount());
+      assertEquals(1, getMessageCount(((Queue) binding.getBindable())));
 
       server.stop();
       server.start();
@@ -212,7 +212,8 @@ public class HornetQMessageHandlerTest extends HornetQRATestBase
       qResourceAdapter.stop();
 
       Binding binding = server.getPostOffice().getBinding(SimpleString.toSimpleString(MDBQUEUEPREFIXED));
-      assertEquals(1, ((Queue) binding.getBindable()).getMessageCount());
+      assertEquals(1, getMessageCount(((Queue) binding.getBindable())));
+
 
       server.stop();
       server.start();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/CommitRollbackTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/CommitRollbackTest.java
@@ -156,9 +156,9 @@ public class CommitRollbackTest extends ServiceTestBase
       cc2.close();
       session.rollback();
       Assert.assertEquals(0, q2.getDeliveringCount());
-      Assert.assertEquals(numMessages, q.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(q));
       Assert.assertEquals(0, q2.getDeliveringCount());
-      Assert.assertEquals(numMessages, q.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(q));
       sendSession.close();
       session.close();
    }
@@ -209,10 +209,10 @@ public class CommitRollbackTest extends ServiceTestBase
       Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
       Queue q = (Queue) server.getPostOffice().getBinding(queueA).getBindable();
       Assert.assertEquals(numMessages, q.getDeliveringCount());
-      Assert.assertEquals(numMessages, q.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(q));
       session.commit();
       Assert.assertEquals(0, q.getDeliveringCount());
-      Assert.assertEquals(0, q.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(q));
       sendSession.close();
       session.close();
 
@@ -243,11 +243,11 @@ public class CommitRollbackTest extends ServiceTestBase
       Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
       Queue q = (Queue) server.getPostOffice().getBinding(queueA).getBindable();
       Assert.assertEquals(numMessages, q.getDeliveringCount());
-      Assert.assertEquals(numMessages, q.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(q));
       session.stop();
       session.rollback();
       Assert.assertEquals(0, q.getDeliveringCount());
-      Assert.assertEquals(numMessages, q.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(q));
       latch = new CountDownLatch(numMessages);
       cc.setMessageHandler(new ackHandler(session, latch));
       session.start();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ConsumerTest.java
@@ -135,7 +135,7 @@ public class ConsumerTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
    }
@@ -170,7 +170,7 @@ public class ConsumerTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
    }
@@ -209,7 +209,7 @@ public class ConsumerTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
    }
@@ -248,12 +248,12 @@ public class ConsumerTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
 
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(QUEUE).getBindable())));
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/DeadLetterAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/DeadLetterAddressTest.java
@@ -327,12 +327,12 @@ public class DeadLetterAddressTest extends ServiceTestBase
       long timeout = System.currentTimeMillis() + 5000;
 
       // DLA transfer is asynchronous fired on the rollback
-      while (System.currentTimeMillis() < timeout && ((Queue)server.getPostOffice().getBinding(qName).getBindable()).getMessageCount() != 0)
+      while (System.currentTimeMillis() < timeout && getMessageCount(((Queue)server.getPostOffice().getBinding(qName).getBindable())) != 0)
       {
          Thread.sleep(1);
       }
 
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(qName).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(qName).getBindable())));
       ClientMessage m = clientConsumer.receiveImmediate();
       Assert.assertNull(m);
       // All the messages should now be in the DLQ

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ExpiryLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ExpiryLargeMessageTest.java
@@ -143,14 +143,14 @@ public class ExpiryLargeMessageTest extends ServiceTestBase
       Thread.sleep(1500);
 
       long timeout = System.currentTimeMillis() + 5000;
-      while (timeout > System.currentTimeMillis() && queueExpiry.getMessageCount() != numberOfMessages)
+      while (timeout > System.currentTimeMillis() && getMessageCount(queueExpiry) != numberOfMessages)
       {
          // What the Expiry Scan would be doing
          myQueue.expireReferences();
          Thread.sleep(50);
       }
 
-      assertEquals(50, queueExpiry.getMessageCount());
+      assertEquals(50, getMessageCount(queueExpiry));
 
       session = sf.createSession(false, false);
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HangConsumerTest.java
@@ -147,9 +147,10 @@ public class HangConsumerTest extends ServiceTestBase
          producer.send(sessionProducer.createMessage(true));
          sessionProducer.commit();
 
-         // These two operations should finish without the test hanging
+         // These three operations should finish without the test hanging
+         queue.flushExecutor();
          queue.getMessagesAdded();
-         queue.getMessageCount();
+         getMessageCount(queue);
 
          releaseConsumers();
 
@@ -160,7 +161,7 @@ public class HangConsumerTest extends ServiceTestBase
 
          // a flush to guarantee any pending task is finished on flushing out delivery and pending msgs
          queue.flushExecutor();
-         Assert.assertEquals(2, queue.getMessageCount());
+         Assert.assertEquals(2, getMessageCount(queue));
          Assert.assertEquals(2, queue.getMessagesAdded());
 
          ClientMessage msg = consumer.receive(5000);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HeuristicXATest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HeuristicXATest.java
@@ -155,7 +155,7 @@ public class HeuristicXATest extends ServiceTestBase
 
       if (isCommit)
       {
-         Assert.assertEquals(1, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+         Assert.assertEquals(1, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
          session = sf.createSession(false, false, false);
 
@@ -170,7 +170,7 @@ public class HeuristicXATest extends ServiceTestBase
          session.close();
       }
 
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
    }
 
    @Test
@@ -237,7 +237,7 @@ public class HeuristicXATest extends ServiceTestBase
 
       if (isCommit)
       {
-         Assert.assertEquals(1, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+         Assert.assertEquals(1, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
          session = sf.createSession(false, false, false);
 
@@ -252,7 +252,7 @@ public class HeuristicXATest extends ServiceTestBase
          session.close();
       }
 
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       server.stop();
 
@@ -337,7 +337,7 @@ public class HeuristicXATest extends ServiceTestBase
 
       if (heuristicCommit)
       {
-         Assert.assertEquals(1, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+         Assert.assertEquals(1, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
          session = sf.createSession(false, false, false);
 
@@ -352,7 +352,7 @@ public class HeuristicXATest extends ServiceTestBase
          session.close();
       }
 
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       server.stop();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/LargeMessageTest.java
@@ -2504,7 +2504,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          Assert.assertEquals(0,
                              ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
          Assert.assertEquals(0,
-                             ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+                             getMessageCount(((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       }
       finally
@@ -2609,7 +2609,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          Assert.assertEquals(0,
                              ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
          Assert.assertEquals(0,
-                             ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+                             getMessageCount(((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       }
       finally
@@ -2942,7 +2942,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          Assert.assertEquals(0,
                              ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
          Assert.assertEquals(0,
-                             ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+                             getMessageCount(((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       }
       finally
@@ -3028,7 +3028,7 @@ public class LargeMessageTest extends LargeMessageTestBase
       Assert.assertEquals(0,
                           ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
       Assert.assertEquals(0,
-                          ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+                          getMessageCount(((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
       log.debug("Thread done");
    }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/MessageExpirationTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/MessageExpirationTest.java
@@ -157,7 +157,7 @@ public class MessageExpirationTest extends ServiceTestBase
       Thread.sleep(500);
 
       Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(queue).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(queue).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(queue).getBindable())));
 
       ClientMessage message2 = consumer.receiveImmediate();
       Assert.assertNull(message2);
@@ -188,7 +188,7 @@ public class MessageExpirationTest extends ServiceTestBase
       Assert.assertNull(message2);
 
       Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(queue).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(queue).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((Queue)server.getPostOffice().getBinding(queue).getBindable())));
 
       consumer.close();
       session.deleteQueue(queue);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/PagingOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/PagingOrderTest.java
@@ -304,9 +304,9 @@ public class PagingOrderTest extends ServiceTestBase
 
       assertEquals(0, errors.get());
 
-      assertEquals(numberOfMessages, q2.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(q2));
       assertEquals(numberOfMessages, q2.getMessagesAdded());
-      assertEquals(0, q1.getMessageCount());
+      assertEquals(0, getMessageCount(q1));
       assertEquals(numberOfMessages, q1.getMessagesAdded());
 
       session.close();
@@ -343,9 +343,9 @@ public class PagingOrderTest extends ServiceTestBase
 
       assertNotNull(q2);
 
-      assertEquals("q2 msg count", numberOfMessages, q2.getMessageCount());
+      assertEquals("q2 msg count", numberOfMessages, getMessageCount(q2));
       assertEquals("q2 msgs added", numberOfMessages, q2.getMessagesAdded());
-      assertEquals("q1 msg count", 0, q1.getMessageCount());
+      assertEquals("q1 msg count", 0, getMessageCount(q1));
       // 0, since nothing was sent to the queue after the server was restarted
       assertEquals("q1 msgs added", 0, q1.getMessagesAdded());
 
@@ -455,15 +455,15 @@ public class PagingOrderTest extends ServiceTestBase
 
       assertEquals(0, errors.get());
       long timeout = System.currentTimeMillis() + 10000;
-      while (numberOfMessages - 100 != q1.getMessageCount() && System.currentTimeMillis() < timeout)
+      while (numberOfMessages - 100 != getMessageCount(q1) && System.currentTimeMillis() < timeout)
       {
          Thread.sleep(500);
 
       }
 
-      assertEquals(numberOfMessages, q2.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(q2));
       assertEquals(numberOfMessages, q2.getMessagesAdded());
-      assertEquals(numberOfMessages - 100, q1.getMessageCount());
+      assertEquals(numberOfMessages - 100, getMessageCount(q1));
       assertEquals(numberOfMessages, q2.getMessagesAdded());
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/PagingTest.java
@@ -205,9 +205,9 @@ public class PagingTest extends ServiceTestBase
 
       session.start();
 
-      assertEquals(numberOfMessages * 2, queue.getMessageCount());
+      assertEquals(numberOfMessages * 2, getMessageCount(queue));
 
-      // The consumer has to be created after the queue.getMessageCount assertion
+      // The consumer has to be created after the getMessageCount(queue) assertion
       // otherwise delivery could alter the messagecount and give us a false failure
       ClientConsumer consumer = session.createConsumer(PagingTest.ADDRESS);
       ClientMessage msg = null;
@@ -231,7 +231,7 @@ public class PagingTest extends ServiceTestBase
 
       locator.close();
 
-      assertEquals(0, queue.getMessageCount());
+      assertEquals(0, getMessageCount(queue));
 
       waitForNotPaging(queue);
 
@@ -542,7 +542,7 @@ public class PagingTest extends ServiceTestBase
       assertNull(cons.receiveImmediate());
       session.commit();
 
-      System.out.println("count = " + queue.getMessageCount());
+      System.out.println("count = " + getMessageCount(queue));
 
       session.commit();
 
@@ -678,13 +678,13 @@ public class PagingTest extends ServiceTestBase
       session.commit();
       producer.close();
 
-      for (long timeout = System.currentTimeMillis() + 60000; timeout > System.currentTimeMillis() && qEXP.getMessageCount() < 1000; )
+      for (long timeout = System.currentTimeMillis() + 60000; timeout > System.currentTimeMillis() && getMessageCount(qEXP) < 1000; )
       {
-         System.out.println("count = " + qEXP.getMessageCount());
+         System.out.println("count = " + getMessageCount(qEXP));
          Thread.sleep(100);
       }
 
-      assertEquals(1000, qEXP.getMessageCount());
+      assertEquals(1000, getMessageCount(qEXP));
 
       session.start();
 
@@ -702,11 +702,11 @@ public class PagingTest extends ServiceTestBase
 
       assertNull(consumer.receiveImmediate());
 
-      for (long timeout = System.currentTimeMillis() + 5000; timeout > System.currentTimeMillis() && queue1.getMessageCount() != 0; )
+      for (long timeout = System.currentTimeMillis() + 5000; timeout > System.currentTimeMillis() && getMessageCount(queue1) != 0; )
       {
          Thread.sleep(100);
       }
-      assertEquals(0, queue1.getMessageCount());
+      assertEquals(0, getMessageCount(queue1));
 
       consumer.close();
 
@@ -721,10 +721,6 @@ public class PagingTest extends ServiceTestBase
       }
 
       assertNull(consumer.receiveImmediate());
-
-      System.out.println("count Exp = " + qEXP.getMessageCount());
-
-      System.out.println("msgCount = " + queue1.getMessageCount());
 
       // This is just to hold some messages as being delivered
       ClientConsumerInternal cons = (ClientConsumerInternal) session.createConsumer(ADDRESS);
@@ -909,7 +905,7 @@ public class PagingTest extends ServiceTestBase
 
       queue = server.locateQueue(PagingTest.ADDRESS);
 
-      assertEquals(0, queue.getMessageCount());
+      assertEquals(0, getMessageCount(queue));
 
       timeout = System.currentTimeMillis() + 10000;
       while (timeout > System.currentTimeMillis() && queue.getPageSubscription().getPagingStore().isPaging())
@@ -1007,7 +1003,7 @@ public class PagingTest extends ServiceTestBase
 
       Queue queue = server.locateQueue(ADDRESS);
 
-      assertEquals(numberOfMessages, queue.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(queue));
 
       LinkedList<Xid> xids = new LinkedList<Xid>();
 
@@ -1044,7 +1040,7 @@ public class PagingTest extends ServiceTestBase
 
       sessionCheck.close();
 
-      assertEquals(numberOfMessages, queue.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(queue));
 
       sf.close();
       locator.close();
@@ -1071,7 +1067,7 @@ public class PagingTest extends ServiceTestBase
 
       session.start();
 
-      assertEquals(numberOfMessages, queue.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(queue));
 
       ClientMessage msg = consumer.receive(5000);
       if (msg != null)
@@ -1125,7 +1121,7 @@ public class PagingTest extends ServiceTestBase
 
       locator.close();
 
-      assertEquals(0, queue.getMessageCount());
+      assertEquals(0, getMessageCount(queue));
 
       waitForNotPaging(queue);
    }
@@ -1300,7 +1296,7 @@ public class PagingTest extends ServiceTestBase
 
       Queue queue = server.locateQueue(ADDRESS);
 
-      assertEquals(numberOfMessages, queue.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(queue));
 
       int msgReceived = 0;
       ClientSession sessionConsumer = sf.createSession(false, false, false);
@@ -1334,7 +1330,7 @@ public class PagingTest extends ServiceTestBase
 
       locator.close();
 
-      assertEquals(0, queue.getMessageCount());
+      assertEquals(0, getMessageCount(queue));
 
       long timeout = System.currentTimeMillis() + 5000;
       while (timeout > System.currentTimeMillis() && queue.getPageSubscription().getPagingStore().isPaging())
@@ -1431,7 +1427,7 @@ public class PagingTest extends ServiceTestBase
 
       Queue queue = server.locateQueue(ADDRESS);
 
-      assertEquals(numberOfMessages, queue.getMessageCount());
+      assertEquals(numberOfMessages, getMessageCount(queue));
 
       int msgReceived = 0;
       ClientSession sessionConsumer = sf.createSession(false, false, false);
@@ -1465,7 +1461,7 @@ public class PagingTest extends ServiceTestBase
 
       locator.close();
 
-      assertEquals(0, queue.getMessageCount());
+      assertEquals(0, getMessageCount(queue));
 
       long timeout = System.currentTimeMillis() + 5000;
       while (timeout > System.currentTimeMillis() && queue.getPageSubscription().getPagingStore().isPaging())
@@ -1534,7 +1530,7 @@ public class PagingTest extends ServiceTestBase
 
       queue = server.locateQueue(ADDRESS);
 
-      // assertEquals(numberOfMessages, queue.getMessageCount());
+      // assertEquals(numberOfMessages, getMessageCount(queue));
 
       msgReceived = 0;
       sessionConsumer = sf.createSession(false, false, false);
@@ -2102,9 +2098,9 @@ public class PagingTest extends ServiceTestBase
             {
                while (running.get())
                {
-                  // log.info("Message count = " + queue.getMessageCount() + " on queue " + queue.getName());
+                  // log.info("Message count = " + getMessageCount(queue) + " on queue " + queue.getName());
                   queue.getMessagesAdded();
-                  queue.getMessageCount();
+                  getMessageCount(queue);
                   // log.info("Message added = " + queue.getMessagesAdded() + " on queue " + queue.getName());
                   Thread.sleep(10);
                }
@@ -3928,7 +3924,7 @@ public class PagingTest extends ServiceTestBase
       {
          Queue queue = (Queue) server.getPostOffice().getBinding(new SimpleString("someQueue" + i)).getBindable();
 
-         Assert.assertEquals("Queue someQueue" + i + " was supposed to be empty", 0, queue.getMessageCount());
+         Assert.assertEquals("Queue someQueue" + i + " was supposed to be empty", 0, getMessageCount(queue));
          Assert.assertEquals("Queue someQueue" + i + " was supposed to be empty", 0, queue.getDeliveringCount());
       }
    }
@@ -5439,7 +5435,7 @@ public class PagingTest extends ServiceTestBase
       producer.send(message);
 
       Queue q = (Queue) server.getPostOffice().getBinding(ADDRESS).getBindable();
-      Assert.assertEquals(3, q.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(q));
 
       // send a message with a dup ID that should fail b/c the address is full
       SimpleString dupID1 = new SimpleString("abcdefg");
@@ -5448,7 +5444,7 @@ public class PagingTest extends ServiceTestBase
 
       validateExceptionOnSending(producer, message);
 
-      Assert.assertEquals(3, q.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(q));
 
       ClientConsumer consumer = session.createConsumer(ADDRESS);
 
@@ -5461,11 +5457,11 @@ public class PagingTest extends ServiceTestBase
       session.commit(); // to make sure it's on the server (roundtrip)
       consumer.close();
 
-      Assert.assertEquals(2, q.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(q));
 
       producer.send(message);
 
-      Assert.assertEquals(3, q.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(q));
 
       consumer = session.createConsumer(ADDRESS);
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/QueueBrowserTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/QueueBrowserTest.java
@@ -310,7 +310,7 @@ public class QueueBrowserTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(100, ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(100, getMessageCount(((Queue)server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
 
@@ -347,7 +347,7 @@ public class QueueBrowserTest extends ServiceTestBase
       }
       // assert that all the messages are there and none have been acked
       Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
-      Assert.assertEquals(100, ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+      Assert.assertEquals(100, getMessageCount(((Queue)server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       session.close();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ReceiveImmediateTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ReceiveImmediateTest.java
@@ -255,7 +255,7 @@ public class ReceiveImmediateTest extends ServiceTestBase
       Assert.assertEquals(0, ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getDeliveringCount());
       int messagesOnServer = browser ? numMessages : 0;
       Assert.assertEquals(messagesOnServer,
-                          ((Queue)server.getPostOffice().getBinding(QUEUE).getBindable()).getMessageCount());
+                          getMessageCount(((Queue)server.getPostOffice().getBinding(QUEUE).getBindable())));
 
       consumer.close();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/SessionTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/SessionTest.java
@@ -350,9 +350,9 @@ public class SessionTest extends ServiceTestBase
       cp.send(clientSession.createMessage(false));
       cp.send(clientSession.createMessage(false));
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(queueName)).getBindable();
-      Assert.assertEquals(0, q.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(q));
       clientSession.commit();
-      Assert.assertEquals(10, q.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(q));
       clientSession.close();
    }
 
@@ -374,12 +374,12 @@ public class SessionTest extends ServiceTestBase
       cp.send(clientSession.createMessage(false));
       cp.send(clientSession.createMessage(false));
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(queueName)).getBindable();
-      Assert.assertEquals(0, q.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(q));
       clientSession.rollback();
       cp.send(clientSession.createMessage(false));
       cp.send(clientSession.createMessage(false));
       clientSession.commit();
-      Assert.assertEquals(2, q.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(q));
       clientSession.close();
    }
 
@@ -404,7 +404,7 @@ public class SessionTest extends ServiceTestBase
       cp.send(clientSession.createMessage(false));
       cp.send(clientSession.createMessage(false));
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(queueName)).getBindable();
-      Assert.assertEquals(10, q.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(q));
       ClientConsumer cc = clientSession.createConsumer(queueName);
       clientSession.start();
       ClientMessage m = cc.receive(5000);
@@ -438,7 +438,7 @@ public class SessionTest extends ServiceTestBase
       Assert.assertNotNull(m);
       m.acknowledge();
       clientSession.commit();
-      Assert.assertEquals(0, q.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(q));
       clientSession.close();
       sendSession.close();
    }
@@ -464,7 +464,7 @@ public class SessionTest extends ServiceTestBase
       cp.send(clientSession.createMessage(false));
       cp.send(clientSession.createMessage(false));
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(queueName)).getBindable();
-      Assert.assertEquals(10, q.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(q));
       ClientConsumer cc = clientSession.createConsumer(queueName);
       clientSession.start();
       ClientMessage m = cc.receive(5000);
@@ -498,7 +498,7 @@ public class SessionTest extends ServiceTestBase
       Assert.assertNotNull(m);
       m.acknowledge();
       clientSession.rollback();
-      Assert.assertEquals(10, q.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(q));
       clientSession.close();
       sendSession.close();
    }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/TransactionalSendTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/TransactionalSendTest.java
@@ -62,17 +62,17 @@ public class TransactionalSendTest extends ServiceTestBase
          cp.send(session.createMessage(false));
       }
       Queue q = (Queue) server.getPostOffice().getBinding(queueA).getBindable();
-      Assert.assertEquals(q.getMessageCount(), 0);
+      Assert.assertEquals(0, getMessageCount(q));
       session.commit();
-      Assert.assertEquals(q.getMessageCount(), numMessages);
+      Assert.assertEquals(getMessageCount(q), numMessages);
       // now send some more
       for (int i = 0; i < numMessages; i++)
       {
          cp.send(session.createMessage(false));
       }
-      Assert.assertEquals(q.getMessageCount(), numMessages);
+      Assert.assertEquals(numMessages, getMessageCount(q));
       session.commit();
-      Assert.assertEquals(q.getMessageCount(), numMessages * 2);
+      Assert.assertEquals(numMessages * 2, getMessageCount(q));
       session.close();
    }
 
@@ -91,17 +91,17 @@ public class TransactionalSendTest extends ServiceTestBase
          cp.send(session.createMessage(false));
       }
       Queue q = (Queue) server.getPostOffice().getBinding(queueA).getBindable();
-      Assert.assertEquals(q.getMessageCount(), 0);
+      Assert.assertEquals(getMessageCount(q), 0);
       session.rollback();
-      Assert.assertEquals(q.getMessageCount(), 0);
+      Assert.assertEquals(getMessageCount(q), 0);
       // now send some more
       for (int i = 0; i < numMessages; i++)
       {
          cp.send(session.createMessage(false));
       }
-      Assert.assertEquals(q.getMessageCount(), 0);
+      Assert.assertEquals(0, getMessageCount(q));
       session.commit();
-      Assert.assertEquals(q.getMessageCount(), numMessages);
+      Assert.assertEquals(numMessages, getMessageCount(q));
       session.close();
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ColocatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ColocatedFailoverTest.java
@@ -561,17 +561,17 @@ public class ColocatedFailoverTest extends ServiceTestBase
 
          long timeout = System.currentTimeMillis() + 5000;
 
-         while (numMessages != myDurSub2Queue.getMessageCount() && timeout > System.currentTimeMillis())
+         while (numMessages != getMessageCount(myDurSub2Queue) && timeout > System.currentTimeMillis())
          {
             Thread.sleep(10);
          }
-         while (numMessages != myDurSub3Queue.getMessageCount() && timeout > System.currentTimeMillis())
+         while (numMessages != getMessageCount(myDurSub3Queue) && timeout > System.currentTimeMillis())
          {
             Thread.sleep(10);
          }
 
-         assertEquals(numMessages, myDurSub2Queue.getMessageCount());
-         assertEquals(numMessages, myDurSub3Queue.getMessageCount());
+         assertEquals(numMessages, getMessageCount(myDurSub2Queue));
+         assertEquals(numMessages, getMessageCount(myDurSub3Queue));
 
          // now pause the SnF queues so messages get stranded there
          Bindings bindingsForAddress = liveServer1.getServer().getPostOffice().getBindingsForAddress(topic);
@@ -605,9 +605,9 @@ public class ColocatedFailoverTest extends ServiceTestBase
          }
 
          String snfAddress = "sf.cluster1." + liveServer2.getServer().getNodeID().toString();
-         assertEquals(numMessages, ((LocalQueueBinding) liveServer1.getServer().getPostOffice().getBinding(SimpleString.toSimpleString(snfAddress))).getQueue().getMessageCount());
+         assertEquals(numMessages, getMessageCount(((LocalQueueBinding) liveServer1.getServer().getPostOffice().getBinding(SimpleString.toSimpleString(snfAddress))).getQueue()));
          snfAddress = "sf.cluster1." + server3.getNodeID().toString();
-         assertEquals(numMessages, ((LocalQueueBinding) liveServer1.getServer().getPostOffice().getBinding(SimpleString.toSimpleString(snfAddress))).getQueue().getMessageCount());
+         assertEquals(numMessages, getMessageCount(((LocalQueueBinding) liveServer1.getServer().getPostOffice().getBinding(SimpleString.toSimpleString(snfAddress))).getQueue()));
 
          liveServer1.crash(true, session1);
 
@@ -759,7 +759,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
          IntegrationTestLogger.LOGGER.info("Committed transaction: " + xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(q.getMessageCount(), 0);
+      assertEquals(getMessageCount(q), 0);
       assertEquals(q.getMessagesAdded(), 1);
    }
 
@@ -793,7 +793,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().rollback(xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(q.getMessageCount(), 1);
+      assertEquals(getMessageCount(q), 1);
       assertEquals(q.getMessagesAdded(), 1);
       ClientConsumer consumer1 = session2.createConsumer(queue);
       session2.start();
@@ -833,7 +833,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().rollback(xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(q.getMessageCount(), 1);
+      assertEquals(getMessageCount(q), 1);
       assertEquals(q.getMessagesAdded(), 1);
       liveServer2.stop();
       liveServer2.start();
@@ -883,7 +883,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().commit(xid, false);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(500, q.getMessageCount());
+      assertEquals(500, getMessageCount(q));
       assertEquals(1000, q.getMessagesAdded());
    }
 
@@ -925,7 +925,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().rollback(xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1000, q.getMessageCount());
+      assertEquals(1000, getMessageCount(q));
       assertEquals(1000, q.getMessagesAdded());
    }
 
@@ -969,7 +969,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
       liveServer2.stop();
       liveServer2.start();
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1000, q.getMessageCount());
+      assertEquals(1000, getMessageCount(q));
       assertEquals(1000, q.getMessagesAdded());
    }
 
@@ -1005,10 +1005,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().commit(xid, false);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(0, q.getMessageCount());
+      assertEquals(0, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
    }
 
@@ -1044,10 +1044,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().rollback(xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
    }
 
@@ -1085,10 +1085,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
       liveServer2.stop();
       liveServer2.start();
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
    }
 
@@ -1128,10 +1128,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().commit(xid, false);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(2, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(2, q.getMessageCount());
+      assertEquals(2, getMessageCount(q));
       assertEquals(2, q.getMessagesAdded());
    }
 
@@ -1171,10 +1171,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
          session2.getXAResource().rollback(xid);
       }
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
    }
 
@@ -1216,10 +1216,10 @@ public class ColocatedFailoverTest extends ServiceTestBase
       liveServer2.stop();
       liveServer2.start();
       Queue q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
       q = (Queue) liveServer2.getServer().getPostOffice().getBinding(queue2).getBindable();
-      assertEquals(1, q.getMessageCount());
+      assertEquals(1, getMessageCount(q));
       assertEquals(1, q.getMessagesAdded());
    }
 
@@ -1339,7 +1339,7 @@ public class ColocatedFailoverTest extends ServiceTestBase
       latch2.await(10, TimeUnit.SECONDS);
       Binding binding = liveServer2.getServer().getPostOffice().getBinding(new SimpleString("jms.queue.testQueue"));
       QueueImpl q = (QueueImpl) binding.getBindable();
-      assertEquals(numMessages * 2, q.getMessageCount());
+      assertEquals(numMessages * 2, getMessageCount(q));
    }
 
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
@@ -276,7 +276,7 @@ public abstract class MultipleServerFailoverTestBase extends ServiceTestBase
       do
       {
 
-         if (q.getMessageCount() >= messageCount)
+         if (getMessageCount(q) >= messageCount)
          {
             return;
          }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/bridge/BridgeTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/bridge/BridgeTestBase.java
@@ -565,6 +565,7 @@ public abstract class BridgeTestBase extends UnitTestCase
       //server may be closed
       if (queueControl != null)
       {
+         queueControl.flushExecutor();
          Long messageCount = queueControl.getMessageCount();
 
          if (messageCount > 0)

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/client/ExpiryMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/client/ExpiryMessageTest.java
@@ -58,8 +58,6 @@ public class ExpiryMessageTest extends JMSTestBase
       Topic topic = createTopic("test-topic");
       TopicControl control = ManagementControlHelper.createTopicControl(topic, mbeanServer);
 
-      System.out.println("size = " + control.getMessageCount());
-
       Connection conn2 = cf.createConnection();
 
       conn2.setClientID("client1");

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/consumer/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/consumer/ConsumerTest.java
@@ -150,8 +150,8 @@ public class ConsumerTest extends JMSTestBase
       }
 
       SimpleString queueName = new SimpleString(HornetQDestination.JMS_QUEUE_ADDRESS_PREFIX + ConsumerTest.Q_NAME);
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(queueName).getBindable()));
+      Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(queueName).getBindable()));
    }
 
    @Test
@@ -203,7 +203,7 @@ public class ConsumerTest extends JMSTestBase
 
       SimpleString queueName = new SimpleString(HornetQDestination.JMS_QUEUE_ADDRESS_PREFIX + ConsumerTest.Q_NAME);
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(queueName).getBindable()));
       conn.close();
    }
 
@@ -288,7 +288,7 @@ public class ConsumerTest extends JMSTestBase
 
       SimpleString queueName = new SimpleString(HornetQDestination.JMS_QUEUE_ADDRESS_PREFIX + ConsumerTest.Q_NAME);
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(queueName).getBindable()));
       conn.close();
    }
 
@@ -318,7 +318,7 @@ public class ConsumerTest extends JMSTestBase
       // Messages should all have been acked since we set pre ack on the cf
       SimpleString queueName = new SimpleString(HornetQDestination.JMS_QUEUE_ADDRESS_PREFIX + ConsumerTest.Q_NAME);
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getDeliveringCount());
-      Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(queueName).getBindable()).getMessageCount());
+      Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(queueName).getBindable()));
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlTest.java
@@ -97,7 +97,7 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
       Assert.assertEquals(0, queueControl.getConsumerCount());
 
       Connection connection = JMSUtil.createConnection(InVMConnectorFactory.class.getName());
@@ -111,7 +111,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       JMSUtil.sendMessages(queue, 2);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
       Assert.assertEquals(2, queueControl.getMessagesAdded());
 
       connection.start();
@@ -119,7 +119,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       Assert.assertNotNull(consumer.receive(500));
       Assert.assertNotNull(consumer.receive(500));
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
       Assert.assertEquals(2, queueControl.getMessagesAdded());
 
       consumer.close();
@@ -134,11 +134,11 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       String[] ids = JMSUtil.sendMessages(queue, 2);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       Map<String, Object>[] data = queueControl.listMessages(null);
       Assert.assertEquals(2, data.length);
@@ -157,11 +157,11 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       String[] ids = JMSUtil.sendMessages(queue, 2);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       String jsonString = queueControl.listMessagesAsJSON(null);
       Assert.assertNotNull(jsonString);
@@ -183,11 +183,11 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       JMSUtil.sendMessages(queue, 2);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       Map<String, Object>[] data = queueControl.listMessages(null);
       Assert.assertEquals(2, data.length);
@@ -204,7 +204,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       queueControl.removeMessage(messageID.toString());
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
    }
 
    @Test
@@ -214,7 +214,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       try
       {
@@ -231,15 +231,15 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       JMSUtil.sendMessages(queue, 2);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       queueControl.removeMessages(null);
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       Connection connection = JMSUtil.createConnection(InVMConnectorFactory.class.getName());
       connection.start();
@@ -255,7 +255,7 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       JMSQueueControl queueControl = createManagementControl();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       Connection conn = createConnection();
 
@@ -270,12 +270,12 @@ public class JMSQueueControlTest extends ManagementTestBase
       message.setStringProperty("foo", "baz");
       producer.send(message);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       int removedMatchingMessagesCount = queueControl.removeMessages("foo = 'bar'");
       Assert.assertEquals(1, removedMatchingMessagesCount);
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       conn.start();
       MessageConsumer consumer = JMSUtil.createConsumer(conn, queue);
@@ -293,7 +293,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       JMSUtil.sendMessages(queue, 1);
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       Map<String, Object>[] data = queueControl.listMessages(null);
       // retrieve the first message info
@@ -324,7 +324,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       String[] messageIDs = JMSUtil.sendMessages(queue, 1);
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       try
       {
@@ -378,11 +378,11 @@ public class JMSQueueControlTest extends ManagementTestBase
       Message msg_2 = JMSUtil.sendMessageWithProperty(session, queue, key, unmatchingValue);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       int changedMessagesCount = queueControl.changeMessagesPriority(filter, newPriority);
       Assert.assertEquals(1, changedMessagesCount);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       connection.start();
       MessageConsumer consumer = session.createConsumer(queue);
@@ -470,13 +470,13 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       String[] messageIDs = JMSUtil.sendMessages(queue, 1);
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(0, expiryQueueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(0, getMessageCount(expiryQueueControl));
 
       Assert.assertTrue(queueControl.expireMessage(messageIDs[0]));
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
-      Assert.assertEquals(1, expiryQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(expiryQueueControl));
 
       Connection connection = JMSUtil.createConnection(InVMConnectorFactory.class.getName());
       connection.start();
@@ -524,11 +524,11 @@ public class JMSQueueControlTest extends ManagementTestBase
       connection.close();
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       int expiredMessagesCount = queueControl.expireMessages(filter);
       Assert.assertEquals(1, expiredMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // consume the unmatched message from queue
       JMSUtil.consumeMessages(1, queue);
@@ -550,7 +550,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSUtil.sendMessageWithProperty(session, queue, key, unmatchingValue);
       JMSUtil.sendMessageWithProperty(session, queue, key, matchingValue);
 
-      Assert.assertEquals(3, queueControl.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(queueControl));
 
       Assert.assertEquals(2, queueControl.countMessages(key + " =" + matchingValue));
       Assert.assertEquals(1, queueControl.countMessages(key + " =" + unmatchingValue));
@@ -615,15 +615,15 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSQueueControl queueControl = createManagementControl();
       JMSQueueControl dlqControl = ManagementControlHelper.createJMSQueueControl(dlq, mbeanServer);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
-      Assert.assertEquals(0, dlqControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
+      Assert.assertEquals(0, getMessageCount(dlqControl));
 
       queueControl.setDeadLetterAddress(dlq.getAddress());
 
       boolean movedToDeadLetterAddress = queueControl.sendMessageToDeadLetterAddress(message.getJMSMessageID());
       Assert.assertTrue(movedToDeadLetterAddress);
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(1, dlqControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(dlqControl));
 
       // check there is a single message to consume from queue
       JMSUtil.consumeMessages(1, queue);
@@ -674,15 +674,15 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSQueueControl queueControl = createManagementControl();
       JMSQueueControl dlqControl = ManagementControlHelper.createJMSQueueControl(dlq, mbeanServer);
 
-      Assert.assertEquals(2, queueControl.getMessageCount());
-      Assert.assertEquals(0, dlqControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
+      Assert.assertEquals(0, getMessageCount(dlqControl));
 
       queueControl.setDeadLetterAddress(dlq.getAddress());
 
       int deadMessageCount = queueControl.sendMessagesToDeadLetterAddress(filter);
       Assert.assertEquals(1, deadMessageCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(1, dlqControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(dlqControl));
 
       conn.start();
       MessageConsumer consumer = sess.createConsumer(queue);
@@ -711,12 +711,12 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSUtil.sendMessages(queue, 2);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // moved all messages to otherQueue
       int movedMessagesCount = queueControl.moveMessages(null, otherQueueName);
       Assert.assertEquals(2, movedMessagesCount);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       // check there is no message to consume from queue
       JMSUtil.consumeMessages(0, queue);
@@ -763,12 +763,12 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSUtil.sendMessageWithProperty(session, queue, key, unmatchingValue);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // moved matching messages to otherQueue
       int movedMessagesCount = queueControl.moveMessages(filter, otherQueueName);
       Assert.assertEquals(1, movedMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       connection.start();
       MessageConsumer consumer = session.createConsumer(queue);
@@ -795,11 +795,11 @@ public class JMSQueueControlTest extends ManagementTestBase
       String[] messageIDs = JMSUtil.sendMessages(queue, 1);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       boolean moved = queueControl.moveMessage(messageIDs[0], otherQueueName);
       Assert.assertTrue(moved);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       JMSUtil.consumeMessages(0, queue);
       JMSUtil.consumeMessages(1, otherQueue);
@@ -844,7 +844,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSQueueControl otherQueueControl = ManagementControlHelper.createJMSQueueControl((HornetQQueue) otherQueue,
                                                                                         mbeanServer);
 
-      Assert.assertEquals(10, queueControl.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queueControl));
 
       int moved = queueControl.moveMessages(null, otherQueueName, true);
 
@@ -879,9 +879,9 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       locator.close();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
-      Assert.assertEquals(0, otherQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(otherQueueControl));
 
       serverManager.destroyQueue(otherQueueName);
    }
@@ -930,7 +930,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSQueueControl otherQueueControl = ManagementControlHelper.createJMSQueueControl((HornetQQueue) otherQueue,
                                                                                         mbeanServer);
 
-      Assert.assertEquals(10, queueControl.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queueControl));
 
       for (int i = 0; i < 10; i++)
       {
@@ -966,9 +966,9 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       locator.close();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
-      Assert.assertEquals(0, otherQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(otherQueueControl));
 
       serverManager.destroyQueue(otherQueueName);
    }
@@ -1001,8 +1001,8 @@ public class JMSQueueControlTest extends ManagementTestBase
       JMSQueueControl otherQueueControl = ManagementControlHelper.createJMSQueueControl((HornetQQueue) otherQueue,
                                                                                         mbeanServer);
 
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(1, otherQueueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(otherQueueControl));
 
       int moved = queueControl.moveMessages(null, otherQueueName, true);
 
@@ -1034,9 +1034,9 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       locator.close();
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
-      Assert.assertEquals(0, otherQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(otherQueueControl));
 
       serverManager.destroyQueue(otherQueueName);
    }
@@ -1050,7 +1050,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       serverManager.createQueue(false, otherQueueName, null, true, otherQueueName);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       try
       {
@@ -1177,7 +1177,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       String[] messageIDs = JMSUtil.sendMessages(queue, 1);
 
       JMSQueueControl queueControl = createManagementControl();
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       try
       {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
@@ -89,6 +89,20 @@ public class JMSQueueControlUsingJMSTest extends JMSQueueControlTest
 
       return new JMSQueueControl()
       {
+
+         @Override
+         public void flushExecutor()
+         {
+            try
+            {
+               proxy.invokeOperation("flushExecutor");
+            }
+            catch (Exception e)
+            {
+               throw new RuntimeException(e.getMessage(), e);
+            }
+         }
+
          public boolean changeMessagePriority(final String messageID, final int newPriority) throws Exception
          {
             return (Boolean)proxy.invokeOperation("changeMessagePriority", messageID, newPriority);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ManagementTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/ManagementTestBase.java
@@ -12,6 +12,7 @@
  */
 package org.hornetq.tests.integration.management;
 import org.hornetq.api.core.management.QueueControl;
+import org.hornetq.api.jms.management.JMSQueueControl;
 import org.junit.Before;
 import org.junit.After;
 
@@ -121,6 +122,18 @@ public abstract class ManagementTestBase extends ServiceTestBase
       return queueControl;
    }
 
+   protected long getMessageCount(JMSQueueControl control) throws Exception
+   {
+      control.flushExecutor();
+      return control.getMessageCount();
+   }
+
+
+   protected long getMessageCount(QueueControl control) throws Exception
+   {
+      control.flushExecutor();
+      return control.getMessageCount();
+   }
 
    // Private -------------------------------------------------------
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlTest.java
@@ -253,15 +253,15 @@ public class QueueControlTest extends ManagementTestBase
       session.createQueue(address, queue, null, false);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       ClientProducer producer = session.createProducer(address);
       producer.send(session.createMessage(false));
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       ManagementTestBase.consumeMessages(1, session, queue);
 
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       session.deleteQueue(queue);
    }
@@ -275,7 +275,7 @@ public class QueueControlTest extends ManagementTestBase
       session.createQueue(address, queue, null, false);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       // It's empty, so it's supposed to be like this
       assertEquals("[{}]", queueControl.getFirstMessageAsJSON());
@@ -803,12 +803,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(message);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // moved all messages to otherQueue
       int movedMessagesCount = queueControl.moveMessages(null, otherQueue.toString());
       Assert.assertEquals(1, movedMessagesCount);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       // check there is no message to consume from queue
       ManagementTestBase.consumeMessages(0, session, queue);
@@ -843,7 +843,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(message);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // moved all messages to unknown queue
       try
@@ -854,7 +854,7 @@ public class QueueControlTest extends ManagementTestBase
       catch (Exception e)
       {
       }
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       ManagementTestBase.consumeMessages(1, session, queue);
 
@@ -895,12 +895,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(unmatchingMessage);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // moved matching messages to otherQueue
       int movedMatchedMessagesCount = queueControl.moveMessages(key + " =" + matchingValue, otherQueue.toString());
       Assert.assertEquals(1, movedMatchedMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // consume the unmatched message from queue
       ClientConsumer consumer = session.createConsumer(queue);
@@ -940,8 +940,8 @@ public class QueueControlTest extends ManagementTestBase
 
       QueueControl queueControl = createManagementControl(address, queue);
       QueueControl otherQueueControl = createManagementControl(otherAddress, otherQueue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
-      Assert.assertEquals(0, otherQueueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
+      Assert.assertEquals(0, getMessageCount(otherQueueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -950,8 +950,8 @@ public class QueueControlTest extends ManagementTestBase
 
       boolean moved = queueControl.moveMessage(messageID, otherQueue.toString());
       Assert.assertTrue(moved);
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(1, otherQueueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(otherQueueControl));
 
       ManagementTestBase.consumeMessages(1, session, queue);
       ManagementTestBase.consumeMessages(1, session, otherQueue);
@@ -974,7 +974,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(session.createMessage(false));
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -990,7 +990,7 @@ public class QueueControlTest extends ManagementTestBase
       catch (Exception e)
       {
       }
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       ManagementTestBase.consumeMessages(1, session, queue);
 
@@ -1027,12 +1027,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(unmatchingMessage);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // removed matching messages to otherQueue
       int removedMatchedMessagesCount = queueControl.removeMessages(key + " =" + matchingValue);
       Assert.assertEquals(1, removedMatchedMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // consume the unmatched message from queue
       ClientConsumer consumer = session.createConsumer(queue);
@@ -1072,12 +1072,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(unmatchingMessage);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // removed matching messages to otherQueue
       int removedMatchedMessagesCount = queueControl.removeMessages(5, key + " =" + matchingValue);
       Assert.assertEquals(1, removedMatchedMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // consume the unmatched message from queue
       ClientConsumer consumer = session.createConsumer(queue);
@@ -1109,12 +1109,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(session.createMessage(false));
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // removed matching messages to otherQueue
       int removedMatchedMessagesCount = queueControl.removeMessages(null);
       Assert.assertEquals(2, removedMatchedMessagesCount);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       session.deleteQueue(queue);
    }
@@ -1133,12 +1133,12 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(session.createMessage(false));
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // removed matching messages to otherQueue
       int removedMatchedMessagesCount = queueControl.removeMessages("");
       Assert.assertEquals(2, removedMatchedMessagesCount);
-      Assert.assertEquals(0, queueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
 
       session.deleteQueue(queue);
    }
@@ -1157,7 +1157,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(session.createMessage(false));
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -1167,7 +1167,7 @@ public class QueueControlTest extends ManagementTestBase
       // delete 1st message
       boolean deleted = queueControl.removeMessage(messageID);
       Assert.assertTrue(deleted);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // check there is a single message to consume from queue
       ManagementTestBase.consumeMessages(1, session, queue);
@@ -1246,7 +1246,7 @@ public class QueueControlTest extends ManagementTestBase
       }
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(100, queueControl.getMessageCount());
+      Assert.assertEquals(100, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -1257,7 +1257,7 @@ public class QueueControlTest extends ManagementTestBase
       // delete 1st message
       boolean deleted = queueControl.removeMessage(messageID);
       Assert.assertTrue(deleted);
-      Assert.assertEquals(99, queueControl.getMessageCount());
+      Assert.assertEquals(99, getMessageCount(queueControl));
 
       cons.close();
 
@@ -1290,7 +1290,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(matchingMessage);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(3, queueControl.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(queueControl));
 
       Assert.assertEquals(2, queueControl.countMessages(key + " =" + matchingValue));
       Assert.assertEquals(1, queueControl.countMessages(key + " =" + unmatchingValue));
@@ -1338,7 +1338,7 @@ public class QueueControlTest extends ManagementTestBase
 
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(110, queueControl.getMessageCount());
+      Assert.assertEquals(110, getMessageCount(queueControl));
 
 
       Assert.assertEquals(0, queueControl.countMessages("nonExistentProperty like \'%Temp/88\'"));
@@ -1373,11 +1373,11 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(unmatchingMessage);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       int expiredMessagesCount = queueControl.expireMessages(key + " =" + matchingValue);
       Assert.assertEquals(1, expiredMessagesCount);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // consume the unmatched message from queue
       ClientConsumer consumer = session.createConsumer(queue);
@@ -1413,8 +1413,8 @@ public class QueueControlTest extends ManagementTestBase
 
       QueueControl queueControl = createManagementControl(address, queue);
       QueueControl expiryQueueControl = createManagementControl(expiryAddress, expiryQueue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(0, expiryQueueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(0, getMessageCount(expiryQueueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -1424,8 +1424,8 @@ public class QueueControlTest extends ManagementTestBase
       queueControl.setExpiryAddress(expiryAddress.toString());
       boolean expired = queueControl.expireMessage(messageID);
       Assert.assertTrue(expired);
-      Assert.assertEquals(0, queueControl.getMessageCount());
-      Assert.assertEquals(1, expiryQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(expiryQueueControl));
 
       ManagementTestBase.consumeMessages(0, session, queue);
       ManagementTestBase.consumeMessages(1, session, expiryQueue);
@@ -1453,7 +1453,7 @@ public class QueueControlTest extends ManagementTestBase
 
       QueueControl queueControl = createManagementControl(address, queue);
       QueueControl deadLetterQueueControl = createManagementControl(deadLetterAddress, deadLetterQueue);
-      Assert.assertEquals(2, queueControl.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -1462,11 +1462,11 @@ public class QueueControlTest extends ManagementTestBase
 
       queueControl.setDeadLetterAddress(deadLetterAddress.toString());
 
-      Assert.assertEquals(0, deadLetterQueueControl.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(deadLetterQueueControl));
       boolean movedToDeadLetterAddress = queueControl.sendMessageToDeadLetterAddress(messageID);
       Assert.assertTrue(movedToDeadLetterAddress);
-      Assert.assertEquals(1, queueControl.getMessageCount());
-      Assert.assertEquals(1, deadLetterQueueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
+      Assert.assertEquals(1, getMessageCount(deadLetterQueueControl));
 
       // check there is a single message to consume from queue
       ManagementTestBase.consumeMessages(1, session, queue);
@@ -1495,7 +1495,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(message);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);
@@ -1529,7 +1529,7 @@ public class QueueControlTest extends ManagementTestBase
       producer.send(message);
 
       QueueControl queueControl = createManagementControl(address, queue);
-      Assert.assertEquals(1, queueControl.getMessageCount());
+      Assert.assertEquals(1, getMessageCount(queueControl));
 
       // the message IDs are set on the server
       Map<String, Object>[] messages = queueControl.listMessages(null);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
@@ -41,6 +41,19 @@ public class QueueControlUsingCoreTest extends QueueControlTest
       {
          private final CoreMessagingProxy proxy = new CoreMessagingProxy(session, ResourceNames.CORE_QUEUE + queue);
 
+         @Override
+         public void flushExecutor()
+         {
+            try
+            {
+               proxy.invokeOperation("flushExecutor");
+            }
+            catch (Exception e)
+            {
+               throw new RuntimeException(e.getMessage(), e);
+            }
+         }
+
          public boolean changeMessagePriority(final long messageID, final int newPriority) throws Exception
          {
             return (Boolean) proxy.invokeOperation("changeMessagePriority", messageID, newPriority);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PageCountSyncOnNonTXTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PageCountSyncOnNonTXTest.java
@@ -160,7 +160,7 @@ public class PageCountSyncOnNonTXTest extends ServiceTestBase
 
             assertNotNull(queue);
 
-            long msgs = queue.getMessageCount();
+            long msgs = getMessageCount(queue);
 
             ClientSessionFactory factory = locator.createSessionFactory();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PagingWithFailoverAndCountersTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PagingWithFailoverAndCountersTest.java
@@ -326,7 +326,7 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
 
             while (isRunning(1))
             {
-               long count = queue2.getMessageCount();
+               long count = getMessageCount(queue2);
                if (count < 0)
                {
                   fail("count < 0 .... being " + count);
@@ -428,7 +428,7 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
       Queue queue = server.locateQueue(SimpleString.toSimpleString("cons2"));
 
 
-      int messageCount = (int) queue.getMessageCount();
+      int messageCount = (int) getMessageCount(queue);
 
       assertTrue(messageCount >= 0);
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/proton/ProtonTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/proton/ProtonTest.java
@@ -143,7 +143,7 @@ public class ProtonTest extends ServiceTestBase
 
             connection.close();
             Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
-            assertEquals(q.getMessageCount(), numMessages);
+            assertEquals(getMessageCount(q), numMessages);
 
             connection = createConnection();
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -161,7 +161,7 @@ public class ProtonTest extends ServiceTestBase
             }
             assertEquals(count, numMessages);
             connection.close();
-            assertEquals(q.getMessageCount(), numMessages);
+            assertEquals(getMessageCount(q), numMessages);
          }
       }, 5000);
    }
@@ -184,7 +184,7 @@ public class ProtonTest extends ServiceTestBase
       session.commit();
       connection.close();
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
-      assertEquals(q.getMessageCount(), numMessages);
+      assertEquals(getMessageCount(q), numMessages);
    }
 
    @Test
@@ -204,7 +204,7 @@ public class ProtonTest extends ServiceTestBase
       }
       connection.close();
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
-      assertEquals(q.getMessageCount(), 0);
+      assertEquals(getMessageCount(q), 0);
    }
 
    @Test
@@ -225,7 +225,7 @@ public class ProtonTest extends ServiceTestBase
       }
       connection.close();
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
-      assertEquals(q.getMessageCount(), numMessages);
+      assertEquals(getMessageCount(q), numMessages);
       //now create a new connection and receive
       connection = createConnection();
       session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -233,7 +233,7 @@ public class ProtonTest extends ServiceTestBase
       Thread.sleep(1000);
       consumer.close();
       connection.close();
-      assertEquals(numMessages, q.getMessageCount());
+      assertEquals(numMessages, getMessageCount(q));
       long taken = (System.currentTimeMillis() - time) / 1000;
       System.out.println("taken = " + taken);
    }
@@ -256,7 +256,7 @@ public class ProtonTest extends ServiceTestBase
       }
       connection.close();
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
-      assertEquals(q.getMessageCount(), numMessages);
+      assertEquals(getMessageCount(q), numMessages);
       //now create a new connection and receive
       connection = createConnection();
       session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
@@ -278,7 +278,7 @@ public class ProtonTest extends ServiceTestBase
 
       consumer.close();
       connection.close();
-      assertEquals(0, q.getMessageCount());
+      assertEquals(0, getMessageCount(q));
       long taken = (System.currentTimeMillis() - time) / 1000;
       System.out.println("taken = " + taken);
 
@@ -326,7 +326,7 @@ public class ProtonTest extends ServiceTestBase
       Queue q = (Queue) server.getPostOffice().getBinding(new SimpleString(address)).getBindable();
 
       connection.close();
-      assertEquals(0, q.getMessageCount());
+      assertEquals(0, getMessageCount(q));
       long taken = (System.currentTimeMillis() - time) / 1000;
       System.out.println("taken = " + taken);
    }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/HornetQMessageHandlerXATest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/HornetQMessageHandlerXATest.java
@@ -114,7 +114,7 @@ public class HornetQMessageHandlerXATest extends HornetQRATestBase
       assertEquals(endpoint.lastMessage.getCoreMessage().getBodyBuffer().readString(), "teststring");
 
       Binding binding = server.getPostOffice().getBinding(MDBQUEUEPREFIXEDSIMPLE);
-      long messageCount = ((Queue) binding.getBindable()).getMessageCount();
+      long messageCount = getMessageCount((Queue) binding.getBindable());
       assertEquals(1, messageCount);
    }
 
@@ -154,7 +154,7 @@ public class HornetQMessageHandlerXATest extends HornetQRATestBase
       assertEquals(endpoint.lastMessage.getCoreMessage().getBodyBuffer().readString(), "teststring");
 
       Binding binding = server.getPostOffice().getBinding(MDBQUEUEPREFIXEDSIMPLE);
-      long messageCount = ((Queue) binding.getBindable()).getMessageCount();
+      long messageCount = getMessageCount((Queue) binding.getBindable());
       assertEquals(1, messageCount);
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/security/SecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/security/SecurityTest.java
@@ -507,7 +507,7 @@ public class SecurityTest extends ServiceTestBase
       session.close();
 
       Queue binding = (Queue) server.getPostOffice().getBinding(new SimpleString(SecurityTest.queueA)).getBindable();
-      Assert.assertEquals(0, binding.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(binding));
    }
 
    @Test
@@ -886,7 +886,7 @@ public class SecurityTest extends ServiceTestBase
       session.close();
 
       Queue binding = (Queue) server.getPostOffice().getBinding(new SimpleString(SecurityTest.queueA)).getBindable();
-      Assert.assertEquals(0, binding.getMessageCount());
+      Assert.assertEquals(0, getMessageCount(binding));
 
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/ScaleDown3NodeTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/ScaleDown3NodeTest.java
@@ -177,7 +177,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the message is not in the queue on node 2
-         messageCount = snfQueue.getMessageCount();
+         messageCount = getMessageCount(snfQueue);
          if (messageCount < TEST_SIZE)
          {
             Thread.sleep(200);
@@ -189,7 +189,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       }
 
       // ensure the message is in the SnF queue
-      Assert.assertEquals(TEST_SIZE, snfQueue.getMessageCount());
+      Assert.assertEquals(TEST_SIZE, getMessageCount(snfQueue));
 
       // trigger scaleDown from node 0 to node 1
       IntegrationTestLogger.LOGGER.info("============ Stopping " + servers[0].getNodeID());
@@ -201,7 +201,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the message is not in the queue on node 2
-         messageCount = ((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount();
+         messageCount = getMessageCount(((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue());
          if (messageCount > 0)
          {
             Thread.sleep(200);
@@ -222,7 +222,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the message is not in the queue on node 2
-         messageCount = ((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount();
+         messageCount = getMessageCount(((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue());
          if (messageCount < TEST_SIZE)
          {
             Thread.sleep(200);
@@ -317,7 +317,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the message is not in the queue on node 2
-         messageCount = snfQueue.getMessageCount();
+         messageCount = getMessageCount(snfQueue);
          if (messageCount < TEST_SIZE * 2)
          {
             Thread.sleep(200);
@@ -329,7 +329,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       }
 
       // ensure the message is in the SnF queue
-      Assert.assertEquals(TEST_SIZE * 2, snfQueue.getMessageCount());
+      Assert.assertEquals(TEST_SIZE * 2, getMessageCount(snfQueue));
 
       // trigger scaleDown from node 0 to node 1
       IntegrationTestLogger.LOGGER.info("============ Stopping " + servers[0].getNodeID());
@@ -342,8 +342,8 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the messages are not in the queues on node 2
-         messageCount = ((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount();
-         messageCount += ((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName3))).getQueue().getMessageCount();
+         messageCount = getMessageCount(((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue());
+         messageCount += getMessageCount(((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName3))).getQueue());
          if (messageCount > 0)
          {
             Thread.sleep(200);
@@ -356,7 +356,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
 
       Assert.assertEquals(0, messageCount);
 
-      Assert.assertEquals(TEST_SIZE, ((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue().getMessageCount());
+      Assert.assertEquals(TEST_SIZE, getMessageCount(((LocalQueueBinding) servers[2].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue()));
 
       // get the messages from queue 1 on node 1
       addConsumer(0, 1, queueName1, null);
@@ -367,8 +367,8 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       while (System.currentTimeMillis() - start < timeout)
       {
          // ensure the message is not in the queue on node 2
-         messageCount = ((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount();
-         messageCount += ((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName3))).getQueue().getMessageCount();
+         messageCount = getMessageCount(((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue());
+         messageCount += getMessageCount(((LocalQueueBinding) servers[1].getPostOffice().getBinding(new SimpleString(queueName3))).getQueue());
          if (messageCount < TEST_SIZE * 2)
          {
             Thread.sleep(200);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/ScaleDownTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/server/ScaleDownTest.java
@@ -125,8 +125,8 @@ public class ScaleDownTest extends ClusterTestBase
 //      removeConsumer(1);
 
       // at this point on node 0 there should be 2 messages in testQueue1 and 1 message in testQueue2
-      Assert.assertEquals(TEST_SIZE, ((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount());
-      Assert.assertEquals(TEST_SIZE - 1, ((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue().getMessageCount());
+      Assert.assertEquals(TEST_SIZE, getMessageCount(((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue()));
+      Assert.assertEquals(TEST_SIZE - 1, getMessageCount(((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue()));
 
       // trigger scaleDown from node 0 to node 1
       servers[0].stop();
@@ -200,9 +200,9 @@ public class ScaleDownTest extends ClusterTestBase
       removeConsumer(1);
 
       // at this point on node 0 there should be 0 messages in testQueue and TEST_SIZE messages in the sfQueue
-      Assert.assertEquals(0, ((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue().getMessageCount());
-      Assert.assertEquals(0, ((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue().getMessageCount());
-      Assert.assertEquals(TEST_SIZE * 2, ((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(sfQueueName))).getQueue().getMessageCount());
+      Assert.assertEquals(0, getMessageCount(((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName1))).getQueue()));
+      Assert.assertEquals(0, getMessageCount(((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(queueName2))).getQueue()));
+      Assert.assertEquals(TEST_SIZE * 2, getMessageCount(((LocalQueueBinding) servers[0].getPostOffice().getBinding(new SimpleString(sfQueueName))).getQueue()));
 
       // trigger scaleDown from node 0 to node 1
       servers[0].stop();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/largemessage/LargeMessageTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/largemessage/LargeMessageTestBase.java
@@ -527,7 +527,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
          session.close();
 
          Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
-         Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getMessageCount());
+         Assert.assertEquals(0, getMessageCount((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()));
 
          validateNoFilesOnLargeDir();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/util/JMSTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/util/JMSTestBase.java
@@ -31,6 +31,8 @@ import java.util.Random;
 import java.util.Set;
 
 import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.api.core.management.QueueControl;
+import org.hornetq.api.jms.management.JMSQueueControl;
 import org.hornetq.core.config.Configuration;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.HornetQServers;
@@ -104,6 +106,20 @@ public class JMSTestBase extends ServiceTestBase
    protected Topic createTopic(final String topicName) throws Exception
    {
       return createTopic(false, topicName);
+   }
+
+
+   protected long getMessageCount(JMSQueueControl control) throws Exception
+   {
+      control.flushExecutor();
+      return control.getMessageCount();
+   }
+
+
+   protected long getMessageCount(QueueControl control) throws Exception
+   {
+      control.flushExecutor();
+      return control.getMessageCount();
    }
 
    /**

--- a/tests/jms-tests/src/test/java/org/hornetq/jms/tests/tools/container/LocalTestServer.java
+++ b/tests/jms-tests/src/test/java/org/hornetq/jms/tests/tools/container/LocalTestServer.java
@@ -420,6 +420,7 @@ public class LocalTestServer implements Server, Runnable
                                                                  .getResource(ResourceNames.JMS_QUEUE + queueName);
       if (queue != null)
       {
+         queue.flushExecutor();
          return queue.getMessageCount();
       }
       else

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/QueueImplTest.java
@@ -266,7 +266,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -332,7 +332,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -342,13 +342,13 @@ public class QueueImplTest extends UnitTestCase
       queue.addConsumer(consumer);
 
       Assert.assertTrue(consumer.getReferences().isEmpty());
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
 
       queue.deliverNow();
 
       assertRefListsIdenticalRefs(refs, consumer.getReferences());
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
    }
@@ -388,13 +388,13 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
       queue.deliverNow();
 
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -404,7 +404,7 @@ public class QueueImplTest extends UnitTestCase
       queue.deliverNow();
 
       assertRefListsIdenticalRefs(refs, consumer.getReferences());
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(10, queue.getDeliveringCount());
    }
@@ -444,13 +444,13 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
       queue.deliverNow();
 
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -465,7 +465,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(20, queue.getMessageCount());
+      Assert.assertEquals(20, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -484,7 +484,7 @@ public class QueueImplTest extends UnitTestCase
       queue.deliverNow();
 
       assertRefListsIdenticalRefs(refs, consumer.getReferences());
-      Assert.assertEquals(30, queue.getMessageCount());
+      Assert.assertEquals(30, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(30, queue.getDeliveringCount());
    }
@@ -583,7 +583,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -593,7 +593,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
 
@@ -625,7 +625,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(numMessages * 2, queue.getMessageCount());
+      Assert.assertEquals(numMessages * 2, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages * 2, queue.getDeliveringCount());
 
@@ -659,7 +659,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(numMessages * 3, queue.getMessageCount());
+      Assert.assertEquals(numMessages * 3, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages * 3, queue.getDeliveringCount());
 
@@ -691,7 +691,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(numMessages * 2, queue.getMessageCount());
+      Assert.assertEquals(numMessages * 2, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages * 2, queue.getDeliveringCount());
 
@@ -720,7 +720,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
 
@@ -904,7 +904,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
 
       Iterator<MessageReference> iterator = queue.iterator();
       List<MessageReference> list = new ArrayList<MessageReference>();
@@ -964,7 +964,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.flushExecutor();
 
-      Assert.assertEquals(2, queue.getMessageCount());
+      Assert.assertEquals(2, getMessageCount(queue));
 
       awaitExecution();
 
@@ -1001,7 +1001,7 @@ public class QueueImplTest extends UnitTestCase
       refs.add(ref4);
 
       queue.flushExecutor();
-      Assert.assertEquals(3, queue.getMessageCount());
+      Assert.assertEquals(3, getMessageCount(queue));
 
       awaitExecution();
 
@@ -1047,7 +1047,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -1100,13 +1100,13 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
       queue.deliverNow();
 
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -1121,7 +1121,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(20, queue.getMessageCount());
+      Assert.assertEquals(20, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -1140,7 +1140,7 @@ public class QueueImplTest extends UnitTestCase
       queue.deliverNow();
 
       Assert.assertEquals(numMessages, consumer.getReferences().size());
-      Assert.assertEquals(30, queue.getMessageCount());
+      Assert.assertEquals(30, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(10, queue.getDeliveringCount());
 
@@ -1180,13 +1180,13 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
       queue.deliverNow();
 
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -1205,7 +1205,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(20, queue.getMessageCount());
+      Assert.assertEquals(20, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(10, queue.getDeliveringCount());
 
@@ -1221,7 +1221,7 @@ public class QueueImplTest extends UnitTestCase
       queue.deliverNow();
 
       Assert.assertEquals(20, consumer.getReferences().size());
-      Assert.assertEquals(30, queue.getMessageCount());
+      Assert.assertEquals(30, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(20, queue.getDeliveringCount());
    }
@@ -1301,7 +1301,7 @@ public class QueueImplTest extends UnitTestCase
       }
 
       queue.flushExecutor();
-      Assert.assertEquals(6, queue.getMessageCount());
+      Assert.assertEquals(6, getMessageCount(queue));
 
       awaitExecution();
 
@@ -1322,7 +1322,7 @@ public class QueueImplTest extends UnitTestCase
 
       queue.deliverNow();
 
-      Assert.assertEquals(4, queue.getMessageCount());
+      Assert.assertEquals(4, getMessageCount(queue));
 
       Assert.assertEquals(4, consumer.getReferences().size());
 
@@ -1470,7 +1470,7 @@ public class QueueImplTest extends UnitTestCase
       }
       // even as this queue is paused, it will receive the messages anyway
       queue.flushExecutor();
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
 
@@ -1480,13 +1480,13 @@ public class QueueImplTest extends UnitTestCase
       queue.addConsumer(consumer);
 
       Assert.assertTrue(consumer.getReferences().isEmpty());
-      Assert.assertEquals(10, queue.getMessageCount());
+      Assert.assertEquals(10, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       // explicit order of delivery
       queue.deliverNow();
       // As the queue is paused, even an explicit order of delivery will not work.
       Assert.assertEquals(0, consumer.getReferences().size());
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       // resuming work
@@ -1495,7 +1495,7 @@ public class QueueImplTest extends UnitTestCase
       awaitExecution();
       // after resuming the delivery begins.
       assertRefListsIdenticalRefs(refs, consumer.getReferences());
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
 
@@ -1544,7 +1544,7 @@ public class QueueImplTest extends UnitTestCase
       // the queue even if it's paused will receive the message but won't forward
       // directly to the consumer until resumed.
       queue.flushExecutor();
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
       Assert.assertTrue(consumer.getReferences().isEmpty());
@@ -1557,7 +1557,7 @@ public class QueueImplTest extends UnitTestCase
 
       // resuming delivery of messages
       assertRefListsIdenticalRefs(refs, consumer.getReferences());
-      Assert.assertEquals(numMessages, queue.getMessageCount());
+      Assert.assertEquals(numMessages, getMessageCount(queue));
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
 
    }


### PR DESCRIPTION
We have recently changed getMessageCount to not flush on executors any longer, but some of our tests were expecting that behaviour. for that reason I replaced a few calls to .getMessageCount() to some method that will do the old semantic.
