### PR TITLE
HORNETQ-1425 Make core client API fluent

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientConsumer.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientConsumer.java
@@ -95,7 +95,7 @@ public interface ClientConsumer extends AutoCloseable
     * @param handler a MessageHandler
     * @throws HornetQException if an exception occurs while setting the MessageHandler
     */
-   void setMessageHandler(MessageHandler handler) throws HornetQException;
+   ClientConsumer setMessageHandler(MessageHandler handler) throws HornetQException;
 
    /**
     * Closes the consumer.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientMessage.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientMessage.java
@@ -38,8 +38,9 @@ public interface ClientMessage extends Message
     * <p>
     * This method is not meant to be called by HornetQ clients.
     * @param deliveryCount message delivery count
+    * @return this ClientMessage
     */
-   void setDeliveryCount(int deliveryCount);
+   ClientMessage setDeliveryCount(int deliveryCount);
 
    /**
     * Acknowledges reception of this message.
@@ -84,8 +85,9 @@ public interface ClientMessage extends Message
     * This method is used when consuming large messages
     *
     * @throws HornetQException
+    * @return this ClientMessage
     */
-   void setOutputStream(OutputStream out) throws HornetQException;
+   ClientMessage setOutputStream(OutputStream out) throws HornetQException;
 
    /**
     * Saves the content of the message to the OutputStream.
@@ -111,7 +113,8 @@ public interface ClientMessage extends Message
     * Sets the body's IntputStream.
     * <br>
     * This method is used when sending large messages
+    * @return this ClientMessage
     */
-   void setBodyInputStream(InputStream bodyInputStream);
+   ClientMessage setBodyInputStream(InputStream bodyInputStream);
 
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSession.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSession.java
@@ -642,8 +642,9 @@ public interface ClientSession extends XAResource, AutoCloseable
     * Sets a <code>SendAcknowledgementHandler</code> for this session.
     *
     * @param handler a SendAcknowledgementHandler
+    * @return this ClientSession
     */
-   void setSendAcknowledgementHandler(SendAcknowledgementHandler handler);
+   ClientSession setSendAcknowledgementHandler(SendAcknowledgementHandler handler);
 
    /**
     * Attach any metadata to the session.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSessionFactory.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ClientSessionFactory.java
@@ -144,8 +144,9 @@ public interface ClientSessionFactory extends AutoCloseable
     * Adds a FailoverEventListener to the session which is notified if a failover event  occurs on the session.
     *
     * @param listener the listener to add
+    * @return this ClientSessionFactory
     */
-   void addFailoverListener(FailoverEventListener listener);
+   ClientSessionFactory addFailoverListener(FailoverEventListener listener);
 
    /**
     * Removes a FailoverEventListener to the session.

--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/client/ServerLocator.java
@@ -24,7 +24,7 @@ import org.hornetq.core.client.impl.Topology;
  * HA, the locator will always get an updated list of members to the server, the server will send
  * the updated list to the client.
  * <p>
- * If you use UDP or JGroups (exclusively JGropus or UDP), the initial discovery is done by the
+ * If you use UDP or JGroups (exclusively JGroups or UDP), the initial discovery is done by the
  * grouping finder, after the initial connection is made the server will always send updates to the
  * client. But the listeners will listen for updates on grouping.
  *
@@ -114,8 +114,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to disable) or greater than 0.
     *
     * @param clientFailureCheckPeriod the period to check failure
+    * @return this ServerLocator
     */
-   void setClientFailureCheckPeriod(long clientFailureCheckPeriod);
+   ServerLocator setClientFailureCheckPeriod(long clientFailureCheckPeriod);
 
    /**
     * When <code>true</code>, consumers created through this factory will create temporary files to
@@ -134,8 +135,9 @@ public interface ServerLocator extends AutoCloseable
     * Sets whether large messages received by consumers created through this factory will be cached in temporary files or not.
     *
     * @param cached <code>true</code> to cache large messages in temporary files, <code>false</code> else
+    * @return this ServerLocator
     */
-   void setCacheLargeMessagesClient(boolean cached);
+   ServerLocator setCacheLargeMessagesClient(boolean cached);
 
    /**
     * Returns the connection <em>time-to-live</em>.
@@ -154,8 +156,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to disable) or greater or equals to 0.
     *
     * @param connectionTTL period in milliseconds
+    * @return this ServerLocator
     */
-   void setConnectionTTL(long connectionTTL);
+   ServerLocator setConnectionTTL(long connectionTTL);
 
    /**
     * Returns the blocking calls timeout.
@@ -174,8 +177,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater or equals to 0
     *
     * @param callTimeout blocking call timeout in milliseconds
+    * @return this ServerLocator
     */
