### PR TITLE
Bug 1174886 - HornetQ TTL / check-period not being respected on the replication channel

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -14,6 +14,7 @@
 package org.hornetq.core.server.impl;
 
 import javax.management.MBeanServer;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.PrintWriter;
@@ -2516,6 +2517,8 @@ public class HornetQServerImpl implements HornetQServer
                   serverLocator0.close();
                }
                serverLocator0 = getFailbackLocator(config);
+               serverLocator0.setConnectionTTL(config.getConnectionTTL());
+               serverLocator0.setClientFailureCheckPeriod(config.getClientFailureCheckPeriod());
             }
             //if the cluster isn't available we want to hang around until it is
             serverLocator0.setReconnectAttempts(-1);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -197,7 +197,7 @@ public abstract class FailoverTestBase extends ServiceTestBase
       liveConfig = createDefaultConfig();
 
       ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig,
-                                                     liveConnector);
+                                                     liveConnector, null);
 
       final String suffix = "_backup";
       backupConfig.setBindingsDirectory(backupConfig.getBindingsDirectory() + suffix);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/replication/ReplicationTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/replication/ReplicationTest.java
@@ -13,6 +13,7 @@
 
 package org.hornetq.tests.integration.replication;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.hornetq.api.core.client.ClientProducer;
 import org.hornetq.api.core.client.ClientSession;
 import org.hornetq.api.core.client.ClientSessionFactory;
 import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.core.config.ClusterConnectionConfiguration;
 import org.hornetq.core.config.Configuration;
 import org.hornetq.core.journal.EncodingSupport;
 import org.hornetq.core.journal.IOAsyncTask;
@@ -69,6 +71,7 @@ import org.hornetq.core.replication.ReplicationManager;
 import org.hornetq.core.server.HornetQComponent;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.ServerMessage;
+import org.hornetq.core.server.impl.HornetQServerImpl;
 import org.hornetq.core.server.impl.ServerMessageImpl;
 import org.hornetq.core.settings.HierarchicalRepository;
 import org.hornetq.core.settings.impl.AddressSettings;
@@ -108,13 +111,33 @@ public final class ReplicationTest extends ServiceTestBase
    private ReplicationManager manager;
    private static final SimpleString ADDRESS = new SimpleString("foobar123");
 
-
    private void setupServer(boolean backup, String... interceptors) throws Exception
    {
+      this.setupServer(false, backup, null, interceptors);
+   }
 
-      final TransportConfiguration liveConnector = TransportConfigurationUtils.getInVMConnector(true);
-      final TransportConfiguration backupConnector = TransportConfigurationUtils.getInVMConnector(false);
-      final TransportConfiguration backupAcceptor = TransportConfigurationUtils.getInVMAcceptor(false);
+   private void setupServer(boolean useNetty, boolean backup,
+                            ExtraConfigurer extraConfig,
+                            String... incomingInterceptors) throws Exception
+   {
+      TransportConfiguration liveConnector = null;
+      TransportConfiguration liveAcceptor = null;
+      TransportConfiguration backupConnector = null;
+      TransportConfiguration backupAcceptor = null;
+
+      if (useNetty)
+      {
+         liveConnector = TransportConfigurationUtils.getNettyConnector(true, 0);
+         liveAcceptor = TransportConfigurationUtils.getNettyAcceptor(true, 0);
+         backupConnector = TransportConfigurationUtils.getNettyConnector(false, 0);
+         backupAcceptor = TransportConfigurationUtils.getNettyAcceptor(false, 0);
+      }
+      else
+      {
+         liveConnector = TransportConfigurationUtils.getInVMConnector(true);
+         backupConnector = TransportConfigurationUtils.getInVMConnector(false);
+         backupAcceptor = TransportConfigurationUtils.getInVMAcceptor(false);
+      }
 
       Configuration backupConfig = createDefaultConfig();
       Configuration liveConfig = createDefaultConfig();
@@ -127,14 +150,20 @@ public final class ReplicationTest extends ServiceTestBase
       backupConfig.setPagingDirectory(backupConfig.getPagingDirectory() + suffix);
       backupConfig.setLargeMessagesDirectory(backupConfig.getLargeMessagesDirectory() + suffix);
 
-      if (interceptors.length > 0)
+      if (incomingInterceptors.length > 0)
       {
-         List<String> interceptorsList = Arrays.asList(interceptors);
+         List<String> interceptorsList = Arrays.asList(incomingInterceptors);
          backupConfig.setIncomingInterceptorClassNames(interceptorsList);
       }
 
       ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig,
-                                                     liveConnector);
+                                                     liveConnector, liveAcceptor);
+
+      if (extraConfig != null)
+      {
+         extraConfig.config(liveConfig, backupConfig);
+      }
+
       if (backup)
       {
          liveServer = createServer(liveConfig);
@@ -143,7 +172,14 @@ public final class ReplicationTest extends ServiceTestBase
       }
 
       backupServer = createServer(backupConfig);
