### PR TITLE
HORNETQ-1457 - fix duplicates in TotalQueueIterator

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
@@ -3095,7 +3095,6 @@ public class QueueImpl implements Queue
    private class TotalQueueIterator implements LinkedListIterator<MessageReference>
    {
       LinkedListIterator<PagedReference> pageIter = null;
-      Iterator<MessageReference> interIterator = null;
       LinkedListIterator<MessageReference> messagesIterator = null;
 
       public TotalQueueIterator()
@@ -3104,7 +3103,6 @@ public class QueueImpl implements Queue
          {
             pageIter = pageSubscription.iterator();
          }
-         interIterator = intermediateMessageReferences.iterator();
          messagesIterator = new SynchronizedIterator(messageReferences.iterator());
       }
 
@@ -3112,10 +3110,6 @@ public class QueueImpl implements Queue
       public boolean hasNext()
       {
          if (messagesIterator.hasNext())
-         {
-            return true;
-         }
-         if (interIterator.hasNext())
          {
             return true;
          }
@@ -3136,10 +3130,6 @@ public class QueueImpl implements Queue
          if (messagesIterator.hasNext())
          {
             return messagesIterator.next();
-         }
-         if (interIterator.hasNext())
-         {
-            return interIterator.next();
          }
          if (pageIter != null)
          {


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1457

remove the intermediateReference iterator as these may be moved anyway