-   void setCallTimeout(long callTimeout);
+   ServerLocator setCallTimeout(long callTimeout);
 
 
    /**
@@ -197,8 +201,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater or equals to -1, -1 means forever
     *
     * @param callFailoverTimeout blocking call timeout in milliseconds
+    * @return this ServerLocator
     */
-   void setCallFailoverTimeout(long callFailoverTimeout);
+   ServerLocator setCallFailoverTimeout(long callFailoverTimeout);
 
    /**
     * Returns the large message size threshold.
@@ -216,8 +221,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater than 0.
     *
     * @param minLargeMessageSize large message size threshold in bytes
+    * @return this ServerLocator
     */
-   void setMinLargeMessageSize(int minLargeMessageSize);
+   ServerLocator setMinLargeMessageSize(int minLargeMessageSize);
 
    /**
     * Returns the window size for flow control of the consumers created through this factory.
@@ -235,8 +241,9 @@ public interface ServerLocator extends AutoCloseable
     * (to set the maximum size of the buffer)
     *
     * @param consumerWindowSize window size (in bytes) used for consumer flow control
+    * @return this ServerLocator
     */
-   void setConsumerWindowSize(int consumerWindowSize);
+   ServerLocator setConsumerWindowSize(int consumerWindowSize);
 
    /**
     * Returns the maximum rate of message consumption for consumers created through this factory.
@@ -256,8 +263,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must -1 (to disable) or a positive integer corresponding to the maximum desired message consumption rate specified in units of messages per second.
     *
     * @param consumerMaxRate maximum rate of message consumption (in messages per seconds)
+    * @return this ServerLocator
     */
-   void setConsumerMaxRate(int consumerMaxRate);
+   ServerLocator setConsumerMaxRate(int consumerMaxRate);
 
    /**
     * Returns the size for the confirmation window of clients using this factory.
@@ -275,8 +283,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to disable the window) or greater than 0.
     *
     * @param confirmationWindowSize size of the confirmation window (in bytes)
+    * @return this ServerLocator
     */
-   void setConfirmationWindowSize(int confirmationWindowSize);
+   ServerLocator setConfirmationWindowSize(int confirmationWindowSize);
 
    /**
     * Returns the window size for flow control of the producers created through this factory.
@@ -294,8 +303,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to disable flow control) or greater than 0.
     *
     * @param producerWindowSize window size (in bytest) for flow control of the producers created through this factory.
+    * @return this ServerLocator
     */
-   void setProducerWindowSize(int producerWindowSize);
+   ServerLocator setProducerWindowSize(int producerWindowSize);
 
    /**
     * Returns the maximum rate of message production for producers created through this factory.
@@ -315,8 +325,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must -1 (to disable) or a positive integer corresponding to the maximum desired message production rate specified in units of messages per second.
     *
     * @param producerMaxRate maximum rate of message production (in messages per seconds)
+    * @return this ServerLocator
     */
-   void setProducerMaxRate(int producerMaxRate);
+   ServerLocator setProducerMaxRate(int producerMaxRate);
 
    /**
     * Returns whether consumers created through this factory will block while
@@ -336,8 +347,9 @@ public interface ServerLocator extends AutoCloseable
     * @param blockOnAcknowledge <code>true</code> to block when sending message
     *                           acknowledgments or <code>false</code> to send them
     *                           asynchronously
+    * @return this ServerLocator
     */
-   void setBlockOnAcknowledge(boolean blockOnAcknowledge);
+   ServerLocator setBlockOnAcknowledge(boolean blockOnAcknowledge);
 
    /**
     * Returns whether producers created through this factory will block while sending <em>durable</em> messages or do it asynchronously.
@@ -355,8 +367,9 @@ public interface ServerLocator extends AutoCloseable
     * Sets whether producers created through this factory will block while sending <em>durable</em> messages or do it asynchronously.
     *
     * @param blockOnDurableSend <code>true</code> to block when sending durable messages or <code>false</code> to send them asynchronously
+    * @return this ServerLocator
     */
-   void setBlockOnDurableSend(boolean blockOnDurableSend);
+   ServerLocator setBlockOnDurableSend(boolean blockOnDurableSend);
 
    /**
     * Returns whether producers created through this factory will block while sending <em>non-durable</em> messages or do it asynchronously.
@@ -374,8 +387,9 @@ public interface ServerLocator extends AutoCloseable
     * Sets whether producers created through this factory will block while sending <em>non-durable</em> messages or do it asynchronously.
     *
     * @param blockOnNonDurableSend <code>true</code> to block when sending non-durable messages or <code>false</code> to send them asynchronously
+    * @return this ServerLocator
     */
-   void setBlockOnNonDurableSend(boolean blockOnNonDurableSend);
+   ServerLocator setBlockOnNonDurableSend(boolean blockOnNonDurableSend);
 
    /**
     * Returns whether producers created through this factory will automatically
@@ -394,8 +408,9 @@ public interface ServerLocator extends AutoCloseable
     * assign a group ID to the messages they sent.
     *
     * @param autoGroup <code>true</code> to automatically assign a group ID to each messages sent through this factory, <code>false</code> else
+    * @return this ServerLocator
     */
