### PR TITLE
Fixing the testsuite

### DIFF
--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1180,6 +1180,12 @@ public abstract class UnitTestCase extends CoreUnitTestCase
             checkThread = true;
          }
 
+         if (Thread.currentThread().getContextClassLoader() == null)
+         {
+            Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+            fail("Thread Context ClassLoader was set to null at some point before this test. We will set to this.getClass().getClassLoader(), but you are supposed to fix your tests");
+         }
+
          checkFilesUsage();
       }
    }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/vertx/HornetQVertxUnitTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/vertx/HornetQVertxUnitTest.java
@@ -69,11 +69,16 @@ public class HornetQVertxUnitTest extends ServiceTestBase
    protected String incomingVertxAddress3 = "org.hornetq.test.incoming3";
    protected String outgoingVertxAddress2 = "org.hornetq.test.outgoing2";
 
+
+   // Vertx is changing the classLoader to null.. this will preserve the original classloader
+   ClassLoader contextClassLoader;
+
    //subclasses may override this method
    //in order to get a server with different connector services
    @Before @Override
    public void setUp() throws Exception
    {
+      contextClassLoader = Thread.currentThread().getContextClassLoader();
       createVertxService();
 
       super.setUp();
@@ -848,5 +853,9 @@ public class HornetQVertxUnitTest extends ServiceTestBase
       vertxManager.stop();
       server.stop();
       server = null;
+
+      // Something on vertx is setting the TCL to null what would break subsequent tests
+      Thread.currentThread().setContextClassLoader(contextClassLoader);
+      super.tearDown();
    }
 }


### PR DESCRIPTION
Something on vert.x is currently setting the Thread's TCL to null what will break several tests,
and will also break maven itself. Something gets a NPE and no further tests will get executed.
