### PR TITLE
fix failback configuration

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/config/ConfigurationUtils.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/ConfigurationUtils.java
@@ -67,7 +67,7 @@ public final class ConfigurationUtils
          case REPLICATED:
          {
             ReplicatedPolicyConfiguration pc = (ReplicatedPolicyConfiguration) conf;
-            return new ReplicatedPolicy(pc.isCheckForLiveServer(), pc.isAllowAutoFailBack(), pc.getFailbackDelay(), pc.getGroupName(), pc.getClusterName());
+            return new ReplicatedPolicy(pc.isCheckForLiveServer(), pc.getGroupName(), pc.getClusterName());
          }
          case REPLICA:
          {

--- a/hornetq-server/src/main/java/org/hornetq/core/config/ha/ReplicatedPolicyConfiguration.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/ha/ReplicatedPolicyConfiguration.java
@@ -19,10 +19,6 @@ public class ReplicatedPolicyConfiguration implements HAPolicyConfiguration
 {
    private boolean checkForLiveServer = HornetQDefaultConfiguration.isDefaultCheckForLiveServer();
 
-   private boolean allowAutoFailBack = HornetQDefaultConfiguration.isDefaultAllowAutoFailback();
-
-   private long failbackDelay = HornetQDefaultConfiguration.getDefaultFailbackDelay();
-
    private String groupName = null;
 
    private String clusterName = null;
@@ -45,28 +41,6 @@ public class ReplicatedPolicyConfiguration implements HAPolicyConfiguration
    public ReplicatedPolicyConfiguration setCheckForLiveServer(boolean checkForLiveServer)
    {
       this.checkForLiveServer = checkForLiveServer;
-      return this;
-   }
-
-   public boolean isAllowAutoFailBack()
-   {
-      return allowAutoFailBack;
-   }
-
-   public ReplicatedPolicyConfiguration setAllowAutoFailBack(boolean allowAutoFailBack)
-   {
-      this.allowAutoFailBack = allowAutoFailBack;
-      return this;
-   }
-
-   public long getFailbackDelay()
-   {
-      return failbackDelay;
-   }
-
-   public ReplicatedPolicyConfiguration setFailbackDelay(long failbackDelay)
-   {
-      this.failbackDelay = failbackDelay;
       return this;
    }
 

--- a/hornetq-server/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/impl/ConfigurationImpl.java
@@ -1156,11 +1156,6 @@ public class ConfigurationImpl implements Configuration
          ReplicaPolicyConfiguration hapc = (ReplicaPolicyConfiguration) haPolicyConfiguration;
          return hapc.getFailbackDelay();
       }
-      else if (haPolicyConfiguration instanceof ReplicatedPolicyConfiguration)
-      {
-         ReplicatedPolicyConfiguration hapc = (ReplicatedPolicyConfiguration) haPolicyConfiguration;
-         return hapc.getFailbackDelay();
-      }
       else if (haPolicyConfiguration instanceof SharedStoreMasterPolicyConfiguration)
       {
          SharedStoreMasterPolicyConfiguration hapc = (SharedStoreMasterPolicyConfiguration) haPolicyConfiguration;
@@ -1180,11 +1175,6 @@ public class ConfigurationImpl implements Configuration
       if (haPolicyConfiguration instanceof ReplicaPolicyConfiguration)
       {
          ReplicaPolicyConfiguration hapc = (ReplicaPolicyConfiguration) haPolicyConfiguration;
-         hapc.setFailbackDelay(failbackDelay);
-      }
-      else if (haPolicyConfiguration instanceof ReplicatedPolicyConfiguration)
-      {
-         ReplicatedPolicyConfiguration hapc = (ReplicatedPolicyConfiguration) haPolicyConfiguration;
          hapc.setFailbackDelay(failbackDelay);
       }
       else if (haPolicyConfiguration instanceof SharedStoreMasterPolicyConfiguration)

--- a/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
@@ -345,11 +345,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
                ReplicaPolicyConfiguration hapc = (ReplicaPolicyConfiguration) haPolicyConfig;
                hapc.setFailbackDelay(getLong(e, "failback-delay", hapc.getFailbackDelay(), Validators.GT_ZERO));
             }
-            else if (haPolicyConfig instanceof ReplicatedPolicyConfiguration)
-            {
-               ReplicatedPolicyConfiguration hapc = (ReplicatedPolicyConfiguration) haPolicyConfig;
-               hapc.setFailbackDelay(getLong(e, "failback-delay", hapc.getFailbackDelay(), Validators.GT_ZERO));
-            }
             else if (haPolicyConfig instanceof SharedStoreMasterPolicyConfiguration)
             {
                SharedStoreMasterPolicyConfiguration hapc = (SharedStoreMasterPolicyConfiguration) haPolicyConfig;
@@ -1310,13 +1305,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
 
       configuration.setCheckForLiveServer(getBoolean(policyNode, "check-for-live-server", configuration.isCheckForLiveServer()));
 
-      configuration.setAllowAutoFailBack(getBoolean(policyNode, "allow-failback", configuration.isCheckForLiveServer()));
-
       configuration.setGroupName(getString(policyNode, "group-name", configuration.getGroupName(), Validators.NO_CHECK));
 
       configuration.setClusterName(getString(policyNode, "clustername", configuration.getClusterName(), Validators.NO_CHECK));
-
-      configuration.setFailbackDelay(getLong(policyNode, "failback-delay", configuration.getFailbackDelay(), Validators.GT_ZERO));
 
       return configuration;
    }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/cluster/ha/ReplicatedPolicy.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/cluster/ha/ReplicatedPolicy.java
@@ -23,13 +23,17 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation>
 {
    private boolean checkForLiveServer = HornetQDefaultConfiguration.isDefaultCheckForLiveServer();
 
-   private boolean allowAutoFailBack = HornetQDefaultConfiguration.isDefaultAllowAutoFailback();
-
-   private long failbackDelay = HornetQDefaultConfiguration.getDefaultFailbackDelay();
-
    private String groupName = null;
 
    private String clusterName;
+
+   /*
+   * these are only set by the ReplicaPolicy after failover to decide if the live server can failback, these should not
+   * be exposed in configuration.
+   * */
+   private boolean allowAutoFailBack = HornetQDefaultConfiguration.isDefaultAllowAutoFailback();
+
+   private long failbackDelay = HornetQDefaultConfiguration.getDefaultFailbackDelay();
 
    /*
    * this is used as the policy when the server is started after a failover
@@ -41,11 +45,9 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation>
    {
    }
 
-   public ReplicatedPolicy(boolean checkForLiveServer, boolean allowAutoFailBack, long failbackDelay, String groupName, String clusterName)
+   public ReplicatedPolicy(boolean checkForLiveServer, String groupName, String clusterName)
    {
       this.checkForLiveServer = checkForLiveServer;
-      this.allowAutoFailBack = allowAutoFailBack;
-      this.failbackDelay = failbackDelay;
       this.groupName = groupName;
       this.clusterName = clusterName;
       /*
@@ -57,9 +59,10 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation>
    public ReplicatedPolicy(boolean checkForLiveServer, boolean allowAutoFailBack, long failbackDelay, String groupName, String clusterName, ReplicaPolicy replicaPolicy)
    {
       this.checkForLiveServer = checkForLiveServer;
+      this.clusterName = clusterName;
+      this.groupName = groupName;
       this.allowAutoFailBack = allowAutoFailBack;
       this.failbackDelay = failbackDelay;
-      this.groupName = groupName;
       this.replicaPolicy = replicaPolicy;
    }
 
@@ -76,11 +79,6 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation>
    public boolean isAllowAutoFailBack()
    {
       return allowAutoFailBack;
-   }
-
-   public void setAllowAutoFailBack(boolean allowAutoFailBack)
-   {
-      this.allowAutoFailBack = allowAutoFailBack;
    }
 
    public long getFailbackDelay()

--- a/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
+++ b/hornetq-server/src/main/resources/schema/hornetq-configuration.xsd
@@ -1793,24 +1793,6 @@
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
-         <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_ALLOW_AUTO_FAILBACK">
-               <xsd:documentation>
-                  Whether a server will automatically stop when a another places a request to take over
-                  its place. The use case is when a regular server stops and its backup takes over its
-                  duties, later the main server restarts and requests the server (the former backup) to
-                  stop operating.
-               </xsd:documentation>
-            </xsd:annotation>
-         </xsd:element>
-         <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
-            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:default="(in milliseconds)"
-                            hq:field_name="DEFAULT_FAILBACK_DELAY">
-               <xsd:documentation>
-                  delay to wait before fail-back occurs on (live's) restart
-               </xsd:documentation>
-            </xsd:annotation>
-         </xsd:element>
       </xsd:all>
    </xsd:complexType>
    <xsd:complexType name="replicaPolicyType">
@@ -1856,7 +1838,7 @@
             </xsd:annotation>
          </xsd:element>
          <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
-            <xsd:annotation hq:linkend="ha.allow-fail-back">
+            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:field_name="DEFAULT_ALLOW_AUTO_FAILBACK">
                <xsd:documentation>
                   Whether a server will automatically stop when a another places a request to take over
                   its place. The use case is when a regular server stops and its backup takes over its
@@ -1866,7 +1848,7 @@
             </xsd:annotation>
          </xsd:element>
          <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
-            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:default="(in milliseconds)">
+            <xsd:annotation hq:linkend="ha.allow-fail-back" hq:default="(in milliseconds)" hq:field_name="DEFAULT_FAILBACK_DELAY">
                <xsd:documentation>
                   if we have to start as a replicated server this is the delay to wait before fail-back occurs
                </xsd:documentation>
@@ -1938,6 +1920,16 @@
    </xsd:complexType>
    <xsd:complexType name="sharedStoreSlavePolicyType">
       <xsd:all>
+         <xsd:element name="allow-failback" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation hq:linkend="ha.allow-fail-back">
+               <xsd:documentation>
+                  Whether a server will automatically stop when a another places a request to take over
+                  its place. The use case is when a regular server stops and its backup takes over its
+                  duties, later the main server restarts and requests the server (the former backup) to
+                  stop operating.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
          <xsd:element name="failback-delay" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/hornetq-server/src/test/java/org/hornetq/core/config/impl/HAPolicyConfigurationTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/config/impl/HAPolicyConfigurationTest.java
@@ -127,10 +127,8 @@ public class HAPolicyConfigurationTest
          HAPolicy haPolicy = server.getHAPolicy();
          assertTrue(haPolicy instanceof ReplicatedPolicy);
          ReplicatedPolicy replicatedPolicy = (ReplicatedPolicy) haPolicy;
-         assertTrue(replicatedPolicy.isAllowAutoFailBack());
          assertEquals(replicatedPolicy.getGroupName(), "purple");
          assertTrue(replicatedPolicy.isCheckForLiveServer());
-         assertEquals(replicatedPolicy.getFailbackDelay(), 1111);
          assertEquals(replicatedPolicy.getClusterName(), "abcdefg");
       }
       finally
@@ -354,10 +352,8 @@ public class HAPolicyConfigurationTest
          ReplicatedPolicy livePolicy = (ReplicatedPolicy) colocatedPolicy.getLivePolicy();
          assertNotNull(livePolicy);
 
-         assertTrue(livePolicy.isAllowAutoFailBack());
          assertEquals(livePolicy.getGroupName(), "purple");
          assertTrue(livePolicy.isCheckForLiveServer());
-         assertEquals(livePolicy.getFailbackDelay(), 1111);
          assertEquals(livePolicy.getClusterName(), "abcdefg");
          ReplicaPolicy backupPolicy = (ReplicaPolicy) colocatedPolicy.getBackupPolicy();
          assertNotNull(backupPolicy);

--- a/hornetq-server/src/test/resources/colocated-hapolicy-config.xml
+++ b/hornetq-server/src/test/resources/colocated-hapolicy-config.xml
@@ -11,10 +11,8 @@
             <request-backup>false</request-backup>
             <backup-port-offset>33</backup-port-offset>
             <master>
-               <allow-failback>true</allow-failback>
                <group-name>purple</group-name>
                <check-for-live-server>true</check-for-live-server>
-               <failback-delay>1111</failback-delay>
                <clustername>abcdefg</clustername>
             </master>
             <slave>

--- a/hornetq-server/src/test/resources/replicated-hapolicy-config.xml
+++ b/hornetq-server/src/test/resources/replicated-hapolicy-config.xml
@@ -5,10 +5,8 @@
    <ha-policy>
       <replication>
          <master>
-            <allow-failback>true</allow-failback>
             <group-name>purple</group-name>
             <check-for-live-server>true</check-for-live-server>
-            <failback-delay>1111</failback-delay>
             <clustername>abcdefg</clustername>
          </master>
       </replication>

--- a/hornetq-server/src/test/resources/shared-store-slave-hapolicy-config.xml
+++ b/hornetq-server/src/test/resources/shared-store-slave-hapolicy-config.xml
@@ -5,6 +5,7 @@
    <ha-policy>
       <shared-store>
          <slave>
+            <allow-failback>true</allow-failback>
             <failback-delay>9876</failback-delay>
             <failover-on-shutdown>false</failover-on-shutdown>
             <restart-backup>false</restart-backup>

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
@@ -94,7 +94,6 @@ public abstract class MultipleServerFailoverTestBase extends ServiceTestBase
          else
          {
             haPolicyConfiguration = new ReplicatedPolicyConfiguration();
-            ((ReplicatedPolicyConfiguration)haPolicyConfiguration).setFailbackDelay(1000);
             if (getNodeGroupName() != null)
             {
                ((ReplicatedPolicyConfiguration)haPolicyConfiguration).setGroupName(getNodeGroupName() + "-" + i);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/ReplicatedFailoverTest.java
@@ -128,8 +128,7 @@ public class ReplicatedFailoverTest extends FailoverTest
       if (isReplicatedFailbackTest)
       {
          ((ReplicatedPolicyConfiguration) liveConfig.getHAPolicyConfiguration())
-            .setCheckForLiveServer(true)
-            .setFailbackDelay(2000);
+            .setCheckForLiveServer(true);
          ((ReplicaPolicyConfiguration) backupConfig.getHAPolicyConfiguration())
             .setMaxSavedReplicatedJournalsSize(2)
             .setAllowFailBack(true)


### PR DESCRIPTION
failback should only ever be exposed on the backup configuration as this is only valid if a backup has failed over,