-   void setAutoGroup(boolean autoGroup);
+   ServerLocator setAutoGroup(boolean autoGroup);
 
    /**
     * Returns the group ID that will be eventually set on each message for the property {@link org.hornetq.api.core.Message#HDR_GROUP_ID}.
@@ -410,8 +425,9 @@ public interface ServerLocator extends AutoCloseable
     * Sets the group ID that will be  set on each message sent through this factory.
     *
     * @param groupID the group ID to use
+    * @return this ServerLocator
     */
-   void setGroupID(String groupID);
+   ServerLocator setGroupID(String groupID);
 
    /**
     * Returns whether messages will pre-acknowledged on the server before they are sent to the consumers or not.
@@ -427,8 +443,9 @@ public interface ServerLocator extends AutoCloseable
     *
     * @param preAcknowledge <code>true</code> to enable pre-acknowledgment,
     *                       <code>false</code> else
+    * @return this ServerLocator
     */
-   void setPreAcknowledge(boolean preAcknowledge);
+   ServerLocator setPreAcknowledge(boolean preAcknowledge);
 
    /**
     * Returns the acknowledgments batch size.
@@ -445,8 +462,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be equal or greater than 0.
     *
     * @param ackBatchSize acknowledgments batch size
+    * @return this ServerLocator
     */
-   void setAckBatchSize(int ackBatchSize);
+   ServerLocator setAckBatchSize(int ackBatchSize);
 
    /**
     * Returns an array of TransportConfigurations representing the static list of live servers used
@@ -476,8 +494,9 @@ public interface ServerLocator extends AutoCloseable
     * or its own pools.
     *
     * @param useGlobalPools <code>true</code> to let this factory uses global thread pools, <code>false</code> else
+    * @return this ServerLocator
     */
-   void setUseGlobalPools(boolean useGlobalPools);
+   ServerLocator setUseGlobalPools(boolean useGlobalPools);
 
    /**
     * Returns the maximum size of the scheduled thread pool.
@@ -495,8 +514,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater than 0.
     *
     * @param scheduledThreadPoolMaxSize maximum size of the scheduled thread pool.
+    * @return this ServerLocator
     */
-   void setScheduledThreadPoolMaxSize(int scheduledThreadPoolMaxSize);
+   ServerLocator setScheduledThreadPoolMaxSize(int scheduledThreadPoolMaxSize);
 
    /**
     * Returns the maximum size of the thread pool.
@@ -514,8 +534,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (for unlimited thread pool) or greater than 0.
     *
     * @param threadPoolMaxSize maximum size of the thread pool.
+    * @return this ServerLocator
     */
-   void setThreadPoolMaxSize(int threadPoolMaxSize);
+   ServerLocator setThreadPoolMaxSize(int threadPoolMaxSize);
 
    /**
     * Returns the time to retry connections created by this factory after failure.
@@ -532,8 +553,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater than 0.
     *
     * @param retryInterval time (in milliseconds) to retry connections created by this factory after failure
+    * @return this ServerLocator
     */
-   void setRetryInterval(long retryInterval);
+   ServerLocator setRetryInterval(long retryInterval);
 
    /**
     * Returns the multiplier to apply to successive retry intervals.
@@ -550,8 +572,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be positive.
     *
     * @param retryIntervalMultiplier multiplier to apply to successive retry intervals
+    * @return this ServerLocator
     */
-   void setRetryIntervalMultiplier(double retryIntervalMultiplier);
+   ServerLocator setRetryIntervalMultiplier(double retryIntervalMultiplier);
 
    /**
     * Returns the maximum retry interval (in the case a retry interval multiplier has been specified).
@@ -569,8 +592,9 @@ public interface ServerLocator extends AutoCloseable
     *
     * @param maxRetryInterval maximum retry interval to apply in the case a retry interval multiplier
     *                         has been specified
+    * @return this ServerLocator
     */
-   void setMaxRetryInterval(long maxRetryInterval);
+   ServerLocator setMaxRetryInterval(long maxRetryInterval);
 
    /**
     * Returns the maximum number of attempts to retry connection in case of failure.
@@ -587,8 +611,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to retry infinitely), 0 (to never retry connection) or greater than 0.
     *
     * @param reconnectAttempts maximum number of attempts to retry connection in case of failure
+    * @return this ServerLocator
     */
-   void setReconnectAttempts(int reconnectAttempts);
+   ServerLocator setReconnectAttempts(int reconnectAttempts);
 
    /**
     * Sets the maximum number of attempts to establish an initial connection.
@@ -596,8 +621,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be -1 (to retry infinitely), 0 (to never retry connection) or greater than 0.
     *
     * @param reconnectAttempts maximum number of attempts for the initial connection
+    * @return this ServerLocator
     */
