### PR TITLE
HORNETQ-1429 Fixing proton session.close and connection.close leaking connections

### DIFF
--- a/hornetq-protocols/hornetq-amqp-protocol/src/main/java/org/hornetq/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
+++ b/hornetq-protocols/hornetq-amqp-protocol/src/main/java/org/hornetq/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
@@ -188,9 +188,9 @@ public class ProtonSessionIntegrationCallback implements AMQPSessionCallback, Se
    }
 
    @Override
-   public void close()
+   public void close() throws Exception
    {
-
+      serverSession.close(false);
    }
 
    @Override
@@ -253,13 +253,11 @@ public class ProtonSessionIntegrationCallback implements AMQPSessionCallback, Se
    @Override
    public void sendProducerCreditsMessage(int credits, SimpleString address)
    {
-      System.out.println("sendProducerCredits " + credits);
    }
 
    @Override
    public void sendProducerCreditsFailMessage(int credits, SimpleString address)
    {
-      System.out.println("sendProducerCredits Fail Message" + credits);
    }
 
    @Override
@@ -287,21 +285,18 @@ public class ProtonSessionIntegrationCallback implements AMQPSessionCallback, Se
    @Override
    public int sendLargeMessage(ServerMessage message, ServerConsumer consumer, long bodySize, int deliveryCount)
    {
-      System.out.println("send Large message");
       return 0;
    }
 
    @Override
    public int sendLargeMessageContinuation(ServerConsumer consumer, byte[] body, boolean continues, boolean requiresResponse)
    {
-      System.out.println("send large message continuation");
       return 0;
    }
 
    @Override
    public void closed()
    {
-      System.out.println("close");
    }
 
    @Override

--- a/hornetq-protocols/hornetq-proton-plug/src/main/java/org/proton/plug/AMQPSessionCallback.java
+++ b/hornetq-protocols/hornetq-proton-plug/src/main/java/org/proton/plug/AMQPSessionCallback.java
@@ -56,7 +56,7 @@ public interface AMQPSessionCallback
 
    void rollbackCurrentTX() throws Exception;
 
-   void close();
+   void close() throws Exception;
 
 
    void ack(Object brokerConsumer, Object message) throws Exception;


### PR DESCRIPTION
This is a small fix after the main refactoring.
Session.close() was leaving sessions around what was making the connection.close() to
ignore close calls and leak connections
