### PR TITLE
BZ-1146506 & HORNETQ-1287  Message does not expire when it is diverted to another queue

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/DivertImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/DivertImpl.java
@@ -100,6 +100,8 @@ public class DivertImpl implements Divert
 
          copy.setAddress(forwardAddress);
 
+         copy.setExpiration(message.getExpiration());
+
          if (transformer != null)
          {
             copy = transformer.transform(copy);

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerMessageImpl.java
@@ -247,16 +247,20 @@ public class ServerMessageImpl extends MessageImpl implements ServerMessage
    @Override
    public void setOriginalHeaders(final ServerMessage other, final MessageReference originalReference, final boolean expiry)
    {
+      SimpleString originalQueue = other.getSimpleStringProperty(Message.HDR_ORIGINAL_QUEUE);
+
+      if (originalQueue != null)
+      {
+         putStringProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
+      }
+      else if (originalReference != null)
+      {
+         putStringProperty(Message.HDR_ORIGINAL_QUEUE, originalReference.getQueue().getName());
+      }
+
       if (other.containsProperty(Message.HDR_ORIG_MESSAGE_ID))
       {
          putStringProperty(Message.HDR_ORIGINAL_ADDRESS, other.getSimpleStringProperty(Message.HDR_ORIGINAL_ADDRESS));
-
-         SimpleString originalQueue = other.getSimpleStringProperty(Message.HDR_ORIGINAL_QUEUE);
-
-         if (originalQueue != null)
-         {
-            putStringProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
-         }
 
          putLongProperty(Message.HDR_ORIG_MESSAGE_ID, other.getLongProperty(Message.HDR_ORIG_MESSAGE_ID));
       }
@@ -264,13 +268,6 @@ public class ServerMessageImpl extends MessageImpl implements ServerMessage
       {
          putStringProperty(Message.HDR_ORIGINAL_ADDRESS, other.getAddress());
 
-         /**
-          * This could be null in some DLA cases since the message wasn't routed yet
-          */
-         if (originalReference != null)
-         {
-            putStringProperty(Message.HDR_ORIGINAL_QUEUE, originalReference.getQueue().getName());
-         }
 
          putLongProperty(Message.HDR_ORIG_MESSAGE_ID, other.getMessageID());
       }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ExpiryAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/ExpiryAddressTest.java
@@ -11,6 +11,7 @@
  * permissions and limitations under the License.
  */
 package org.hornetq.tests.integration.client;
+import org.hornetq.core.message.impl.MessageImpl;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -52,15 +53,16 @@ public class ExpiryAddressTest extends ServiceTestBase
    public void testBasicSend() throws Exception
    {
       SimpleString ea = new SimpleString("EA");
+      SimpleString adSend = new SimpleString("a1");
       SimpleString qName = new SimpleString("q1");
       SimpleString eq = new SimpleString("EA1");
       AddressSettings addressSettings = new AddressSettings();
       addressSettings.setExpiryAddress(ea);
-      server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
+      server.getAddressSettingsRepository().addMatch("#", addressSettings);
       clientSession.createQueue(ea, eq, null, false);
-      clientSession.createQueue(qName, qName, null, false);
+      clientSession.createQueue(adSend, qName, null, false);
 
-      ClientProducer producer = clientSession.createProducer(qName);
+      ClientProducer producer = clientSession.createProducer(adSend);
       ClientMessage clientMessage = createTextMessage(clientSession, "heyho!");
       clientMessage.setExpiration(System.currentTimeMillis());
       producer.send(clientMessage);
@@ -74,6 +76,9 @@ public class ExpiryAddressTest extends ServiceTestBase
       clientConsumer.close();
       clientConsumer = clientSession.createConsumer(eq);
       m = clientConsumer.receive(500);
+      Assert.assertNotNull(m);
+      Assert.assertEquals(qName.toString(), m.getStringProperty(MessageImpl.HDR_ORIGINAL_QUEUE));
+      Assert.assertEquals(adSend.toString(), m.getStringProperty(MessageImpl.HDR_ORIGINAL_ADDRESS));
       Assert.assertNotNull(m);
       Assert.assertEquals(m.getBodyBuffer().readString(), "heyho!");
       m.acknowledge();
@@ -165,6 +170,9 @@ public class ExpiryAddressTest extends ServiceTestBase
 
       Assert.assertNotNull(m);
 
+      assertNotNull(m.getStringProperty(MessageImpl.HDR_ORIGINAL_ADDRESS));
+      assertNotNull(m.getStringProperty(MessageImpl.HDR_ORIGINAL_QUEUE));
+
       ExpiryAddressTest.log.info("acking");
       m.acknowledge();
 
@@ -177,6 +185,9 @@ public class ExpiryAddressTest extends ServiceTestBase
       m = clientConsumer.receive(500);
 
       Assert.assertNotNull(m);
+
+      assertNotNull(m.getStringProperty(MessageImpl.HDR_ORIGINAL_ADDRESS));
+      assertNotNull(m.getStringProperty(MessageImpl.HDR_ORIGINAL_QUEUE));
 
       ExpiryAddressTest.log.info("acking");
       m.acknowledge();
@@ -206,6 +217,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       ClientConsumer clientConsumer = clientSession.createConsumer(qName);
       ClientMessage m = clientConsumer.receiveImmediate();
       Assert.assertNull(m);
+
       clientConsumer.close();
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/divert/DivertTest.java
@@ -24,8 +24,10 @@ import org.hornetq.api.core.client.ClientSessionFactory;
 import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.core.config.Configuration;
 import org.hornetq.core.config.DivertConfiguration;
+import org.hornetq.core.message.impl.MessageImpl;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.HornetQServers;
+import org.hornetq.core.settings.impl.AddressSettings;
 import org.hornetq.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -127,6 +129,147 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer2.receiveImmediate());
+
+      session.close();
+
+      sf.close();
+
+      messagingService.stop();
+   }
+
+
+   @Test
+   public void testSingleDivertWithExpiry() throws Exception
+   {
+      Configuration conf = createDefaultConfig();
+      final String testAddress = "testAddress";
+
+      final String forwardAddress = "forwardAddress";
+
+      final String expiryAddress = "expiryAddress";
+
+      conf.getAddressesSettings().clear();
+
+      AddressSettings expirySettings = new AddressSettings();
+      expirySettings.setExpiryAddress(new SimpleString(expiryAddress));
+
+      conf.getAddressesSettings().put("#", expirySettings);
+
+      DivertConfiguration divertConf = new DivertConfiguration("divert1",
+                                                               "divert1",
+                                                               testAddress,
+                                                               forwardAddress,
+                                                               false,
+                                                               null,
+                                                               null);
+
+      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+
+      divertConfs.add(divertConf);
+
+      conf.setDivertConfigurations(divertConfs);
+
+      HornetQServer messagingService = addServer(HornetQServers.newHornetQServer(conf, true));
+
+      messagingService.start();
+
+
+      ServerLocator locator = createInVMNonHALocator();
+
+      ClientSessionFactory sf = createSessionFactory(locator);
+
+      ClientSession session = sf.createSession(false, false, false);
+
+      final SimpleString queueName1 = new SimpleString("queue1");
+
+      final SimpleString queueName2 = new SimpleString("queue2");
+
+      session.createQueue(new SimpleString(forwardAddress), queueName1, null, true);
+
+      session.createQueue(new SimpleString(testAddress), queueName2, null, true);
+
+      session.createQueue(new SimpleString(expiryAddress), new SimpleString(expiryAddress), null, true);
+
+      session.start();
+
+      ClientProducer producer = session.createProducer(new SimpleString(testAddress));
+
+      ClientConsumer consumer1 = session.createConsumer(queueName1);
+
+      ClientConsumer consumer2 = session.createConsumer(queueName2);
+
+      final int numMessages = 1;
+
+      final SimpleString propKey = new SimpleString("testkey");
+
+      for (int i = 0; i < numMessages; i++)
+      {
+         ClientMessage message = session.createMessage(true);
+
+         message.putIntProperty(propKey, i);
+
+         message.setExpiration(System.currentTimeMillis() + 1000);
+
+         producer.send(message);
+      }
+      session.commit();
+
+
+      // this context is validating if these messages are routed correctly
+      {
+         int count1 = 0;
+         ClientMessage message = null;
+         while ((message = consumer1.receiveImmediate()) != null)
+         {
+            message.acknowledge();
+            count1++;
+         }
+
+         int count2 = 0;
+         message = null;
+         while ((message = consumer2.receiveImmediate()) != null)
+         {
+            message.acknowledge();
+            count2++;
+         }
+
+         assertEquals(1, count1);
+         assertEquals(1, count2);
+         session.rollback();
+      }
+      Thread.sleep(2000);
+
+      // it must been expired by now
+      assertNull(consumer1.receiveImmediate());
+      // it must been expired by now
+      assertNull(consumer2.receiveImmediate());
+
+      int countOriginal1 = 0;
+      int countOriginal2 = 0;
+      ClientConsumer consumerExpiry = session.createConsumer(expiryAddress);
+
+      for (int i = 0; i < numMessages * 2; i++)
+      {
+         ClientMessage message = consumerExpiry.receive(5000);
+         System.out.println("Received message " + message);
+         assertNotNull(message);
+
+         if (message.getStringProperty(MessageImpl.HDR_ORIGINAL_QUEUE).equals("queue1"))
+         {
+            countOriginal1++;
+         }
+         else if (message.getStringProperty(MessageImpl.HDR_ORIGINAL_QUEUE).equals("queue2"))
+         {
+            countOriginal2++;
+         }
+         else
+         {
+            System.out.println("message not part of any expired queue" + message);
+         }
+      }
+
+      assertEquals(numMessages, countOriginal1);
+      assertEquals(numMessages, countOriginal2);
 
       session.close();
 


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1287
https://bugzilla.redhat.com/show_bug.cgi?id=1146506

Diverts were not setting the expiry message during any type of divert.
It seems this was an initial design decision but I don't see a reason why
expiry should be removed between routing and diverting.
Besides this we also fixed the case where the original queue wasn't set
during divert and expiry.
