### PR TITLE
BZ-1149936 HORNETQ-1427 Avoid orphaned consumers

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/management/impl/HornetQServerControlImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/management/impl/HornetQServerControlImpl.java
@@ -1245,8 +1245,8 @@ public class HornetQServerControlImpl extends AbstractControl implements HornetQ
             String remoteAddress = connection.getRemoteAddress();
             if (remoteAddress.contains(ipAddress))
             {
-               remotingService.removeConnection(connection.getID());
                connection.fail(HornetQMessageBundle.BUNDLE.connectionsClosedByManagement(ipAddress));
+               remotingService.removeConnection(connection.getID());
                closed = true;
             }
          }

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
@@ -399,6 +399,23 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
       return started;
    }
 
+
+   private RemotingConnection getConnection(final Object remotingConnectionID)
+   {
+      ConnectionEntry entry = connections.get(remotingConnectionID);
+
+      if (entry != null)
+      {
+         return entry.connection;
+      }
+      else
+      {
+         HornetQServerLogger.LOGGER.errorRemovingConnection();
+
+         return null;
+      }
+   }
+
    public RemotingConnection removeConnection(final Object remotingConnectionID)
    {
       ConnectionEntry entry = connections.remove(remotingConnectionID);
@@ -668,10 +685,11 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
 
                for (Object id : idsToRemove)
                {
-                  RemotingConnection conn = removeConnection(id);
+                  RemotingConnection conn = getConnection(id);
                   if (conn != null)
                   {
                      conn.fail(HornetQMessageBundle.BUNDLE.clientExited(conn.getRemoteAddress()));
+                     removeConnection(id);
                   }
                }
 

--- a/hornetq-server/src/main/java/org/hornetq/core/server/ServerConsumer.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/ServerConsumer.java
@@ -32,6 +32,14 @@ public interface ServerConsumer extends Consumer
 
    void close(boolean failed) throws Exception;
 
+   /**
+    * This method is just to remove itself from Queues.
+    * If for any reason during a close an exception occurred, the exception treatment
+    * will call removeItself what should take the consumer out of any queues.
+    * @throws Exception
+    */
+   void removeItself() throws Exception;
+
    List<MessageReference> cancelRefs(boolean failed, boolean lastConsumedAsDelivered, Transaction tx) throws Exception;
 
    void setStarted(boolean started);

--- a/hornetq-server/src/main/java/org/hornetq/core/server/ServerSession.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/ServerSession.java
@@ -43,7 +43,7 @@ public interface ServerSession
 
    RemotingConnection getRemotingConnection();
 
-   void removeConsumer(long consumerID) throws Exception;
+   boolean removeConsumer(long consumerID) throws Exception;
 
    void acknowledge(long consumerID, long messageID) throws Exception;
 

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
@@ -397,6 +397,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
       return filter;
    }
 
+   @Override
    public void close(final boolean failed) throws Exception
    {
       callback.removeReadyListener(this);
@@ -410,16 +411,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
          del.finish();
       }
 
-      if (browseOnly)
-      {
-         browserDeliverer.close();
-      }
-      else
-      {
-         messageQueue.removeConsumer(this);
-      }
-
-      session.removeConsumer(id);
+      removeItself();
 
       LinkedList<MessageReference> refs = cancelRefs(failed, false, null);
 
@@ -465,6 +457,21 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
 
          managementService.sendNotification(notification);
       }
