### PR TITLE
test fix on TemporaryQueueTest

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/TemporaryQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/TemporaryQueueTest.java
@@ -565,6 +565,13 @@ public class TemporaryQueueTest extends ServiceTestBase
                         serverCloseLatch.await(2 * RemotingServiceImpl.CONNECTION_TTL_CHECK_INTERVAL +
                                                   2 *
                                                      TemporaryQueueTest.CONNECTION_TTL, TimeUnit.MILLISECONDS));
+
+      // The next getCount will be asynchronously done at the end of failure. We will wait some time until it has reached there.
+      for (long timeout = System.currentTimeMillis() + 5000; timeout > System.currentTimeMillis() && server.getConnectionCount() > 0;)
+      {
+         Thread.sleep(1);
+      }
+
       Assert.assertEquals(0, server.getConnectionCount());
 
       session.close();


### PR DESCRIPTION
The test is now closing connections at the end. the previous assertion needed to be adapted
