### PR TITLE
Bug 1174886 - HornetQ TTL / check-period not being respected on the replication channel

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/cluster/ClusterManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/cluster/ClusterManager.java
@@ -747,7 +747,7 @@ public final class ClusterManager implements HornetQComponent
                                                        config.getClusterNotificationInterval(),
                                                        config.getClusterNotificationAttempts());
 
-         clusterController.addClusterConnection(clusterConnection.getName(), dg);
+         clusterController.addClusterConnection(clusterConnection.getName(), dg, config);
       }
       else
       {
@@ -790,7 +790,7 @@ public final class ClusterManager implements HornetQComponent
                                                        config.getClusterNotificationAttempts());
 
 
-         clusterController.addClusterConnection(clusterConnection.getName(), tcConfigs);
+         clusterController.addClusterConnection(clusterConnection.getName(), tcConfigs, config);
       }
 
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -206,7 +206,7 @@ public abstract class FailoverTestBase extends ServiceTestBase
       backupConfig = createDefaultConfig();
       liveConfig = createDefaultConfig();
 
-      ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig, liveConnector);
+      ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig, liveConnector, null);
 
       final String suffix = "_backup";
       backupConfig.setBindingsDirectory(backupConfig.getBindingsDirectory() + suffix)

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/util/ReplicatedBackupUtils.java
@@ -30,11 +30,17 @@ public final class ReplicatedBackupUtils
                                                TransportConfiguration backupConnector,
                                                TransportConfiguration backupAcceptor,
                                                Configuration liveConfig,
-                                               TransportConfiguration liveConnector)
+                                               TransportConfiguration liveConnector,
+                                               TransportConfiguration liveAcceptor)
    {
       if (backupAcceptor != null)
       {
          backupConfig.clearAcceptorConfigurations().addAcceptorConfiguration(backupAcceptor);
+      }
+
+      if (liveAcceptor != null)
+      {
+         liveConfig.clearAcceptorConfigurations().addAcceptorConfiguration(liveAcceptor);
       }
 
       backupConfig.addConnectorConfiguration(BACKUP_NODE_NAME, backupConnector)


### PR DESCRIPTION

The connection-ttl and client-failure-check-period are not passed
to the server locator used to create replication connection. So the
fix sets the two parameters in SharedNothingBackupActivation.