### PR TITLE
HORNETQ-1125 Added ServiceRegistry to Server

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -325,6 +325,8 @@ public class HornetQServerImpl implements HornetQServer
 
    private boolean scheduledPoolSupplied = false;
 
+   private ServiceRegistry serviceRegistry;
+
    // Constructors
    // ---------------------------------------------------------------------------------
 
@@ -365,6 +367,15 @@ public class HornetQServerImpl implements HornetQServer
                             final HornetQSecurityManager securityManager,
                             final HornetQServer parentServer)
    {
+      this(configuration, mbeanServer, securityManager, parentServer, null);
+   }
+
+   public HornetQServerImpl(Configuration configuration,
+                            MBeanServer mbeanServer,
+                            final HornetQSecurityManager securityManager,
+                            final HornetQServer parentServer,
+                            final ServiceRegistry serviceRegistry)
+   {
       if (configuration == null)
       {
          configuration = new ConfigurationImpl();
@@ -396,39 +407,7 @@ public class HornetQServerImpl implements HornetQServer
 
       this.parentServer = parentServer;
 
-   }
-
-
-   public HornetQServerImpl(Configuration configuration,
-                            MBeanServer mbeanServer,
-                            final HornetQSecurityManager securityManager,
-                            final HornetQServer parentServer,
-                            final ExecutorService threadPool,
-                            final ScheduledExecutorService scheduledPool)
-   {
-      this(configuration, mbeanServer, securityManager, parentServer);
-
-      if (threadPool != null)
-      {
-         this.threadPool = threadPool;
-         this.executorFactory = new OrderedExecutorFactory(threadPool);
-         this.threadPoolSupplied = true;
-      }
-
-      if (scheduledPool != null)
-      {
-         this.scheduledPool = scheduledPool;
-         this.scheduledPoolSupplied = true;
-      }
-   }
-
-   public HornetQServerImpl(Configuration configuration,
-                            MBeanServer mbeanServer,
-                            final HornetQSecurityManager securityManager,
-                            final ExecutorService threadPool,
-                            final ScheduledExecutorService scheduledPool)
-   {
-      this(configuration, mbeanServer, securityManager, null, threadPool, scheduledPool);
+      this.serviceRegistry = serviceRegistry == null ?  new ServiceRegistry() : serviceRegistry;
    }
 
    // life-cycle methods
@@ -537,7 +516,7 @@ public class HornetQServerImpl implements HornetQServer
                                                      identity != null ? identity : "");
          }
          // start connector service
-         connectorsService = new ConnectorsService(configuration, storageManager, scheduledPool, postOffice);
+         connectorsService = new ConnectorsService(configuration, storageManager, scheduledPool, postOffice, serviceRegistry);
          connectorsService.start();
       }
       finally
