### PR TITLE
HORNETQ-1421 Fix MBeans warning on shutdown

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -667,11 +667,7 @@ public class HornetQServerImpl implements HornetQServer
          stopComponent(deploymentManager);
       }
 
-      if (managementService != null)
-         managementService.unregisterServer();
-
       stopComponent(backupManager);
-      stopComponent(managementService);
       activation.preStorageClose();
       stopComponent(pagingManager);
 
@@ -682,6 +678,11 @@ public class HornetQServerImpl implements HornetQServer
       // error shutdown
       if (remotingService != null)
          remotingService.stop(criticalIOError);
+
+      // Stop the management service after the remoting service to ensure all acceptors are deregistered with JMX
+      if (managementService != null)
+         managementService.unregisterServer();
+      stopComponent(managementService);
 
       stopComponent(securityManager);
       stopComponent(resourceManager);


### PR DESCRIPTION
Acceptors were previously not being correctly deregristered from JMX and
the management service registry.  This was due to the management service
registry being shutdown before the remoting service had a chance to
deregister the acceptors from it.  This patch shutsdown the remoting
service before the management service to ensure this no longer happens.