-   void setInitialConnectAttempts(int reconnectAttempts);
+   ServerLocator setInitialConnectAttempts(int reconnectAttempts);
 
    /**
     * @return the number of attempts to be made for first initial connection.
@@ -616,8 +642,9 @@ public interface ServerLocator extends AutoCloseable
     * Sets the value for FailoverOnInitialReconnection
     *
     * @param failover
+    * @return this ServerLocator
     */
-   void setFailoverOnInitialConnection(boolean failover);
+   ServerLocator setFailoverOnInitialConnection(boolean failover);
 
    /**
     * Returns the class name of the connection load balancing policy.
@@ -634,8 +661,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be the name of a class implementing {@link org.hornetq.api.core.client.loadbalance.ConnectionLoadBalancingPolicy}.
     *
     * @param loadBalancingPolicyClassName class name of the connection load balancing policy
+    * @return this ServerLocator
     */
-   void setConnectionLoadBalancingPolicyClassName(String loadBalancingPolicyClassName);
+   ServerLocator setConnectionLoadBalancingPolicyClassName(String loadBalancingPolicyClassName);
 
    /**
     * Returns the initial size of messages created through this factory.
@@ -652,8 +680,9 @@ public interface ServerLocator extends AutoCloseable
     * Value must be greater than 0.
     *
     * @param size initial size of messages created through this factory.
+    * @return this ServerLocator
     */
-   void setInitialMessagePacketSize(int size);
+   ServerLocator setInitialMessagePacketSize(int size);
 
    /**
     * Adds an interceptor which will be executed <em>after packets are received from the server</em>. Invoking this
@@ -671,15 +700,17 @@ public interface ServerLocator extends AutoCloseable
     * Adds an interceptor which will be executed <em>after packets are received from the server</em>.
     *
     * @param interceptor an Interceptor
+    * @return this ServerLocator
     */
-   void addIncomingInterceptor(Interceptor interceptor);
+   ServerLocator addIncomingInterceptor(Interceptor interceptor);
 
    /**
     * Adds an interceptor which will be executed <em>before packets are sent to the server</em>.
     *
     * @param interceptor an Interceptor
+    * @return this ServerLocator
     */
-   void addOutgoingInterceptor(Interceptor interceptor);
+   ServerLocator addOutgoingInterceptor(Interceptor interceptor);
 
    /**
     * Removes an interceptor. Invoking this method is the same as invoking
@@ -741,11 +772,12 @@ public interface ServerLocator extends AutoCloseable
     * Sets whether to compress or not large messages.
     *
     * @param compressLargeMessages
+    * @return this ServerLocator
     */
-   void setCompressLargeMessage(boolean compressLargeMessages);
+   ServerLocator setCompressLargeMessage(boolean compressLargeMessages);
 
    // XXX No javadocs
-   void addClusterTopologyListener(ClusterTopologyListener listener);
+   ServerLocator addClusterTopologyListener(ClusterTopologyListener listener);
 
    // XXX No javadocs
    void removeClusterTopologyListener(ClusterTopologyListener listener);

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
@@ -421,7 +421,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
 
    // Must be synchronized since messages may be arriving while handler is being set and might otherwise end
    // up not queueing enough executors - so messages get stranded
-   public synchronized void setMessageHandler(final MessageHandler theHandler) throws HornetQException
+   public synchronized ClientConsumerImpl setMessageHandler(final MessageHandler theHandler) throws HornetQException
    {
       checkClosed();
 
@@ -449,6 +449,8 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
       {
          waitForOnMessageToComplete(true);
       }
+
+      return this;
    }
 
    public void close() throws HornetQException

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientLargeMessageImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientLargeMessageImpl.java
@@ -131,7 +131,7 @@ public final class ClientLargeMessageImpl extends ClientMessageImpl implements C
    }
 
    @Override
-   public void setOutputStream(final OutputStream out) throws HornetQException
+   public ClientLargeMessageImpl setOutputStream(final OutputStream out) throws HornetQException
    {
       if (bodyBuffer != null)
       {
@@ -141,6 +141,8 @@ public final class ClientLargeMessageImpl extends ClientMessageImpl implements C
       {
          largeMessageController.setOutputStream(out);
       }
+
+      return this;
    }
 
    @Override

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientMessageImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientMessageImpl.java
@@ -78,9 +78,10 @@ public class ClientMessageImpl extends MessageImpl implements ClientMessageInter
       this.consumer = consumer;
    }
 
-   public void setDeliveryCount(final int deliveryCount)
+   public ClientMessageImpl setDeliveryCount(final int deliveryCount)
    {
       this.deliveryCount = deliveryCount;
+      return this;
    }
 
    public int getDeliveryCount()