+   }
+
+   @Override
+   public void removeItself() throws Exception
+   {
+      if (browseOnly)
+      {
+         browserDeliverer.close();
+      }
+      else
+      {
+         messageQueue.removeConsumer(this);
+      }
+
+      session.removeConsumer(id);
    }
 
    /**

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
@@ -277,12 +277,9 @@ public class ServerSessionImpl implements ServerSession, FailureListener
       return Collections.unmodifiableSet(consumersClone);
    }
 
-   public void removeConsumer(final long consumerID) throws Exception
+   public boolean removeConsumer(final long consumerID) throws Exception
    {
-      if (consumers.remove(consumerID) == null)
-      {
-         throw new IllegalStateException("Cannot find consumer with id " + consumerID + " to remove");
-      }
+      return consumers.remove(consumerID) != null;
    }
 
    private void doClose(final boolean failed) throws Exception
@@ -304,14 +301,6 @@ public class ServerSessionImpl implements ServerSession, FailureListener
                HornetQServerLogger.LOGGER.warn(e.getMessage(), e);
             }
          }
-
-         server.removeSession(name);
-
-         remotingConnection.removeFailureListener(this);
-
-         callback.closed();
-
-         closed = true;
       }
 
       //putting closing of consumers outside the sync block
@@ -320,7 +309,22 @@ public class ServerSessionImpl implements ServerSession, FailureListener
 
       for (ServerConsumer consumer : consumersClone)
       {
-         consumer.close(failed);
+         try
+         {
+            consumer.close(failed);
+         }
+         catch (Throwable e)
+         {
+            HornetQServerLogger.LOGGER.warn(e.getMessage(), e);
+            try
+            {
+               consumer.removeItself();
+            }
+            catch (Throwable e2)
+            {
+               HornetQServerLogger.LOGGER.warn(e2.getMessage(), e2);
+            }
+         }
       }
 
       consumers.clear();
@@ -335,6 +339,18 @@ public class ServerSessionImpl implements ServerSession, FailureListener
          {
             HornetQServerLogger.LOGGER.errorDeletingLargeMessageFile(error);
          }
+      }
+
+
+      synchronized (this)
+      {
+         server.removeSession(name);
+
+         remotingConnection.removeFailureListener(this);
+
+         callback.closed();
+
+         closed = true;
       }
    }
 

--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1676,11 +1676,21 @@ public abstract class UnitTestCase extends CoreUnitTestCase
 
    protected final ServerLocator createNonHALocator(final boolean isNetty)
    {
-      ServerLocator locatorWithoutHA =
-         isNetty
-            ? HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY))
-            : HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(INVM_CONNECTOR_FACTORY));
+      ServerLocator locatorWithoutHA = internalCreateNonHALocator(isNetty);
       return addServerLocator(locatorWithoutHA);
+   }
+
+   /**
+    * Creates the Locator without adding it to the list where the tearDown will take place
+    * This is because we don't want it closed in certain tests where we are issuing failures
+    * @param isNetty
+    * @return
+    */
+   protected ServerLocator internalCreateNonHALocator(boolean isNetty)
+   {
+      return isNetty
+         ? HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY))
+         : HornetQClient.createServerLocatorWithoutHA(new TransportConfiguration(INVM_CONNECTOR_FACTORY));
    }
 
    protected static final void stopComponent(HornetQComponent component)

