### PR TITLE
HORNETQ-1417 OpenWire support -- Producer Flow Control

### DIFF
--- a/hornetq-protocols/hornetq-openwire-protocol/src/main/java/org/hornetq/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/hornetq-protocols/hornetq-openwire-protocol/src/main/java/org/hornetq/core/protocol/openwire/OpenWireProtocolManager.java
@@ -383,7 +383,7 @@ public class OpenWireProtocolManager implements ProtocolManager
          AMQSession sess = context.getConnection().getAdvisorySession();
          if (sess != null)
          {
-            sess.send(producerExchange, advisoryMessage);
+            sess.send(producerExchange, advisoryMessage, false);
          }
       }
       finally

--- a/hornetq-protocols/hornetq-openwire-protocol/src/main/java/org/hornetq/core/protocol/openwire/SendingResult.java
+++ b/hornetq-protocols/hornetq-openwire-protocol/src/main/java/org/hornetq/core/protocol/openwire/SendingResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.hornetq.core.protocol.openwire;
+
+import org.hornetq.api.core.SimpleString;
+import org.hornetq.core.paging.impl.PagingStoreImpl;
+import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
+
+/**
+ * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>
+ */
+public class SendingResult
+{
+   private boolean blockNextSend;
+   private PagingStoreImpl blockPagingStore;
+   private SimpleString blockingAddress;
+
+   public void setBlockNextSend(boolean block)
+   {
+      this.blockNextSend = block;
+   }
+
+   public boolean isBlockNextSend()
+   {
+      return this.blockNextSend;
+   }
+
+   public void setBlockPagingStore(PagingStoreImpl store)
+   {
+      this.blockPagingStore = store;
+   }
+
+   public PagingStoreImpl getBlockPagingStore()
+   {
+      return this.blockPagingStore;
+   }
+
+   public void setBlockingAddress(SimpleString address)
+   {
+      this.blockingAddress = address;
+   }
+
+   public SimpleString getBlockingAddress()
+   {
+      return this.blockingAddress;
+   }
+
+   public boolean isSendFailIfNoSpace()
+   {
+      AddressFullMessagePolicy policy = this.blockPagingStore.getAddressFullMessagePolicy();
+      return policy == AddressFullMessagePolicy.FAIL;
+   }
+}

--- a/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PagingStoreImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/impl/PagingStoreImpl.java
@@ -1197,7 +1197,7 @@ public class PagingStoreImpl implements PagingStore
    }
 
    // To be used on isDropMessagesWhenFull
-   private boolean isFull()
+   public boolean isFull()
    {
       return maxSize > 0 && getAddressSize() > maxSize;
    }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/BasicOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/BasicOpenWireTest.java
@@ -231,6 +231,19 @@ public class BasicOpenWireTest extends OpenWireTestBase
    {
       return factory.createConnection();
    }
+
+   protected void safeClose(Session s)
+   {
+      try
+      {
+         s.close();
+      }
+      catch (Throwable e)
+      {
+      }
+   }
+
+
 }
 
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/OpenWireTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/OpenWireTestBase.java
@@ -73,6 +73,8 @@ public class OpenWireTestBase extends ServiceTestBase
       serverConfig.getAcceptorConfigurations().add(transportConfiguration);
       serverConfig.setSecurityEnabled(enableSecurity);
 
