### PR TITLE
Bug 1174886 - HornetQ TTL / check-period not being respected on the replication channel

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -13,6 +13,7 @@
 package org.hornetq.core.server.impl;
 
 import javax.management.MBeanServer;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.PrintWriter;
@@ -2410,6 +2411,8 @@ public class HornetQServerImpl implements HornetQServer
                   serverLocator0.close();
                }
                serverLocator0 = getFailbackLocator(config);
+               serverLocator0.setConnectionTTL(config.getConnectionTTL());
+               serverLocator0.setClientFailureCheckPeriod(config.getClientFailureCheckPeriod());
             }
             //if the cluster isn't available we want to hang around until it is
             serverLocator0.setReconnectAttempts(-1);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -182,7 +182,7 @@ public abstract class FailoverTestBase extends ServiceTestBase
       liveConfig = createDefaultConfig();
 
       ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig,
-                                                     liveConnector);
+                                                     liveConnector, null);
 
       final String suffix = "_backup";
       backupConfig.setBindingsDirectory(backupConfig.getBindingsDirectory() + suffix);

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
@@ -33,13 +33,21 @@ public final class ReplicatedBackupUtils
                                                TransportConfiguration backupConnector,
                                                TransportConfiguration backupAcceptor,
                                                Configuration liveConfig,
-                                               TransportConfiguration liveConnector)
+                                               TransportConfiguration liveConnector,
+                                               TransportConfiguration liveAcceptor)
    {
       if (backupAcceptor != null)
       {
          Set<TransportConfiguration> backupAcceptorSet = backupConfig.getAcceptorConfigurations();
          backupAcceptorSet.clear();
          backupAcceptorSet.add(backupAcceptor);
+      }
+
+      if (liveAcceptor != null)
+      {
+         Set<TransportConfiguration> liveAcceptorSet = liveConfig.getAcceptorConfigurations();
+         liveAcceptorSet.clear();
+         liveAcceptorSet.add(liveAcceptor);
       }
 
       backupConfig.getConnectorConfigurations().put(BACKUP_NODE_NAME, backupConnector);


### PR DESCRIPTION

The connection-ttl and client-failure-check-period are not passed
to the server locator used to create replication connection. So the
fix sets the two parameters in SharedNothingBackupActivation.