### PR TITLE
HORNETQ-1437  Keep JNDI when destroying JMS queues

### DIFF
--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/server/impl/JMSServerManagerImpl.java
@@ -906,32 +906,33 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
    {
       checkInitialised();
 
-      removeFromJNDI(queues, queueJNDI, name);
-
-      queues.remove(name);
-      queueJNDI.remove(name);
-
-      jmsManagementService.unregisterQueue(name);
-
       server.destroyQueue(HornetQDestination.createQueueAddressFromName(name), null, true);
 
-      storage.deleteDestination(PersistedType.Queue, name);
+      // if the queue has consumers the queue won't actually be removed therefore only remove the queue from JNDI, etc.
+      // if the queue is actually removed
+      if (this.server.getPostOffice().getBinding(HornetQDestination.createQueueAddressFromName(name)) == null)
+      {
+         removeFromJNDI(queues, queueJNDI, name);
 
-      sendNotification(JMSNotificationType.QUEUE_DESTROYED, name);
+         queues.remove(name);
+         queueJNDI.remove(name);
 
-      return true;
+         jmsManagementService.unregisterQueue(name);
+
+         storage.deleteDestination(PersistedType.Queue, name);
+
+         sendNotification(JMSNotificationType.QUEUE_DESTROYED, name);
+         return true;
+      }
+      else
+      {
+         return false;
+      }
    }
 
    public synchronized boolean destroyTopic(final String name) throws Exception
    {
       checkInitialised();
-
-      removeFromJNDI(topics, topicJNDI, name);
-
-      topics.remove(name);
-      topicJNDI.remove(name);
-
-      jmsManagementService.unregisterTopic(name);
 
       AddressControl addressControl = (AddressControl)server.getManagementService()
          .getResource(ResourceNames.CORE_ADDRESS + HornetQDestination.createTopicAddressFromName(name));
@@ -952,10 +953,30 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback
                server.destroyQueue(SimpleString.toSimpleString(queueName), null, true);
             }
          }
+
+         if (addressControl.getQueueNames().length == 0)
+         {
+            removeFromJNDI(topics, topicJNDI, name);
+
+            topics.remove(name);
+            topicJNDI.remove(name);
+
+            jmsManagementService.unregisterTopic(name);
+
+            storage.deleteDestination(PersistedType.Topic, name);
+
+            sendNotification(JMSNotificationType.TOPIC_DESTROYED, name);
+            return true;
+         }
+         else
+         {
+            return false;
+         }
       }
-      storage.deleteDestination(PersistedType.Topic, name);
-      sendNotification(JMSNotificationType.TOPIC_DESTROYED, name);
-      return true;
+      else
+      {
+         return false;
+      }
    }
 
    public synchronized void createConnectionFactory(final String name,


### PR DESCRIPTION
Change the semantics of the destroyTopic(java.lang.String) and
destroyQueue(java.lang.String) methods on
org.hornetq.api.jms.management.JMSServerControl so that if consumers
are attached to the topic/queue then the JNDI bindings are not removed.