--- a/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/OrphanedConsumerTest.java
+++ b/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/OrphanedConsumerTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.byteman.tests;
+
+
+import org.hornetq.api.core.SimpleString;
+import org.hornetq.api.core.client.ClientConsumer;
+import org.hornetq.api.core.client.ClientMessage;
+import org.hornetq.api.core.client.ClientProducer;
+import org.hornetq.api.core.client.ClientSession;
+import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.core.client.impl.ClientSessionFactoryImpl;
+import org.hornetq.core.server.HornetQServer;
+import org.hornetq.core.server.Queue;
+import org.hornetq.tests.util.ServiceTestBase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Clebert Suconic
+ */
+@RunWith(BMUnitRunner.class)
+public class OrphanedConsumerTest extends ServiceTestBase
+{
+
+   private static boolean conditionActive = true;
+
+   public static final boolean isConditionActive()
+   {
+      return conditionActive;
+   }
+
+
+   public static final void setConditionActive(boolean _conditionActive)
+   {
+      conditionActive = _conditionActive;
+   }
+
+
+   public static void throwException() throws Exception
+   {
+      throw new InterruptedException("nice.. I interrupted this!");
+   }
+
+   private HornetQServer server;
+
+   private ServerLocator locator;
+
+   static HornetQServer staticServer;
+
+   /**
+    * {@link #leavingCloseOnTestCountersWhileClosing()} will set this in case of any issues.
+    * the test must then validate for this being null
+    */
+   static AssertionError verification;
+
+   /**
+    * This static method is an entry point for the byteman rules on {@link #testOrphanedConsumers()}
+    * */
+   public static void leavingCloseOnTestCountersWhileClosing()
+   {
+      if (staticServer.getConnectionCount() == 0)
+      {
+         verification = new AssertionError("The connection was closed before the consumers and sessions, this may cause issues on management leaving Orphaned Consumers!");
+      }
+
+      if (staticServer.getSessions().size() == 0)
+      {
+         verification = new AssertionError("The session was closed before the consumers, this may cause issues on management leaving Orphaned Consumers!");
+      }
+   }
+
+
+   @Override
+   @Before
+   public void setUp() throws Exception
+   {
+      super.setUp();
+      setConditionActive(true);
+      /** I'm using the internal method here because closing
+       *  this locator on tear down would hang.
+       *  as we are tweaking with the internal state and making it fail */
+      locator = internalCreateNonHALocator(true);
+   }
+
+
+   @Override
+   @After
+   public void tearDown() throws Exception
+   {
+      super.tearDown();
+      setConditionActive(false);
+
+      staticServer = null;
+   }
+
+
+   /**
+    * This is like being two tests in one:
+    * I - validating that any exception during the close wouldn't stop connection from being closed
+    * II - validating that the connection is only removed at the end of the process and you wouldn't see
+    *      inconsistencies on management
+    * @throws Exception
+    */
+   @Test
+   @BMRules
+      (
+         rules =
+            {
+               @BMRule
+                  (
+                     name = "closeExit",
+                     targetClass = "org.hornetq.core.server.impl.ServerConsumerImpl",
+                     targetMethod = "close",
+                     targetLocation = "AT EXIT",
+                     condition = "org.hornetq.byteman.tests.OrphanedConsumerTest.isConditionActive()",
+                     action = "System.out.println(\"throwing stuff\");throw new InterruptedException()"
+                  ),
+               @BMRule
+                  (
+                     name = "closeEnter",
+                     targetClass = "org.hornetq.core.server.impl.ServerConsumerImpl",
+                     targetMethod = "close",
+                     targetLocation = "ENTRY",
+                     condition = "org.hornetq.byteman.tests.OrphanedConsumerTest.isConditionActive()",
+                     action = "org.hornetq.byteman.tests.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()"
+                  )
+
+            }
+      )
+   public void testOrphanedConsumers() throws Exception
+   {
+      internalTestOrphanedConsumers(false);
+   }
+
+
+   /**
+    * This is like being two tests in one:
+    * I - validating that any exception during the close wouldn't stop connection from being closed
+    * II - validating that the connection is only removed at the end of the process and you wouldn't see
+    *      inconsistencies on management
+    * @throws Exception
+    */
+   @Test
+   @BMRules
+      (
+         rules =
+            {
+               @BMRule
+                  (
+                     name = "closeExit",
+                     targetClass = "org.hornetq.core.server.impl.ServerConsumerImpl",
+                     targetMethod = "close",
+                     targetLocation = "AT EXIT",
+                     condition = "org.hornetq.byteman.tests.OrphanedConsumerTest.isConditionActive()",
+                     action = "System.out.println(\"throwing stuff\");throw new InterruptedException()"
+                  ),
+               @BMRule
+                  (
+                     name = "closeEnter",
+                     targetClass = "org.hornetq.core.server.impl.ServerConsumerImpl",
+                     targetMethod = "close",
+                     targetLocation = "ENTRY",
+                     condition = "org.hornetq.byteman.tests.OrphanedConsumerTest.isConditionActive()",
+                     action = "org.hornetq.byteman.tests.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()"
+                  )
+
+            }
+      )
+   public void testOrphanedConsumersByManagement() throws Exception
+   {
+      internalTestOrphanedConsumers(true);
+   }
+
+   /**
+    *
+    * @param useManagement true = it will use a management operation to make the connection failure, false through ping
+    * @throws Exception
+    */
+   private void internalTestOrphanedConsumers(boolean useManagement) throws Exception
+   {
+      final int NUMBER_OF_MESSAGES = 2;
+      server = createServer(true, true);
+      server.start();
+      staticServer = server;
+
+      locator.setBlockOnNonDurableSend(false);
+      locator.setBlockOnDurableSend(false);
+      locator.setBlockOnAcknowledge(true);
+      locator.setConnectionTTL(1000);
+      locator.setClientFailureCheckPeriod(100);
+      locator.setReconnectAttempts(0);
+      // We are not interested on consumer-window-size on this test
+      // We want that every message is delivered
+      // as we asserting for number of consumers available and round-robin on delivery
+      locator.setConsumerWindowSize(-1);
+
+      ClientSessionFactoryImpl sf = (ClientSessionFactoryImpl)createSessionFactory(locator);
+
+      ClientSession session = sf.createSession(true, true, 0);
+
+      session.createQueue("queue", "queue1", true);
+      session.createQueue("queue", "queue2", true);
+
+      ClientProducer prod = session.createProducer("queue");
+
+      ClientConsumer consumer = session.createConsumer("queue1");
+      ClientConsumer consumer2 = session.createConsumer("queue2");
+
+
+      Queue queue1 = server.locateQueue(new SimpleString("queue1"));
+
+      Queue queue2 = server.locateQueue(new SimpleString("queue2"));
+
+      session.start();
+
+
+      if (!useManagement)
+      {
+         sf.stopPingingAfterOne();
+
+         for (long timeout = System.currentTimeMillis() + 6000; timeout > System.currentTimeMillis() && server.getConnectionCount() != 0; )
+         {
+            Thread.sleep(100);
+         }
+
+         // an extra second to avoid races of something closing the session while we are asserting it
+         Thread.sleep(1000);
+      }
+      else
+      {
+         server.getHornetQServerControl().closeConnectionsForAddress("127.0.0.1");
+      }
+
+      if (verification != null)
+      {
+         throw verification;
+      }
+
+      assertEquals(0, queue1.getConsumerCount());
+      assertEquals(0, queue2.getConsumerCount());
+
+      setConditionActive(false);
+
+      locator = internalCreateNonHALocator(true);
+
+      locator.setBlockOnNonDurableSend(false);
+      locator.setBlockOnDurableSend(false);
+      locator.setBlockOnAcknowledge(true);
+      locator.setReconnectAttempts(0);
+      locator.setConsumerWindowSize(-1);
+
+      sf = (ClientSessionFactoryImpl)locator.createSessionFactory();
+      session = sf.createSession(true, true, 0);
+
+
+      session.start();
+
+
+      prod = session.createProducer("queue");
+
+      for (int i = 0; i < NUMBER_OF_MESSAGES; i++)
+      {
+         ClientMessage message = session.createMessage(true);
+         message.putIntProperty("i", i);
+         prod.send(message);
+      }
+
+      consumer = session.createConsumer("queue1");
+      consumer2 = session.createConsumer("queue2");
+
+      for (int i = 0; i < NUMBER_OF_MESSAGES; i++)
+      {
+         assertNotNull(consumer.receive(5000));
+         assertNotNull(consumer2.receive(5000));
+      }
+
+      session.close();
+   }
+
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1427
https://bugzilla.redhat.com/show_bug.cgi?id=1149936

We have been reported about orphaned consumers cases.
The only cases where I saw this possibly happening was during a hypotethical
exception during server.close() or during a temporary blocking client (thread waiting to lock)

To avoid that I'm now removing connections at the end of loops and making the exception treatment
per consumer, so if any exception happened we will continue closing. at the worst case the connection
will still be on the maps and this won't be na issue any longer.
