### PR TITLE
BZ-1160683 NoSuchMethodError during init

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/group/impl/LocalGroupingHandler.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/group/impl/LocalGroupingHandler.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -43,9 +44,9 @@ import org.hornetq.utils.TypedProperties;
  */
 public final class LocalGroupingHandler extends GroupHandlingAbstract
 {
-   private final ConcurrentHashMap<SimpleString, GroupBinding> map = new ConcurrentHashMap<SimpleString, GroupBinding>();
+   private final ConcurrentMap<SimpleString, GroupBinding> map = new ConcurrentHashMap<SimpleString, GroupBinding>();
 
-   private final ConcurrentHashMap<SimpleString, List<GroupBinding>> groupMap = new ConcurrentHashMap<SimpleString, List<GroupBinding>>();
+   private final ConcurrentMap<SimpleString, List<GroupBinding>> groupMap = new ConcurrentHashMap<SimpleString, List<GroupBinding>>();
 
    private final SimpleString name;
 


### PR DESCRIPTION
When compiled by JDK 8 targeting Java 6 and then run on JDK 6 or 7 the
ConcurrentHashMap#keyset() method can fail because the return types
changed in Java 8. Using ConcurrentMap interface to resolve the issue.