@@ -159,9 +160,10 @@ public class ClientMessageImpl extends MessageImpl implements ClientMessageInter
    }
 
    @Override
-   public void setOutputStream(final OutputStream out) throws HornetQException
+   public ClientMessageImpl setOutputStream(final OutputStream out) throws HornetQException
    {
       saveToOutputStream(out);
+      return this;
    }
 
    @Override
@@ -186,9 +188,10 @@ public class ClientMessageImpl extends MessageImpl implements ClientMessageInter
    /**
     * @param bodyInputStream the bodyInputStream to set
     */
-   public void setBodyInputStream(final InputStream bodyInputStream)
+   public ClientMessageImpl setBodyInputStream(final InputStream bodyInputStream)
    {
       this.bodyInputStream = bodyInputStream;
+      return this;
    }
 
    @Override

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -471,9 +471,10 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
       return listeners.remove(listener);
    }
 
-   public void addFailoverListener(FailoverEventListener listener)
+   public ClientSessionFactoryImpl addFailoverListener(FailoverEventListener listener)
    {
       failoverListeners.add(listener);
+      return this;
    }
 
    public boolean removeFailoverListener(FailoverEventListener listener)

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -951,9 +951,10 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
       doCleanup(failingOver);
    }
 
-   public void setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
+   public ClientSessionImpl setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
    {
       sessionContext.setSendAcknowledgementHandler(handler);
+      return this;
    }
 
    public void preHandleFailover(RemotingConnection connection)

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/DelegatingSession.java
@@ -508,9 +508,10 @@ public class DelegatingSession implements ClientSessionInternal
       session.rollback(xid);
    }
 
-   public void setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
+   public DelegatingSession setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
    {
       session.setSendAcknowledgementHandler(handler);
+      return this;
    }
 
    public boolean setTransactionTimeout(final int seconds) throws XAException

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -675,9 +675,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return connect(true);
    }
 
-   public void setAfterConnectionInternalListener(AfterConnectInternalListener listener)
+   public ServerLocatorImpl setAfterConnectionInternalListener(AfterConnectInternalListener listener)
    {
       this.afterConnectListener = listener;
+      return this;
    }
 
    public AfterConnectInternalListener getAfterConnectInternalListener()
@@ -963,9 +964,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return cacheLargeMessagesClient;
    }
 
-   public void setCacheLargeMessagesClient(final boolean cached)
+   public ServerLocatorImpl setCacheLargeMessagesClient(final boolean cached)
    {
       cacheLargeMessagesClient = cached;
+      return this;
    }
 
    public long getClientFailureCheckPeriod()
@@ -973,10 +975,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return clientFailureCheckPeriod;
    }
 
-   public void setClientFailureCheckPeriod(final long clientFailureCheckPeriod)
+   public ServerLocatorImpl setClientFailureCheckPeriod(final long clientFailureCheckPeriod)
    {
       checkWrite();
       this.clientFailureCheckPeriod = clientFailureCheckPeriod;
+      return this;
    }
 
    public long getConnectionTTL()
@@ -984,10 +987,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return connectionTTL;
    }
 
-   public void setConnectionTTL(final long connectionTTL)
+   public ServerLocatorImpl setConnectionTTL(final long connectionTTL)
    {
       checkWrite();
       this.connectionTTL = connectionTTL;
+      return this;
    }
 
    public long getCallTimeout()
@@ -995,10 +999,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return callTimeout;
    }
 
-   public void setCallTimeout(final long callTimeout)
+   public ServerLocatorImpl setCallTimeout(final long callTimeout)
    {
       checkWrite();
       this.callTimeout = callTimeout;
+      return this;
    }
 
    public long getCallFailoverTimeout()
@@ -1006,10 +1011,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return callFailoverTimeout;
    }
 
-   public void setCallFailoverTimeout(long callFailoverTimeout)
+   public ServerLocatorImpl setCallFailoverTimeout(long callFailoverTimeout)
    {
       checkWrite();
       this.callFailoverTimeout = callFailoverTimeout;
+      return this;
    }
 
    public int getMinLargeMessageSize()
@@ -1017,10 +1023,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return minLargeMessageSize;
    }
 
-   public void setMinLargeMessageSize(final int minLargeMessageSize)
+   public ServerLocatorImpl setMinLargeMessageSize(final int minLargeMessageSize)
    {
       checkWrite();
       this.minLargeMessageSize = minLargeMessageSize;
+      return this;
    }
 
    public int getConsumerWindowSize()
@@ -1028,10 +1035,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return consumerWindowSize;
    }
 
-   public void setConsumerWindowSize(final int consumerWindowSize)
+   public ServerLocatorImpl setConsumerWindowSize(final int consumerWindowSize)
    {
       checkWrite();
       this.consumerWindowSize = consumerWindowSize;
+      return this;
    }
 
    public int getConsumerMaxRate()
