### PR TITLE
HORNETQ-1297 Handle MDB w/durable sub but no name

### DIFF
--- a/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivationSpec.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQActivationSpec.java
@@ -13,12 +13,18 @@
 package org.hornetq.ra.inflow;
 
 import javax.jms.Session;
+import javax.jms.Topic;
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
 import javax.resource.spi.ResourceAdapter;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
 
 import org.hornetq.ra.ConnectionFactoryProperties;
 import org.hornetq.ra.HornetQRALogger;
@@ -773,9 +779,39 @@ public class HornetQActivationSpec extends ConnectionFactoryProperties implement
          HornetQRALogger.LOGGER.trace("validate()");
       }
 
-      if (destination == null || destination.trim().equals(""))
+      List<String> errorMessages = new ArrayList<String>();
+      List<PropertyDescriptor> propsNotSet = new ArrayList<PropertyDescriptor>();
+
+      try
       {
-         throw new InvalidPropertyException("Destination is mandatory");
+         if (destination == null || destination.trim().equals(""))
+         {
+            propsNotSet.add(new PropertyDescriptor("destination", HornetQActivationSpec.class));
+            errorMessages.add("Destination is mandatory.");
+         }
+
+         if (Topic.class.getName().equals(destinationType) && isSubscriptionDurable() && (subscriptionName == null || subscriptionName.length() == 0))
+         {
+            propsNotSet.add(new PropertyDescriptor("subscriptionName", HornetQActivationSpec.class));
+            errorMessages.add("If subscription is durable then subscription name must be specified.");
+         }
+      }
+      catch (IntrospectionException e)
+      {
+         e.printStackTrace();
+      }
+
+      if (propsNotSet.size() > 0) {
+         StringBuffer b = new StringBuffer();
+         b.append("Invalid settings:");
+         for (Iterator<String> iter = errorMessages.iterator(); iter.hasNext();) {
+            b.append(" ");
+            b.append(iter.next());
+         }
+         InvalidPropertyException e = new InvalidPropertyException(b.toString());
+         final PropertyDescriptor[] descriptors = propsNotSet.toArray(new PropertyDescriptor[propsNotSet.size()]);
+         e.setInvalidPropertyDescriptors(descriptors);
+         throw e;
       }
    }
 

--- a/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/inflow/HornetQMessageHandler.java
@@ -104,11 +104,9 @@ public class HornetQMessageHandler implements MessageHandler
       SimpleString selectorString = selector == null || selector.trim().equals("") ? null : new SimpleString(selector);
       if (activation.isTopic() && spec.isSubscriptionDurable())
       {
-         String subscriptionName = spec.getSubscriptionName();
-         String clientID = spec.getClientID();
-
-         SimpleString queueName = new SimpleString(HornetQDestination.createQueueNameForDurableSubscription(true, clientID,
-                                                                                                            subscriptionName));
+         SimpleString queueName = new SimpleString(HornetQDestination.createQueueNameForDurableSubscription(true,
+                                                                                                            spec.getClientID(),
+                                                                                                            spec.getSubscriptionName()));
 
          QueueQuery subResponse = session.queueQuery(queueName);
 


### PR DESCRIPTION
NOTE: This change will break the TCK since it contains tests which use a
durable subscription without a subscription name. However, we are
challenging these tests in the TCK. The challenge is being done at
https://issues.jboss.org/browse/CTS-199.