+      extraServerConfig(serverConfig);
+
       if (enableSecurity)
       {
          server.getSecurityManager().addRole("openwireSender", "sender");
@@ -121,6 +123,11 @@ public class OpenWireTestBase extends ServiceTestBase
 
       registerConnectionFactory();
       System.out.println("debug: server started");
+   }
+
+   //override this to add extra server configs
+   protected void extraServerConfig(Configuration serverConfig)
+   {
    }
 
    protected void registerConnectionFactory() throws Exception

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/amq/ProducerFlowControlSendFailTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/amq/ProducerFlowControlSendFailTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.hornetq.tests.integration.openwire.amq;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ResourceAllocationException;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
+import org.hornetq.core.settings.impl.AddressSettings;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * adapted from: org.apache.activemq.ProducerFlowControlSendFailTest
+ *
+ * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>
+ *
+ */
+public class ProducerFlowControlSendFailTest extends ProducerFlowControlTest
+{
+
+   @Override
+   @Before
+   public void setUp() throws Exception
+   {
+      super.setUp();
+   }
+
+   @Override
+   @After
+   public void tearDown() throws Exception
+   {
+      super.tearDown();
+   }
+
+   @Override
+   protected void extraServerConfig(Configuration serverConfig)
+   {
+      String match = "jms.queue.#";
+      Map<String, AddressSettings> asMap = serverConfig.getAddressesSettings();
+      AddressSettings settings = asMap.get(match);
+      settings.setMaxSizeBytes(1);
+      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+   }
+
+   @Override
+   public void test2ndPubisherWithStandardConnectionThatIsBlocked() throws Exception
+   {
+      // with sendFailIfNoSpace set, there is no blocking of the connection
+   }
+
+   @Override
+   public void testAsyncPubisherRecoverAfterBlock() throws Exception
+   {
+      // sendFail means no flowControllwindow as there is no producer ack, just
+      // an exception
+   }
+
+   @Override
+   @Test
+   public void testPubisherRecoverAfterBlock() throws Exception
+   {
+      ActiveMQConnectionFactory factory = (ActiveMQConnectionFactory) getConnectionFactory();
+      // with sendFail, there must be no flowControllwindow
+      // sendFail is an alternative flow control mechanism that does not block
+      factory.setUseAsyncSend(true);
+      this.flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      this.flowControlConnection.start();
+
+      final Session session = this.flowControlConnection.createSession(false,
+            Session.CLIENT_ACKNOWLEDGE);
+      final MessageProducer producer = session.createProducer(queueA);
+
+      final AtomicBoolean keepGoing = new AtomicBoolean(true);
+
+      Thread thread = new Thread("Filler")
+      {
+         @Override
+         public void run()
+         {
+            while (keepGoing.get())
+            {
+               try
+               {
+                  producer.send(session.createTextMessage("Test message"));
+                  if (gotResourceException.get())
+                  {
+                     System.out.println("got exception");
+                     // do not flood the broker with requests when full as we
+                     // are sending async and they
+                     // will be limited by the network buffers
+                     Thread.sleep(200);
+                  }
+               }
+               catch (Exception e)
+               {
+                  // with async send, there will be no exceptions
+                  e.printStackTrace();
+               }
+            }
+         }
+      };
+      thread.start();
+      waitForBlockedOrResourceLimit(new AtomicBoolean(false));
+
+      // resourceException on second message, resumption if we
+      // can receive 10
+      MessageConsumer consumer = session.createConsumer(queueA);
+      TextMessage msg;
+      for (int idx = 0; idx < 10; ++idx)
+      {
+         msg = (TextMessage) consumer.receive(1000);
+         if (msg != null)
+         {
+            msg.acknowledge();
+         }
+      }
+      keepGoing.set(false);
+      consumer.close();
+   }
+
+   @Test
+   public void testPubisherRecoverAfterBlockWithSyncSend() throws Exception
+   {
+      ActiveMQConnectionFactory factory = (ActiveMQConnectionFactory) getConnectionFactory();
+      factory.setExceptionListener(null);
+      factory.setUseAsyncSend(false);
+      this.flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      this.flowControlConnection.start();
+
+      final Session session = this.flowControlConnection.createSession(false,
+            Session.CLIENT_ACKNOWLEDGE);
+      final MessageProducer producer = session.createProducer(queueA);
+
+      final AtomicBoolean keepGoing = new AtomicBoolean(true);
+      final AtomicInteger exceptionCount = new AtomicInteger(0);
+      Thread thread = new Thread("Filler")
+      {
+         @Override
+         public void run()
+         {
+            while (keepGoing.get())
+            {
+               try
+               {
+                  producer.send(session.createTextMessage("Test message"));
+               }
+               catch (JMSException arg0)
+               {
+                  if (arg0 instanceof ResourceAllocationException)
+                  {
+                     gotResourceException.set(true);
+                     exceptionCount.incrementAndGet();
+                  }
+               }
+            }
+         }
+      };
+      thread.start();
+      waitForBlockedOrResourceLimit(new AtomicBoolean(false));
+
+      // resourceException on second message, resumption if we
+      // can receive 10
+      MessageConsumer consumer = session.createConsumer(queueA);
+      TextMessage msg;
+      for (int idx = 0; idx < 10; ++idx)
+      {
+         msg = (TextMessage) consumer.receive(1000);
+         if (msg != null)
+         {
+            msg.acknowledge();
+         }
+      }
+      assertTrue("we were blocked at least 5 times", 5 < exceptionCount.get());
+      keepGoing.set(false);
+   }
+
+   protected ConnectionFactory getConnectionFactory() throws Exception
+   {
+      factory.setExceptionListener(new ExceptionListener()
+      {
+         public void onException(JMSException arg0)
+         {
+            if (arg0 instanceof ResourceAllocationException)
+            {
+               gotResourceException.set(true);
+            }
+         }
+      });
+      return factory;
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/amq/ProducerFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/openwire/amq/ProducerFlowControlTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.hornetq.tests.integration.openwire.amq;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.transport.tcp.TcpTransport;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
+import org.hornetq.core.settings.impl.AddressSettings;
+import org.hornetq.tests.integration.openwire.BasicOpenWireTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * adapted from: org.apache.activemq.ProducerFlowControlTest
+ *
+ * @author <a href="mailto:hgao@redhat.com">Howard Gao</a>
+ *
+ */
+public class ProducerFlowControlTest extends BasicOpenWireTest
+{
+   ActiveMQQueue queueA = new ActiveMQQueue("QUEUE.A");
+   ActiveMQQueue queueB = new ActiveMQQueue("QUEUE.B");
+   protected ActiveMQConnection flowControlConnection;
+   // used to test sendFailIfNoSpace on SystemUsage
+   protected final AtomicBoolean gotResourceException = new AtomicBoolean(false);
+   private Thread asyncThread = null;
+
+   @Test
+   public void test2ndPubisherWithProducerWindowSendConnectionThatIsBlocked() throws Exception
+   {
+      factory.setProducerWindowSize(1024 * 64);
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      Session session = flowControlConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      MessageConsumer consumer = session.createConsumer(queueB);
+
+      // Test sending to Queue A
+      // 1 few sends should not block until the producer window is used up.
+      fillQueue(queueA);
+
+      // Test sending to Queue B it should not block since the connection
+      // should not be blocked.
+      CountDownLatch pubishDoneToQeueuB = asyncSendTo(queueB, "Message 1");
+      assertTrue(pubishDoneToQeueuB.await(2, TimeUnit.SECONDS));
+
+      TextMessage msg = (TextMessage) consumer.receive();
+      assertEquals("Message 1", msg.getText());
+      msg.acknowledge();
+
+      pubishDoneToQeueuB = asyncSendTo(queueB, "Message 2");
+      assertTrue(pubishDoneToQeueuB.await(2, TimeUnit.SECONDS));
+
+      msg = (TextMessage) consumer.receive();
+      assertEquals("Message 2", msg.getText());
+      msg.acknowledge();
+
+      consumer.close();
+   }
+
+   @Test
+   public void testPubisherRecoverAfterBlock() throws Exception
+   {
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      final Session session = flowControlConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+      final MessageProducer producer = session.createProducer(queueA);
+
+      final AtomicBoolean done = new AtomicBoolean(true);
+      final AtomicBoolean keepGoing = new AtomicBoolean(true);
+
+      Thread thread = new Thread("Filler")
+      {
+         int i;
+
+         @Override
+         public void run()
+         {
+            while (keepGoing.get())
+            {
+               done.set(false);
+               try
+               {
+                  producer.send(session.createTextMessage("Test message " + ++i));
+               }
+               catch (JMSException e)
+               {
+                  break;
+               }
+            }
+         }
+      };
+      thread.start();
+      waitForBlockedOrResourceLimit(done);
+
+      // after receiveing messges, producer should continue sending messages
+      // (done == false)
+      MessageConsumer consumer = session.createConsumer(queueA);
+      TextMessage msg;
+      for (int idx = 0; idx < 5; ++idx)
+      {
+         msg = (TextMessage) consumer.receive(1000);
+         System.out.println("received: " + idx + ", msg: "
+               + msg.getJMSMessageID());
+         msg.acknowledge();
+      }
+      Thread.sleep(1000);
+      keepGoing.set(false);
+
+      consumer.close();
+      assertFalse("producer has resumed", done.get());
+   }
+
+   @Test
+   public void testAsyncPubisherRecoverAfterBlock() throws Exception
+   {
+      factory.setProducerWindowSize(1024 * 5);
+      factory.setUseAsyncSend(true);
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      final Session session = flowControlConnection.createSession(false,
+            Session.CLIENT_ACKNOWLEDGE);
+      final MessageProducer producer = session.createProducer(queueA);
+
+      final AtomicBoolean done = new AtomicBoolean(true);
+      final AtomicBoolean keepGoing = new AtomicBoolean(true);
+
+      Thread thread = new Thread("Filler")
+      {
+         int i;
+
+         @Override
+         public void run()
+         {
+            while (keepGoing.get())
+            {
+               done.set(false);
+               try
+               {
+                  producer.send(session.createTextMessage("Test message " + ++i));
+               }
+               catch (JMSException e)
+               {
+               }
+            }
+         }
+      };
+      thread.start();
+      waitForBlockedOrResourceLimit(done);
+
+      // after receiveing messges, producer should continue sending messages
+      // (done == false)
+      MessageConsumer consumer = session.createConsumer(queueA);
+      TextMessage msg;
+      for (int idx = 0; idx < 5; ++idx)
+      {
+         msg = (TextMessage) consumer.receive(1000);
+         assertNotNull("Got a message", msg);
+         System.out.println("received: " + idx + ", msg: " + msg.getJMSMessageID());
+         msg.acknowledge();
+      }
+      Thread.sleep(1000);
+      keepGoing.set(false);
+
+      consumer.close();
+      assertFalse("producer has resumed", done.get());
+   }
+
+   @Test
+   public void test2ndPubisherWithSyncSendConnectionThatIsBlocked() throws Exception
+   {
+      factory.setAlwaysSyncSend(true);
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      Session session = flowControlConnection.createSession(false,
+            Session.CLIENT_ACKNOWLEDGE);
+      MessageConsumer consumer = session.createConsumer(queueB);
+
+      // Test sending to Queue A
+      // 1st send should not block. But the rest will.
+      fillQueue(queueA);
+
+      // Test sending to Queue B it should not block.
+      CountDownLatch pubishDoneToQeueuB = asyncSendTo(queueB, "Message 1");
+      assertTrue(pubishDoneToQeueuB.await(2, TimeUnit.SECONDS));
+
+      TextMessage msg = (TextMessage) consumer.receive();
+      assertEquals("Message 1", msg.getText());
+      msg.acknowledge();
+
+      pubishDoneToQeueuB = asyncSendTo(queueB, "Message 2");
+      assertTrue(pubishDoneToQeueuB.await(2, TimeUnit.SECONDS));
+
+      msg = (TextMessage) consumer.receive();
+      assertEquals("Message 2", msg.getText());
+      msg.acknowledge();
+      consumer.close();
+   }
+
+   @Test
+   public void testSimpleSendReceive() throws Exception
+   {
+      factory.setAlwaysSyncSend(true);
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      Session session = flowControlConnection.createSession(false,
+            Session.CLIENT_ACKNOWLEDGE);
+      MessageConsumer consumer = session.createConsumer(queueA);
+
+      // Test sending to Queue B it should not block.
+      CountDownLatch pubishDoneToQeueuA = asyncSendTo(queueA, "Message 1");
+      assertTrue(pubishDoneToQeueuA.await(2, TimeUnit.SECONDS));
+
+      TextMessage msg = (TextMessage) consumer.receive();
+      assertEquals("Message 1", msg.getText());
+      msg.acknowledge();
+
+      pubishDoneToQeueuA = asyncSendTo(queueA, "Message 2");
+      assertTrue(pubishDoneToQeueuA.await(2, TimeUnit.SECONDS));
+
+      msg = (TextMessage) consumer.receive();
+      assertEquals("Message 2", msg.getText());
+      msg.acknowledge();
+      consumer.close();
+   }
+
+   @Test
+   public void test2ndPubisherWithStandardConnectionThatIsBlocked() throws Exception
+   {
+      flowControlConnection = (ActiveMQConnection) factory.createConnection();
+      flowControlConnection.start();
+
+      // Test sending to Queue A
+      // 1st send should not block.
+      fillQueue(queueA);
+
+      // Test sending to Queue B it should block.
+      // Since even though the it's queue limits have not been reached, the
+      // connection
+      // is blocked.
+      CountDownLatch pubishDoneToQeueuB = asyncSendTo(queueB, "Message 1");
+      assertFalse(pubishDoneToQeueuB.await(2, TimeUnit.SECONDS));
+   }
+
+   private void fillQueue(final ActiveMQQueue queue) throws JMSException,
+         InterruptedException
+   {
+      final AtomicBoolean done = new AtomicBoolean(true);
+      final AtomicBoolean keepGoing = new AtomicBoolean(true);
+
+      // Starts an async thread that every time it publishes it sets the done
+      // flag to false.
+      // Once the send starts to block it will not reset the done flag
+      // anymore.
+      asyncThread = new Thread("Fill thread.")
+      {
+         public void run()
+         {
+            Session session = null;
+            try
+            {
+               session = flowControlConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+               MessageProducer producer = session.createProducer(queue);
+               producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+               while (keepGoing.get())
+               {
+                  done.set(false);
+                  producer.send(session.createTextMessage("Hello World"));
+               }
+            }
+            catch (JMSException e)
+            {
+            }
+            finally
+            {
+               safeClose(session);
+            }
+         }
+      };
+      asyncThread.start();
+
+      waitForBlockedOrResourceLimit(done);
+      keepGoing.set(false);
+   }
+
+   protected void waitForBlockedOrResourceLimit(final AtomicBoolean done) throws InterruptedException
+   {
+      while (true)
+      {
+         Thread.sleep(2000);
+         System.out.println("check done: " + done.get() + " ex: " + gotResourceException.get());
+         // the producer is blocked once the done flag stays true or there is a
+         // resource exception
+         if (done.get() || gotResourceException.get())
+         {
+            break;
+         }
+         done.set(true);
+      }
+   }
+
+   private CountDownLatch asyncSendTo(final ActiveMQQueue queue,
+         final String message) throws JMSException
+   {
+      final CountDownLatch done = new CountDownLatch(1);
+      new Thread("Send thread.")
+      {
+         public void run()
+         {
+            Session session = null;
+            try
+            {
+               session = flowControlConnection.createSession(false,
+                     Session.AUTO_ACKNOWLEDGE);
+               MessageProducer producer = session.createProducer(queue);
+               producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+               producer.send(session.createTextMessage(message));
+               done.countDown();
+            }
+            catch (JMSException e)
+            {
+               e.printStackTrace();
+            }
+            finally
+            {
+               safeClose(session);
+            }
+         }
+      }.start();
+      return done;
+   }
+
+   @Override
+   protected void extraServerConfig(Configuration serverConfig)
+   {
+      String match = "jms.queue.#";
+      Map<String, AddressSettings> asMap = serverConfig.getAddressesSettings();
+      AddressSettings settings = asMap.get(match);
+      settings.setMaxSizeBytes(1);
+      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+   }
+
+   @Override
+   @Before
+   public void setUp() throws Exception
+   {
+      super.setUp();
+      this.makeSureCoreQueueExist("QUEUE.A");
+      this.makeSureCoreQueueExist("QUEUE.B");
+   }
+
+   @Override
+   @After
+   public void tearDown() throws Exception
+   {
+      if (flowControlConnection != null)
+      {
+         TcpTransport t = (TcpTransport) flowControlConnection.getTransport().narrow(TcpTransport.class);
+         t.getTransportListener().onException(new IOException("Disposed."));
+         flowControlConnection.getTransport().stop();
+         flowControlConnection.close();
+      }
+      if (asyncThread != null)
+      {
+         asyncThread.join();
+         asyncThread = null;
+      }
+      super.tearDown();
+   }
+
+}


### PR DESCRIPTION
Implement OpenWire producer flow control. Based on configuration, when
a queue's memory space is full, the producer can either be blocked (via
client side window size or server side blocking), or get a relevant
failure exception. The details are given in this link:

http://activemq.apache.org/producer-flow-control.html
