### PR TITLE
HORNETQ-1414 Allow exclusions/list on cluster addr

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/SymmetricClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/SymmetricClusterTest.java
@@ -25,6 +25,7 @@ import org.hornetq.tests.util.UnitTestCase;
  * Most of the cases are covered in OneWayTwoNodeClusterTest - we don't duplicate them all here
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
+ * @author <a href="mtaylor@redhat,com">Martyn Taylor</a>
  *
  * Created 3 Feb 2009 09:10:43
  *
@@ -1758,6 +1759,196 @@ public class SymmetricClusterTest extends ClusterTestBase
       waitForBindings(4, "queues.testaddress", 7, 7, true);
 
       waitForBindings(4, "queues.testaddress", 0, 0, false);
+   }
+
+   @Test
+   /**
+    * This test verifies that addresses matching a simple string filter such as 'jms' result in bindings being created
+    * on appropriate nodes in the cluster.  It also verifies that addresses not matching the simple string filter do not
+    * result in bindings being created.
+    */
+   public void testClusterAddressCreatesBindingsForSimpleStringAddressFilters() throws Exception
+   {
+      setupCluster("jms", "jms", "jms", "jms", "jms");
+      startServers();
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+      setupSessionFactory(2, isNetty());
+      setupSessionFactory(3, isNetty());
+      setupSessionFactory(4, isNetty());
+
+      createQueue(0, "jms.queues.test.1", "queue0", null, false);
+      createQueue(1, "jms.queues.test.1", "queue0", null, false);
+      createQueue(2, "jms.queues.test.1", "queue0", null, false);
+      createQueue(3, "jms.queues.test.1", "queue0", null, false);
+      createQueue(4, "jms.queues.test.1", "queue0", null, false);
+
+      createQueue(0, "foo.queues.test.1", "queue1", null, false);
+      createQueue(1, "foo.queues.test.1", "queue1", null, false);
+      createQueue(2, "foo.queues.test.1", "queue1", null, false);
+      createQueue(3, "foo.queues.test.1", "queue1", null, false);
+      createQueue(4, "foo.queues.test.1", "queue1", null, false);
+
+      waitForBindings(0, "jms.queues.test.1", 4, 0, false);
+      waitForBindings(1, "jms.queues.test.1", 4, 0, false);
+      waitForBindings(2, "jms.queues.test.1", 4, 0, false);
+      waitForBindings(3, "jms.queues.test.1", 4, 0, false);
+      waitForBindings(4, "jms.queues.test.1", 4, 0, false);
+
+      waitForBindings(0, "foo.queues.test.1", 0, 0, false);
+      waitForBindings(1, "foo.queues.test.1", 0, 0, false);
+      waitForBindings(2, "foo.queues.test.1", 0, 0, false);
+      waitForBindings(3, "foo.queues.test.1", 0, 0, false);
+      waitForBindings(4, "foo.queues.test.1", 0, 0, false);
+   }
+
+   @Test
+   /**
+    * This test verifies that an string exclude filter '!jms.eu.uk' results in bindings not being created for this
+    * address for nodes in a cluster.  But ensures that other addresses are matched and bindings created.
+    */
+   public void testClusterAddressDoesNotCreatesBindingsForStringExcludesAddressFilters() throws Exception
+   {
+      setupCluster("!jms.eu.uk", "!jms.eu.uk", "!jms.eu.uk", "!jms.eu.uk", "!jms.eu.uk");
+      startServers();
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+      setupSessionFactory(2, isNetty());
+      setupSessionFactory(3, isNetty());
+      setupSessionFactory(4, isNetty());
+
+      createQueue(0, "jms.eu.uk", "queue0", null, false);
+      createQueue(1, "jms.eu.uk", "queue0", null, false);
+      createQueue(2, "jms.eu.uk", "queue0", null, false);
+      createQueue(3, "jms.eu.uk", "queue0", null, false);
+      createQueue(4, "jms.eu.uk", "queue0", null, false);
+
+      createQueue(0, "jms.eu.de", "queue1", null, false);
+      createQueue(1, "jms.eu.de", "queue1", null, false);
+      createQueue(2, "jms.eu.de", "queue1", null, false);
+      createQueue(3, "jms.eu.de", "queue1", null, false);
+      createQueue(4, "jms.eu.de", "queue1", null, false);
+
+      waitForBindings(0, "jms.eu.de", 4, 0, false);
+      waitForBindings(1, "jms.eu.de", 4, 0, false);
+      waitForBindings(2, "jms.eu.de", 4, 0, false);
+      waitForBindings(3, "jms.eu.de", 4, 0, false);
+      waitForBindings(4, "jms.eu.de", 4, 0, false);
+
+      waitForBindings(0, "jms.eu.uk", 0, 0, false);
+      waitForBindings(1, "jms.eu.uk", 0, 0, false);
+      waitForBindings(2, "jms.eu.uk", 0, 0, false);
+      waitForBindings(3, "jms.eu.uk", 0, 0, false);
+      waitForBindings(4, "jms.eu.uk", 0, 0, false);
+   }
+
+   /**
+    * This test verifies that remote bindings are only created for queues that match jms.eu or jms.us excluding
+    * jms.eu.uk and jms.us.bos.  Represented by the address filter 'jms.eu,!jms.eu.uk,jms.us,!jms.us.bos'
+    * @throws Exception
+    */
+   @Test
+   public void testClusterAddressFiltersExcludesAndIncludesAddressesInList() throws Exception
+   {
+      setupCluster("jms.eu,!jms.eu.uk,jms.us,!jms.us.bos",
+                   "jms.eu,!jms.eu.uk,jms.us,!jms.us.bos",
+                   "jms.eu,!jms.eu.uk,jms.us,!jms.us.bos",
+                   "jms.eu,!jms.eu.uk,jms.us,!jms.us.bos",
+                   "jms.eu,!jms.eu.uk,jms.us,!jms.us.bos");
+
+      startServers();
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+      setupSessionFactory(2, isNetty());
+      setupSessionFactory(3, isNetty());
+      setupSessionFactory(4, isNetty());
+
+      createQueue(0, "jms.eu.uk", "queue0", null, false);
+      createQueue(1, "jms.eu.uk", "queue0", null, false);
+      createQueue(2, "jms.eu.uk", "queue0", null, false);
+      createQueue(3, "jms.eu.uk", "queue0", null, false);
+      createQueue(4, "jms.eu.uk", "queue0", null, false);
+
+      createQueue(0, "jms.eu.de", "queue1", null, false);
+      createQueue(1, "jms.eu.de", "queue1", null, false);
+      createQueue(2, "jms.eu.de", "queue1", null, false);
+      createQueue(3, "jms.eu.de", "queue1", null, false);
+      createQueue(4, "jms.eu.de", "queue1", null, false);
+
+      createQueue(0, "jms.eu.fr", "queue2", null, false);
+      createQueue(1, "jms.eu.fr", "queue2", null, false);
+      createQueue(2, "jms.eu.fr", "queue2", null, false);
+      createQueue(3, "jms.eu.fr", "queue2", null, false);
+      createQueue(4, "jms.eu.fr", "queue2", null, false);
+
+      createQueue(0, "jms.us.ca", "queue4", null, false);
+      createQueue(1, "jms.us.ca", "queue4", null, false);
+      createQueue(2, "jms.us.ca", "queue4", null, false);
+      createQueue(3, "jms.us.ca", "queue4", null, false);
+      createQueue(4, "jms.us.ca", "queue4", null, false);
+
+      createQueue(0, "jms.us.se", "queue5", null, false);
+      createQueue(1, "jms.us.se", "queue5", null, false);
+      createQueue(2, "jms.us.se", "queue5", null, false);
+      createQueue(3, "jms.us.se", "queue5", null, false);
+      createQueue(4, "jms.us.se", "queue5", null, false);
+
+      createQueue(0, "jms.us.ny", "queue6", null, false);
+      createQueue(1, "jms.us.ny", "queue6", null, false);
+      createQueue(2, "jms.us.ny", "queue6", null, false);
+      createQueue(3, "jms.us.ny", "queue6", null, false);
+      createQueue(4, "jms.us.ny", "queue6", null, false);
+
+      waitForBindings(0, "jms.eu.de", 4, 0, false);
+      waitForBindings(1, "jms.eu.de", 4, 0, false);
+      waitForBindings(2, "jms.eu.de", 4, 0, false);
+      waitForBindings(3, "jms.eu.de", 4, 0, false);
+      waitForBindings(4, "jms.eu.de", 4, 0, false);
+
+      waitForBindings(0, "jms.eu.fr", 4, 0, false);
+      waitForBindings(1, "jms.eu.fr", 4, 0, false);
+      waitForBindings(2, "jms.eu.fr", 4, 0, false);
+      waitForBindings(3, "jms.eu.fr", 4, 0, false);
+      waitForBindings(4, "jms.eu.fr", 4, 0, false);
+
+      waitForBindings(0, "jms.eu.uk", 0, 0, false);
+      waitForBindings(1, "jms.eu.uk", 0, 0, false);
+      waitForBindings(2, "jms.eu.uk", 0, 0, false);
+      waitForBindings(3, "jms.eu.uk", 0, 0, false);
+      waitForBindings(4, "jms.eu.uk", 0, 0, false);
+
+      waitForBindings(0, "jms.us.ca", 4, 0, false);
+      waitForBindings(1, "jms.us.ca", 4, 0, false);
+      waitForBindings(2, "jms.us.ca", 4, 0, false);
+      waitForBindings(3, "jms.us.ca", 4, 0, false);
+      waitForBindings(4, "jms.us.ca", 4, 0, false);
+
+      waitForBindings(0, "jms.us.ny", 4, 0, false);
+      waitForBindings(1, "jms.us.ny", 4, 0, false);
+      waitForBindings(2, "jms.us.ny", 4, 0, false);
+      waitForBindings(3, "jms.us.ny", 4, 0, false);
+      waitForBindings(4, "jms.us.ny", 4, 0, false);
+
+      waitForBindings(0, "jms.us.bos", 0, 0, false);
+      waitForBindings(1, "jms.us.bos", 0, 0, false);
+      waitForBindings(2, "jms.us.bos", 0, 0, false);
+      waitForBindings(3, "jms.us.bos", 0, 0, false);
+      waitForBindings(4, "jms.us.bos", 0, 0, false);
+   }
+
+   protected void setupCluster(String addr1, String addr2, String addr3, String addr4, String addr5) throws Exception
+   {
+      setupClusterConnection("cluster0", addr1, true, 1, isNetty(), 0, 1, 2, 3, 4);
+
+      setupClusterConnection("cluster1", addr2, true, 1, isNetty(), 1, 0, 2, 3, 4);
+
+      setupClusterConnection("cluster2", addr3, true, 1, isNetty(), 2, 0, 1, 3, 4);
+
+      setupClusterConnection("cluster3", addr4, true, 1, isNetty(), 3, 0, 1, 2, 4);
+      setupClusterConnection("cluster4", addr5, true, 1, isNetty(), 4, 0, 1, 2, 3);
    }
 
    protected void setupCluster() throws Exception

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/cluster/impl/ClusterConnectionBridgeTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/cluster/impl/ClusterConnectionBridgeTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.tests.unit.core.server.cluster.impl;
+
+import org.hornetq.api.core.management.ManagementHelper;
+import org.hornetq.core.server.cluster.impl.ClusterConnectionBridge;
+import org.hornetq.tests.util.UnitTestCase;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:mtaylor@redhat.com">Martyn Taylor</a>
+ */
+
+public class ClusterConnectionBridgeTest extends UnitTestCase
+{
+   @Test
+   public void testCreateSelectorFromAddressForNormalMatches()
+   {
+      String address = "jms.my.address";
+      String expectedSelector = ManagementHelper.HDR_ADDRESS + " LIKE '" + address + "%'";
+      assertEquals(expectedSelector, ClusterConnectionBridge.createSelectorFromAddress(address));
+   }
+
+   @Test
+   public void testCreateSelectorFromAddressForExclusions()
+   {
+      String address = "jms.my.address";
+      String expectedSelector = ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address + "%'";
+      assertEquals(expectedSelector, ClusterConnectionBridge.createSelectorFromAddress("!" + address));
+   }
+
+   @Test
+   public void testCreateSelectorFromListForNormalMatches()
+   {
+      String address1 = "jms.test1.address";
+      String address2 = "jms.test2.address";
+      String addresses = address1 + "," + address2;
+
+      StringBuilder expectedSelector = new StringBuilder();
+      expectedSelector.append("(");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " LIKE '" + address1 + "%')");
+      expectedSelector.append(" OR ");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " LIKE '" + address2 + "%')");
+      expectedSelector.append(")");
+      assertEquals(expectedSelector.toString(), ClusterConnectionBridge.createSelectorFromAddress(addresses));
+   }
+
+   @Test
+   public void testCreateSelectorFromListForExclusions()
+   {
+      String address1 = "jms.test1.address";
+      String address2 = "jms.test2.address";
+      String addresses = "!" + address1 + "," + "!" + address2;
+
+      StringBuilder expectedSelector = new StringBuilder();
+      expectedSelector.append("(");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address1 + "%')");
+      expectedSelector.append(" AND ");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address2 + "%')");
+      expectedSelector.append(")");
+      assertEquals(expectedSelector.toString(), ClusterConnectionBridge.createSelectorFromAddress(addresses));
+   }
+
+   @Test
+   public void testCreateSelectorFromListForExclusionsAndNormalMatches()
+   {
+      String address1 = "jms.test1.address";
+      String address2 = "jms.test2.address";
+      String address3 = "jms.test3.address";
+      String address4 = "jms.test4.address";
+      String addresses = address1 + ",!" + address2 + "," + address3 + ",!" + address4;
+
+      StringBuilder expectedSelector = new StringBuilder();
+      expectedSelector.append("(((" + ManagementHelper.HDR_ADDRESS + " LIKE '" + address1 + "%')");
+      expectedSelector.append(" OR ");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " LIKE '" + address3 + "%'))");
+      expectedSelector.append(" AND ");
+      expectedSelector.append("((" + ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address2 + "%')");
+      expectedSelector.append(" AND ");
+      expectedSelector.append("(" + ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address4 + "%')))");
+
+      assertEquals(expectedSelector.toString(), ClusterConnectionBridge.createSelectorFromAddress(addresses));
+   }
+
+   @Test
+   public void testCreateSelectorFromListIgnoresEmptyStrings()
+   {
+      String address1 = "jms.test1.address";
+      String address2 = "jms.test2.address";
+      String addresses = address1 + ",!" + address2 + ",,,";
+
+      StringBuilder expectedSelector = new StringBuilder();
+      expectedSelector.append("(((" + ManagementHelper.HDR_ADDRESS + " LIKE '" + address1 + "%'))");
+      expectedSelector.append(" AND ");
+      expectedSelector.append("((" + ManagementHelper.HDR_ADDRESS + " NOT LIKE '" + address2 + "%')))");
+
+      assertEquals(expectedSelector.toString(), ClusterConnectionBridge.createSelectorFromAddress(addresses));
+   }
+}


### PR DESCRIPTION
Adds the ability to support more than just a single string for matching
addresses on cluster connections.  Cluster connection address can now
consist of a list of strings that are used as filters, any of which can
be matched against the address.  In addition a new exclusion syntax '!'
is now supported that allows users to explicitly ignore any address
matching anything following '!'.

For example: 'jms.eu,!jms.eu.uk' will match all addresses beginning with
jms.eu except for those beginning with jms.eu.uk.