@@ -1039,10 +1047,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return consumerMaxRate;
    }
 
-   public void setConsumerMaxRate(final int consumerMaxRate)
+   public ServerLocatorImpl setConsumerMaxRate(final int consumerMaxRate)
    {
       checkWrite();
       this.consumerMaxRate = consumerMaxRate;
+      return this;
    }
 
    public int getConfirmationWindowSize()
@@ -1050,10 +1059,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return confirmationWindowSize;
    }
 
-   public void setConfirmationWindowSize(final int confirmationWindowSize)
+   public ServerLocatorImpl setConfirmationWindowSize(final int confirmationWindowSize)
    {
       checkWrite();
       this.confirmationWindowSize = confirmationWindowSize;
+      return this;
    }
 
    public int getProducerWindowSize()
@@ -1061,10 +1071,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return producerWindowSize;
    }
 
-   public void setProducerWindowSize(final int producerWindowSize)
+   public ServerLocatorImpl setProducerWindowSize(final int producerWindowSize)
    {
       checkWrite();
       this.producerWindowSize = producerWindowSize;
+      return this;
    }
 
    public int getProducerMaxRate()
@@ -1072,10 +1083,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return producerMaxRate;
    }
 
-   public void setProducerMaxRate(final int producerMaxRate)
+   public ServerLocatorImpl setProducerMaxRate(final int producerMaxRate)
    {
       checkWrite();
       this.producerMaxRate = producerMaxRate;
+      return this;
    }
 
    public boolean isBlockOnAcknowledge()
@@ -1083,10 +1095,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return blockOnAcknowledge;
    }
 
-   public void setBlockOnAcknowledge(final boolean blockOnAcknowledge)
+   public ServerLocatorImpl setBlockOnAcknowledge(final boolean blockOnAcknowledge)
    {
       checkWrite();
       this.blockOnAcknowledge = blockOnAcknowledge;
+      return this;
    }
 
    public boolean isBlockOnDurableSend()
@@ -1094,10 +1107,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return blockOnDurableSend;
    }
 
-   public void setBlockOnDurableSend(final boolean blockOnDurableSend)
+   public ServerLocatorImpl setBlockOnDurableSend(final boolean blockOnDurableSend)
    {
       checkWrite();
       this.blockOnDurableSend = blockOnDurableSend;
+      return this;
    }
 
    public boolean isBlockOnNonDurableSend()
@@ -1105,10 +1119,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return blockOnNonDurableSend;
    }
 
-   public void setBlockOnNonDurableSend(final boolean blockOnNonDurableSend)
+   public ServerLocatorImpl setBlockOnNonDurableSend(final boolean blockOnNonDurableSend)
    {
       checkWrite();
       this.blockOnNonDurableSend = blockOnNonDurableSend;
+      return this;
    }
 
    public boolean isAutoGroup()
@@ -1116,10 +1131,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return autoGroup;
    }
 
-   public void setAutoGroup(final boolean autoGroup)
+   public ServerLocatorImpl setAutoGroup(final boolean autoGroup)
    {
       checkWrite();
       this.autoGroup = autoGroup;
+      return this;
    }
 
    public boolean isPreAcknowledge()
@@ -1127,10 +1143,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return preAcknowledge;
    }
 
-   public void setPreAcknowledge(final boolean preAcknowledge)
+   public ServerLocatorImpl setPreAcknowledge(final boolean preAcknowledge)
    {
       checkWrite();
       this.preAcknowledge = preAcknowledge;
+      return this;
    }
 
    public int getAckBatchSize()
@@ -1138,10 +1155,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return ackBatchSize;
    }
 
-   public void setAckBatchSize(final int ackBatchSize)
+   public ServerLocatorImpl setAckBatchSize(final int ackBatchSize)
    {
       checkWrite();
       this.ackBatchSize = ackBatchSize;
+      return this;
    }
 
    public boolean isUseGlobalPools()
@@ -1149,10 +1167,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return useGlobalPools;
    }
 
-   public void setUseGlobalPools(final boolean useGlobalPools)
+   public ServerLocatorImpl setUseGlobalPools(final boolean useGlobalPools)
    {
       checkWrite();
       this.useGlobalPools = useGlobalPools;
+      return this;
    }
 
    public int getScheduledThreadPoolMaxSize()
@@ -1160,10 +1179,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return scheduledThreadPoolMaxSize;
    }
 
-   public void setScheduledThreadPoolMaxSize(final int scheduledThreadPoolMaxSize)
+   public ServerLocatorImpl setScheduledThreadPoolMaxSize(final int scheduledThreadPoolMaxSize)
    {
       checkWrite();
       this.scheduledThreadPoolMaxSize = scheduledThreadPoolMaxSize;
+      return this;
    }
 
    public int getThreadPoolMaxSize()