-      locator = createInVMNonHALocator();
+      if (useNetty)
+      {
+         locator = createNettyNonHALocator();
+      }
+      else
+      {
+         locator = createInVMNonHALocator();
+      }
       backupServer.start();
       if (backup)
       {
@@ -410,6 +446,55 @@ public final class ReplicationTest extends ServiceTestBase
       });
 
       Assert.assertTrue(latch2.await(5, TimeUnit.SECONDS));
+
+   }
+
+   @Test
+   public void testClusterConnectionConfigs() throws Exception
+   {
+      final long ttlOverride = 123456789;
+      final long checkPeriodOverride = 987654321;
+
+      ExtraConfigurer configurer = new ExtraConfigurer() {
+
+         @Override
+         public void config(Configuration liveConfig, Configuration backupConfig)
+         {
+            List<ClusterConnectionConfiguration> ccList = backupConfig.getClusterConfigurations();
+            assertTrue(ccList.size() > 0);
+            ClusterConnectionConfiguration cc = ccList.get(0);
+            cc.setConnectionTTL(ttlOverride);
+            cc.setClientFailureCheckPeriod(checkPeriodOverride);
+         }
+      };
+      this.setupServer(true, true, configurer);
+      assertTrue(backupServer instanceof HornetQServerImpl);
+
+      //use reflection to get the server locator used by
+      //replication point to create replication connection.
+      //check the ttl and check period config that they
+      //are correctly set
+      ServerLocator replicationLocator = null;
+      Field fActivation = HornetQServerImpl.class.getDeclaredField("activation");
+      fActivation.setAccessible(true);
+      Object backupActivation = fActivation.get(backupServer);
+      Class<?>[] innerClasses = HornetQServerImpl.class.getDeclaredClasses();
+      for (Class<?> cls : innerClasses)
+      {
+         String clsName = cls.getName();
+         System.out.println("inner: " + cls.getName());
+         if (clsName.contains("SharedNothingBackupActivation"))
+         {
+            Field locatorField = cls.getDeclaredField("serverLocator0");
+            locatorField.setAccessible(true);
+            replicationLocator = (ServerLocator) locatorField.get(backupActivation);
+            break;
+         }
+      }
+      assertNotNull(replicationLocator);
+
+      assertEquals(ttlOverride, replicationLocator.getConnectionTTL());
+      assertEquals(checkPeriodOverride, replicationLocator.getClientFailureCheckPeriod());
 
    }
 
@@ -902,5 +987,10 @@ public final class ReplicationTest extends ServiceTestBase
       {
          // no-op
       }
+   }
+
+   private interface ExtraConfigurer
+   {
+      void config(Configuration liveConfig, Configuration backupConfig);
    }
 }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
@@ -21,13 +21,21 @@ public final class ReplicatedBackupUtils
                                                TransportConfiguration backupConnector,
                                                TransportConfiguration backupAcceptor,
                                                Configuration liveConfig,
-                                               TransportConfiguration liveConnector)
+                                               TransportConfiguration liveConnector,
+                                               TransportConfiguration liveAcceptor)
    {
       if (backupAcceptor != null)
       {
          Set<TransportConfiguration> backupAcceptorSet = backupConfig.getAcceptorConfigurations();
          backupAcceptorSet.clear();
          backupAcceptorSet.add(backupAcceptor);
+      }
+
+      if (liveAcceptor != null)
+      {
+         Set<TransportConfiguration> liveAcceptorSet = liveConfig.getAcceptorConfigurations();
+         liveAcceptorSet.clear();
+         liveAcceptorSet.add(liveAcceptor);
       }
 
       backupConfig.getConnectorConfigurations().put(BACKUP_NODE_NAME, backupConnector);


### PR DESCRIPTION
The connection-ttl and client-failure-check-period are not passed
to the server locator used to create replication connection. So the
fix sets the two parameters in SharedNothingBackupActivation.