@@ -1694,6 +1673,53 @@ public class HornetQServerImpl implements HornetQServer
 
 
    /**
+    * Sets up HornetQ Executor Services.
+    */
+   private void initializeExecutorServices()
+   {
+      /* We check to see if a Thread Pool is supplied in the InjectedObjectRegistry.  If so we created a new Ordered
+       * Executor based on the provided Thread pool.  Otherwise we create a new ThreadPool.
+       */
+      if (serviceRegistry.getExecutorService() == null)
+      {
+         ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-server-" + this.toString(), false, getThisClassLoader());
+         if (configuration.getThreadPoolMaxSize() == -1)
+         {
+            threadPool = Executors.newCachedThreadPool(tFactory);
+         }
+         else
+         {
+            threadPool = Executors.newFixedThreadPool(configuration.getThreadPoolMaxSize(), tFactory);
+         }
+      }
+      else
+      {
+         threadPool = serviceRegistry.getExecutorService();
+         this.threadPoolSupplied = true;
+      }
+      this.executorFactory = new OrderedExecutorFactory(threadPool);
+
+       /* We check to see if a Scheduled Executor Service is provided in the InjectedObjectRegistry.  If so we use this
+       * Scheduled ExecutorService otherwise we create a new one.
+       */
+      if (serviceRegistry.getScheduledExecutorService() == null)
+      {
+         ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-scheduled-threads", false, getThisClassLoader());
+         scheduledPool = new ScheduledThreadPoolExecutor(configuration.getScheduledThreadPoolMaxSize(), tFactory);
+      }
+      else
+      {
+         this.scheduledPoolSupplied = true;
+         this.scheduledPool = serviceRegistry.getScheduledExecutorService();
+      }
+   }
+
+   public ServiceRegistry getServiceRegistry()
+   {
+      return serviceRegistry;
+   }
+
+   /**
     * Starts everything apart from RemotingService and loading the data.
     * <p/>
     * After optional intermediary steps, Part 1 is meant to be followed by part 2
@@ -1704,38 +1730,14 @@ public class HornetQServerImpl implements HornetQServer
    {
       if (state == SERVER_STATE.STOPPED)
          return false;
+
       // Create the pools - we have two pools - one for non scheduled - and another for scheduled
-
-      ThreadFactory tFactory = new HornetQThreadFactory("HornetQ-server-" + this.toString(),
-                                                        false,
-                                                        getThisClassLoader());
-
+      initializeExecutorServices();
 
       if (configuration.getJournalType() == JournalType.ASYNCIO && !AIOSequentialFileFactory.isSupported())
       {
          HornetQServerLogger.LOGGER.switchingNIO();
          configuration.setJournalType(JournalType.NIO);
-      }
-
-      if (!threadPoolSupplied)
-      {
-         if (configuration.getThreadPoolMaxSize() == -1)
-         {
-            threadPool = Executors.newCachedThreadPool(tFactory);
-         }
-         else
-         {
-            threadPool = Executors.newFixedThreadPool(configuration.getThreadPoolMaxSize(), tFactory);
-         }
-         executorFactory = new OrderedExecutorFactory(threadPool);
-      }
-
-      if (!scheduledPoolSupplied)
-      {
-         scheduledPool = new ScheduledThreadPoolExecutor(configuration.getScheduledThreadPoolMaxSize(),
-                                                         new HornetQThreadFactory("HornetQ-scheduled-threads",
-                                                                                  false,
-                                                                                  getThisClassLoader()));
       }
 
       managementService = new ManagementServiceImpl(mbeanServer, configuration);
@@ -1802,7 +1804,14 @@ public class HornetQServerImpl implements HornetQServer
 
       clusterManager.deploy();
 
-      remotingService = new RemotingServiceImpl(clusterManager, configuration, this, managementService, scheduledPool, protocolManagerFactories,  executorFactory.getExecutor());
+      remotingService = new RemotingServiceImpl(clusterManager,
+                                                configuration,
+                                                this,
+                                                managementService,
+                                                scheduledPool,
+                                                protocolManagerFactories,
+                                                executorFactory.getExecutor(),
+                                                serviceRegistry);
 
       messagingServerControl = managementService.registerServer(postOffice,
                                                                 storageManager,

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServiceRegistry.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServiceRegistry.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.core.server.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.api.core.Pair;
+import org.hornetq.core.config.ConnectorServiceConfiguration;
+import org.hornetq.core.server.ConnectorServiceFactory;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class ServiceRegistry
+{
+   private ExecutorService executorService;
+
+   private ScheduledExecutorService scheduledExecutorService;
+
+   /* We are using a List rather than HashMap here as HornetQ allows multiple instances of the same class to be added
+   * to the interceptor list
+   */
+   private Map<String, Interceptor> incomingInterceptors;
+
+   private Map<String, Interceptor> outgoingInterceptors;
+
+   private Map<String, Pair<ConnectorServiceFactory, ConnectorServiceConfiguration>> connectorServices;
+
+   public ServiceRegistry()
+   {
+      this.incomingInterceptors = new ConcurrentHashMap<String, Interceptor>();
+      this.outgoingInterceptors = new ConcurrentHashMap<String, Interceptor>();
+      this.connectorServices = new ConcurrentHashMap<String, Pair<ConnectorServiceFactory, ConnectorServiceConfiguration>>();
+   }
+
+   public ExecutorService getExecutorService()
+   {
+      return executorService;
+   }
+
+   public void setExecutorService(ExecutorService executorService)
+   {
+      this.executorService = executorService;
+   }
+
+   public ScheduledExecutorService getScheduledExecutorService()
+   {
+      return scheduledExecutorService;
+   }
+
+   public void setScheduledExecutorService(ScheduledExecutorService scheduledExecutorService)
+   {
+      this.scheduledExecutorService = scheduledExecutorService;
+   }
+
+   public void addConnectorService(ConnectorServiceFactory connectorServiceFactory, ConnectorServiceConfiguration configuration)
+   {
+      connectorServices.put(configuration.getConnectorName(), new Pair<>(connectorServiceFactory, configuration));
+   }
+
+   public void removeConnectorService(ConnectorServiceConfiguration configuration)
+   {
+      connectorServices.remove(configuration.getConnectorName());
+   }
+
+   public Collection<Pair<ConnectorServiceFactory, ConnectorServiceConfiguration>> getConnectorServices()
+   {
+      return connectorServices.values();
+   }
+
+   public void addIncomingInterceptor(String name, Interceptor interceptor)
+   {
+      incomingInterceptors.put(name, interceptor);
+   }
+
+   public void removeIncomingInterceptor(String name)
+   {
+      incomingInterceptors.remove(name);
+   }
+
+   public Collection<Interceptor> getIncomingInterceptors()
+   {
+      return Collections.unmodifiableCollection(incomingInterceptors.values());
+   }
+
+   public Interceptor getIncomingInterceptor(String name)
+   {
+      return incomingInterceptors.get(name);
+   }
+
+   public void addOutgoingInterceptor(String name, Interceptor interceptor)
+   {
+      outgoingInterceptors.put(name, interceptor);
+   }
+
+   public Interceptor getOutgoingInterceptor(String name)
+   {
+      return outgoingInterceptors.get(name);
+   }
+
+   public void removeOutgoingInterceptor(String name)
+   {
+      outgoingInterceptors.remove(name);
+   }
+
+   public Collection<Interceptor> getOutgoingInterceptors()
+   {
+      return Collections.unmodifiableCollection(outgoingInterceptors.values());
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/ConnectorsServiceTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/ConnectorsServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.ConnectorServiceConfiguration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.server.ConnectorService;
+import org.hornetq.core.server.impl.ConnectorsService;
+import org.hornetq.core.server.impl.ServiceRegistry;
+import org.hornetq.tests.unit.core.config.impl.fakes.FakeConnectorService;
+import org.hornetq.tests.unit.core.config.impl.fakes.FakeConnectorServiceFactory;
+import org.hornetq.tests.util.UnitTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class ConnectorsServiceTest extends UnitTestCase
+{
+   private Configuration configuration;
+
+   private ServiceRegistry serviceRegistry;
+
+   @Before
+   public void setUp() throws Exception
+   {
+      // Setup Configuration
+      configuration = new ConfigurationImpl();
+      serviceRegistry = new ServiceRegistry();
+   }
+
+   /**
+    * Test that the connectors added via the service registry are added to the connectorsService,
+    * @throws Exception
+    */
+   @Test
+   public void testConnectorsServiceUsesInjectedConnectorServiceFactory() throws Exception
+   {
+      ConnectorServiceConfiguration connectorServiceConfiguration =
+         new ConnectorServiceConfiguration(null, new HashMap<String, Object>(), "myfact");
+
+      // Creates a fake connector service factory that returns the fake connector service object
+      ConnectorService connectorService = new FakeConnectorService();
+      FakeConnectorServiceFactory connectorServiceFactory = new FakeConnectorServiceFactory();
+
+      serviceRegistry.addConnectorService(connectorServiceFactory, connectorServiceConfiguration);
+      ConnectorsService connectorsService = new ConnectorsService(configuration, null, null, null, serviceRegistry);
+      connectorsService.start();
+
+      assertTrue(connectorsService.getConnectors().size() == 1);
+      assertTrue(connectorsService.getConnectors().contains(connectorServiceFactory.getConnectorService()));
+   }
+
+   /**
+    * Test that the connectors added via the config are added to the connectors service.
+    * @throws Exception
+    */
+   @Test
+   public void testConnectorsServiceUsesConfiguredConnectorServices() throws Exception
+   {
+      ConnectorServiceConfiguration connectorServiceConfiguration =
+         new ConnectorServiceConfiguration(FakeConnectorServiceFactory.class.getCanonicalName(), new HashMap<String, Object>(), "myfact");
+
+      List<ConnectorServiceConfiguration> connectorServiceConfigurations = new ArrayList<ConnectorServiceConfiguration>();
+      connectorServiceConfigurations.add(connectorServiceConfiguration);
+
+      configuration.setConnectorServiceConfigurations(connectorServiceConfigurations);
+      ConnectorsService connectorsService = new ConnectorsService(configuration, null, null, null, serviceRegistry);
+      connectorsService.start();
+
+      assertTrue(connectorsService.getConnectors().size() == 1);
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorService.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl.fakes;
+
+import org.hornetq.core.server.ConnectorService;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeConnectorService implements ConnectorService
+{
+   @Override
+   public String getName()
+   {
+      return null;
+   }
+
+   @Override
+   public void start() throws Exception
+   {
+   }
+
+   @Override
+   public void stop() throws Exception
+   {
+   }
+
+   @Override
+   public boolean isStarted()
+   {
+      return false;
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorServiceFactory.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/fakes/FakeConnectorServiceFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.config.impl.fakes;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.hornetq.core.persistence.StorageManager;
+import org.hornetq.core.postoffice.PostOffice;
+import org.hornetq.core.server.ConnectorService;
+import org.hornetq.core.server.ConnectorServiceFactory;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeConnectorServiceFactory implements ConnectorServiceFactory
+{
+   private ConnectorService connectorService;
+
+   public FakeConnectorServiceFactory()
+   {
+      this.connectorService = new FakeConnectorService();
+   }
+
+   @Override
+   public ConnectorService createConnectorService(String connectorName, Map<String, Object> configuration, StorageManager storageManager, PostOffice postOffice, ScheduledExecutorService scheduledThreadPool)
+   {
+      if (connectorService == null)
+      {
+         return new FakeConnectorService();
+      }
+      return connectorService;
+   }
+
+   @Override
+   public Set<String> getAllowableProperties()
+   {
+      return new HashSet<String>();
+   }
+
+   @Override
+   public Set<String> getRequiredProperties()
+   {
+      return new HashSet<String>();
+   }
+
+   public ConnectorService getConnectorService()
+   {
+      return connectorService;
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/RemotingServiceImplTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/RemotingServiceImplTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.remoting.server.impl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.config.impl.ConfigurationImpl;
+import org.hornetq.core.remoting.server.impl.RemotingServiceImpl;
+import org.hornetq.core.server.impl.ServiceRegistry;
+import org.hornetq.tests.unit.core.remoting.server.impl.fake.FakeInterceptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class RemotingServiceImplTest
+{
+   private ServiceRegistry serviceRegistry;
+
+   private RemotingServiceImpl remotingService;
+
+   private Configuration configuration;
+
+   @Before
+   public void setUp() throws Exception
+   {
+      serviceRegistry = new ServiceRegistry();
+      configuration = new ConfigurationImpl();
+      configuration.setAcceptorConfigurations(new HashSet<TransportConfiguration>());
+      remotingService = new RemotingServiceImpl(null, configuration, null, null, null, null, null, serviceRegistry);
+   }
+
+   /**
+    * Tests that the method addReflectivelyInstantiatedInterceptors creates new instances of interceptors and adds
+    * them to the provided list.
+    */
+   @Test
+   public void testAddReflectivelyInstantiatedInterceptorsAddsNewInstancesToList() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("addReflectivelyInstantiatedInterceptors",
+                                                                  List.class,
+                                                                  List.class);
+      method.setAccessible(true);
+      List<String> interceptorClassNames = new ArrayList<String>();
+      for (int i = 0; i < 5; i++)
+      {
+         interceptorClassNames.add(FakeInterceptor.class.getCanonicalName());
+      }
+      List<Interceptor> interceptors = new ArrayList<Interceptor>();
+      method.invoke(remotingService, interceptorClassNames, interceptors);
+
+      assertTrue(interceptors.size() == 5);
+      assertTrue(interceptors.get(0) instanceof FakeInterceptor);
+      assertTrue(interceptors.get(0) != interceptors.get(1));
+   }
+
+   /**
+    * Tests ensures that setInterceptors methods adds both interceptors from the service registry and also interceptors
+    * defined in the configuration.
+    */
+   @Test
+   public void testSetInterceptorsAddsBothInterceptorsFromConfigAndServiceRegistry() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("setInterceptors",
+                                                                  Configuration.class);
+      Field incomingInterceptors = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      Field outgoingInterceptors = RemotingServiceImpl.class.getDeclaredField("outgoingInterceptors");
+
+      method.setAccessible(true);
+      incomingInterceptors.setAccessible(true);
+      outgoingInterceptors.setAccessible(true);
+
+      serviceRegistry.addIncomingInterceptor("Foo", new FakeInterceptor());
+      serviceRegistry.addOutgoingInterceptor("Bar", new FakeInterceptor());
+
+      List<String> interceptorClassNames = new ArrayList<String>();
+      interceptorClassNames.add(FakeInterceptor.class.getCanonicalName());
+      configuration.setIncomingInterceptorClassNames(interceptorClassNames);
+      configuration.setOutgoingInterceptorClassNames(interceptorClassNames);
+
+      method.invoke(remotingService, configuration);
+
+      assertTrue(((List) incomingInterceptors.get(remotingService)).size() == 2 );
+      assertTrue(((List) outgoingInterceptors.get(remotingService)).size() == 2 );
+      assertTrue(((List) incomingInterceptors.get(remotingService)).contains(serviceRegistry.getIncomingInterceptor("Foo")));
+      assertTrue(((List) outgoingInterceptors.get(remotingService)).contains(serviceRegistry.getOutgoingInterceptor("Bar")));
+   }
+
+   /**
+    * Tests ensures that both interceptors from the service registry and also interceptors defined in the configuration
+    * are added to the RemotingServiceImpl on creation
+    */
+   @Test
+   public void testInterceptorsAreAddedOnCreationOfServiceRegistry() throws Exception
+   {
+      Method method = RemotingServiceImpl.class.getDeclaredMethod("setInterceptors",
+                                                                  Configuration.class);
+      Field incomingInterceptors = RemotingServiceImpl.class.getDeclaredField("incomingInterceptors");
+      Field outgoingInterceptors = RemotingServiceImpl.class.getDeclaredField("outgoingInterceptors");
+
+      method.setAccessible(true);
+      incomingInterceptors.setAccessible(true);
+      outgoingInterceptors.setAccessible(true);
+
+      serviceRegistry.addIncomingInterceptor("Foo", new FakeInterceptor());
+      serviceRegistry.addOutgoingInterceptor("Bar", new FakeInterceptor());
+
+      List<String> interceptorClassNames = new ArrayList<String>();
+      interceptorClassNames.add(FakeInterceptor.class.getCanonicalName());
+      configuration.setIncomingInterceptorClassNames(interceptorClassNames);
+      configuration.setOutgoingInterceptorClassNames(interceptorClassNames);
+
+      remotingService = new RemotingServiceImpl(null, configuration, null, null, null, null, null, serviceRegistry);
+
+      assertTrue(((List) incomingInterceptors.get(remotingService)).size() == 2 );
+      assertTrue(((List) outgoingInterceptors.get(remotingService)).size() == 2 );
+      assertTrue(((List) incomingInterceptors.get(remotingService)).contains(serviceRegistry.getIncomingInterceptor("Foo")));
+      assertTrue(((List) outgoingInterceptors.get(remotingService)).contains(serviceRegistry.getOutgoingInterceptor("Bar")));
+   }
+}

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/fake/FakeInterceptor.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/server/impl/fake/FakeInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.remoting.server.impl.fake;
+
+import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.core.protocol.core.Packet;
+import org.hornetq.spi.core.protocol.RemotingConnection;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class FakeInterceptor implements Interceptor
+{
+
+   @Override
+   public boolean intercept(Packet packet, RemotingConnection connection) throws HornetQException
+   {
+      return false;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1125

This patch adds an ServiceRegistry which stores references to
objects that are intended to be injected into HornetQ server.  This
allows WildFly to inject objects that Wildfly is responsible for
managing such as ExecutorServices. In addition Wildfly is able to create
objects in it's own class loader such as Intercepors and
ConnectorServiceFactories and inject them into HornetQ.  This means that
the HornetQ class loader does not need to be aware of the various
dependencies require to instantiate these objects.