@@ -1171,10 +1191,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return threadPoolMaxSize;
    }
 
-   public void setThreadPoolMaxSize(final int threadPoolMaxSize)
+   public ServerLocatorImpl setThreadPoolMaxSize(final int threadPoolMaxSize)
    {
       checkWrite();
       this.threadPoolMaxSize = threadPoolMaxSize;
+      return this;
    }
 
    public long getRetryInterval()
@@ -1182,10 +1203,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return retryInterval;
    }
 
-   public void setRetryInterval(final long retryInterval)
+   public ServerLocatorImpl setRetryInterval(final long retryInterval)
    {
       checkWrite();
       this.retryInterval = retryInterval;
+      return this;
    }
 
    public long getMaxRetryInterval()
@@ -1193,10 +1215,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return maxRetryInterval;
    }
 
-   public void setMaxRetryInterval(final long retryInterval)
+   public ServerLocatorImpl setMaxRetryInterval(final long retryInterval)
    {
       checkWrite();
       maxRetryInterval = retryInterval;
+      return this;
    }
 
    public double getRetryIntervalMultiplier()
@@ -1204,10 +1227,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return retryIntervalMultiplier;
    }
 
-   public void setRetryIntervalMultiplier(final double retryIntervalMultiplier)
+   public ServerLocatorImpl setRetryIntervalMultiplier(final double retryIntervalMultiplier)
    {
       checkWrite();
       this.retryIntervalMultiplier = retryIntervalMultiplier;
+      return this;
    }
 
    public int getReconnectAttempts()
@@ -1215,16 +1239,18 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return reconnectAttempts;
    }
 
-   public void setReconnectAttempts(final int reconnectAttempts)
+   public ServerLocatorImpl setReconnectAttempts(final int reconnectAttempts)
    {
       checkWrite();
       this.reconnectAttempts = reconnectAttempts;
+      return this;
    }
 
-   public void setInitialConnectAttempts(int initialConnectAttempts)
+   public ServerLocatorImpl setInitialConnectAttempts(int initialConnectAttempts)
    {
       checkWrite();
       this.initialConnectAttempts = initialConnectAttempts;
+      return this;
    }
 
    public int getInitialConnectAttempts()
@@ -1237,10 +1263,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return this.failoverOnInitialConnection;
    }
 
-   public void setFailoverOnInitialConnection(final boolean failover)
+   public ServerLocatorImpl setFailoverOnInitialConnection(final boolean failover)
    {
       checkWrite();
       this.failoverOnInitialConnection = failover;
+      return this;
    }
 
    public String getConnectionLoadBalancingPolicyClassName()
@@ -1248,10 +1275,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return connectionLoadBalancingPolicyClassName;
    }
 
-   public void setConnectionLoadBalancingPolicyClassName(final String loadBalancingPolicyClassName)
+   public ServerLocatorImpl setConnectionLoadBalancingPolicyClassName(final String loadBalancingPolicyClassName)
    {
       checkWrite();
       connectionLoadBalancingPolicyClassName = loadBalancingPolicyClassName;
+      return this;
    }
 
    public TransportConfiguration[] getStaticTransportConfigurations()
@@ -1272,14 +1300,16 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       addIncomingInterceptor(interceptor);
    }
 
-   public void addIncomingInterceptor(final Interceptor interceptor)
+   public ServerLocatorImpl addIncomingInterceptor(final Interceptor interceptor)
    {
       incomingInterceptors.add(interceptor);
+      return this;
    }
 
-   public void addOutgoingInterceptor(final Interceptor interceptor)
+   public ServerLocatorImpl addOutgoingInterceptor(final Interceptor interceptor)
    {
       outgoingInterceptors.add(interceptor);
+      return this;
    }
 
    @Override
@@ -1304,16 +1334,18 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return initialMessagePacketSize;
    }
 
-   public void setInitialMessagePacketSize(final int size)
+   public ServerLocatorImpl setInitialMessagePacketSize(final int size)
    {
       checkWrite();
       initialMessagePacketSize = size;
+      return this;
    }
 
-   public void setGroupID(final String groupID)
+   public ServerLocatorImpl setGroupID(final String groupID)
    {
       checkWrite();
       this.groupID = groupID;
+      return this;
    }
 
    public String getGroupID()
@@ -1326,9 +1358,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return compressLargeMessage;
    }
 
-   public void setCompressLargeMessage(boolean avoid)
+   public ServerLocatorImpl setCompressLargeMessage(boolean avoid)
    {
       this.compressLargeMessage = avoid;
+      return this;
    }
 
    private void checkWrite()
@@ -1348,14 +1381,16 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return initialConnectors.length;
    }
 
-   public void setIdentity(String identity)
+   public ServerLocatorImpl setIdentity(String identity)
    {
       this.identity = identity;
+      return this;
    }
 
-   public void setNodeID(String nodeID)
+   public ServerLocatorImpl setNodeID(String nodeID)
    {
       this.nodeID = nodeID;
+      return this;
    }
 
    public String getNodeID()
@@ -1363,9 +1398,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return nodeID;
    }
 
-   public void setClusterConnection(boolean clusterConnection)
+   public ServerLocatorImpl setClusterConnection(boolean clusterConnection)
    {
       this.clusterConnection = clusterConnection;
+      return this;
    }
 
    public boolean isClusterConnection()
@@ -1378,9 +1414,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return clusterTransportConfiguration;
    }
 
-   public void setClusterTransportConfiguration(TransportConfiguration tc)
+   public ServerLocatorImpl setClusterTransportConfiguration(TransportConfiguration tc)
    {
       this.clusterTransportConfiguration = tc;
+      return this;
    }
 
    @Override
@@ -1742,9 +1779,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    }
 
    @Override
-   public void setPacketDecoder(PacketDecoder packetDecoder)
+   public ServerLocatorImpl setPacketDecoder(PacketDecoder packetDecoder)
    {
       this.packetDecoder = packetDecoder;
+      return this;
    }
 
    @Override
@@ -1753,9 +1791,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return getNumInitialConnectors() > 0 || getDiscoveryGroupConfiguration() != null;
    }
 
-   public void addClusterTopologyListener(final ClusterTopologyListener listener)
+   public ServerLocatorImpl addClusterTopologyListener(final ClusterTopologyListener listener)
    {
       topology.addClusterTopologyListener(listener);
+      return this;
    }
 
    public void removeClusterTopologyListener(final ClusterTopologyListener listener)

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorInternal.java
@@ -36,14 +36,14 @@ public interface ServerLocatorInternal extends ServerLocator
 
    AfterConnectInternalListener getAfterConnectInternalListener();
 
-   void setAfterConnectionInternalListener(AfterConnectInternalListener listener);
+   ServerLocatorInternal setAfterConnectionInternalListener(AfterConnectInternalListener listener);
 
    /** Used to better identify Cluster Connection Locators on logs. To facilitate eventual debugging.
     *
     *  This method used to be on tests interface, but I'm now making it part of the public interface since*/
-   void setIdentity(String identity);
+   ServerLocatorInternal setIdentity(String identity);
 
-   void setNodeID(String nodeID);
+   ServerLocatorInternal setNodeID(String nodeID);
 
    String getNodeID();
 
@@ -70,17 +70,17 @@ public interface ServerLocatorInternal extends ServerLocator
     */
    void notifyNodeDown(long uniqueEventID, String nodeID);
 
-   void setClusterConnection(boolean clusterConnection);
+   ServerLocatorInternal setClusterConnection(boolean clusterConnection);
 
    boolean isClusterConnection();
 
    TransportConfiguration getClusterTransportConfiguration();
 
-   void setClusterTransportConfiguration(TransportConfiguration tc);
+   ServerLocatorInternal setClusterTransportConfiguration(TransportConfiguration tc);
 
    Topology getTopology();
 
-   void setPacketDecoder(PacketDecoder instance);
+   ServerLocatorInternal setPacketDecoder(PacketDecoder instance);
 
    boolean isConnectable();
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/AcknowledgeTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/AcknowledgeTest.java
@@ -363,9 +363,9 @@ public class AcknowledgeTest extends ServiceTestBase
       }
 
       @Override
-      public void setMessageHandler(MessageHandler handler) throws HornetQException
+      public FakeConsumerWithID setMessageHandler(MessageHandler handler) throws HornetQException
       {
-
+         return this;
       }
 
       @Override

--- a/tests/jms-tests/src/test/java/org/hornetq/jms/tests/message/MessageHeaderTest.java
+++ b/tests/jms-tests/src/test/java/org/hornetq/jms/tests/message/MessageHeaderTest.java
@@ -1336,8 +1336,9 @@ public class MessageHeaderTest extends MessageHeaderTestBase
          return 0;
       }
 
-      public void setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
+      public FakeSession setSendAcknowledgementHandler(final SendAcknowledgementHandler handler)
       {
+         return this;
       }
 
       public void commit(final Xid xid, final boolean b) throws XAException

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
@@ -811,9 +811,9 @@ public class LargeMessageBufferTest extends UnitTestCase
          return null;
       }
 
-      public void setMessageHandler(final MessageHandler handler) throws HornetQException
+      public FakeConsumerInternal setMessageHandler(final MessageHandler handler) throws HornetQException
       {
-
+         return this;
       }
 
       public void acknowledge(final ClientMessage message) throws HornetQException


### PR DESCRIPTION
Make the core client API fluent so that the setters can be chained
together for more readable code.

Test-suite results: http://messaging-09.jbm.lab.bos.redhat.com:8080/job/hornetq-param/826/#showFailuresLink.  No failures related to my changes.
