### PR TITLE
Management Methods for first message timestamp

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/management/QueueControl.java
@@ -91,6 +91,16 @@ public interface QueueControl
    String getFirstMessageAsJSON() throws Exception;
 
    /**
+    * Returns the timestamp of the first message in milliseconds.
+    */
+   Long getFirstMessageTimestamp() throws Exception;
+
+   /**
+    * Returns the age of the first message in milliseconds.
+    */
+   Long getFirstMessageAge() throws Exception;
+
+   /**
     * Returns the expiry address associated to this queue.
     */
    String getExpiryAddress();

--- a/hornetq-jms-client/src/main/java/org/hornetq/api/jms/management/JMSQueueControl.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/api/jms/management/JMSQueueControl.java
@@ -67,6 +67,21 @@ public interface JMSQueueControl extends DestinationControl
     */
    String getSelector();
 
+   /**
+    * Returns the first message on the queue as JSON
+    */
+   String getFirstMessageAsJSON() throws Exception;
+
+   /**
+    * Returns the timestamp of the first message in milliseconds.
+    */
+   Long getFirstMessageTimestamp() throws Exception;
+
+   /**
+    * Returns the age of the first message in milliseconds.
+    */
+   Long getFirstMessageAge() throws Exception;
+
    // Operations ----------------------------------------------------
 
    /**

--- a/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
+++ b/hornetq-jms-server/src/main/java/org/hornetq/jms/management/impl/JMSQueueControlImpl.java
@@ -155,6 +155,21 @@ public class JMSQueueControlImpl extends StandardMBean implements JMSQueueContro
       coreQueueControl.setExpiryAddress(expiryAddress);
    }
 
+   public String getFirstMessageAsJSON() throws Exception
+   {
+      return coreQueueControl.getFirstMessageAsJSON();
+   }
+
+   public Long getFirstMessageTimestamp() throws Exception
+   {
+      return coreQueueControl.getFirstMessageTimestamp();
+   }
+
+   public Long getFirstMessageAge() throws Exception
+   {
+      return coreQueueControl.getFirstMessageAge();
+   }
+
    @Override
    public void addJNDI(String jndi) throws Exception
    {

--- a/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/management/impl/QueueControlImpl.java
@@ -15,6 +15,7 @@ package org.hornetq.core.management.impl;
 import javax.management.MBeanOperationInfo;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -531,7 +532,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
       }
    }
 
-   public String getFirstMessageAsJSON() throws Exception
+   protected Map<String, Object>[] getFirstMessage() throws Exception
    {
       checkStarted();
 
@@ -550,7 +551,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
                Message message = ref.getMessage();
                messages.add(message.toMap());
             }
-            return toJSON(messages.toArray(new Map[1])).toString();
+            return messages.toArray(new Map[1]);
          }
          finally
          {
@@ -562,6 +563,37 @@ public class QueueControlImpl extends AbstractControl implements QueueControl
          blockOnIO();
       }
 
+   }
+
+   public String getFirstMessageAsJSON() throws Exception
+   {
+      return toJSON(getFirstMessage()).toString();
+   }
+
+   public Long getFirstMessageTimestamp() throws Exception
+   {
+      Map<String, Object>[] _message = getFirstMessage();
+      if (_message == null || _message.length == 0 || _message[0] == null)
+      {
+         return null;
+      }
+      Map<String, Object> message = _message[0];
+      if (!message.containsKey("timestamp"))
+      {
+         return null;
+      }
+      return (Long)message.get("timestamp");
+   }
+
+   public Long getFirstMessageAge() throws Exception
+   {
+      Long firstMessageTimestamp = getFirstMessageTimestamp();
+      if (firstMessageTimestamp == null)
+      {
+         return null;
+      }
+      long now = new Date().getTime();
+      return now - firstMessageTimestamp.longValue();
    }
 
    public long countMessages(final String filterStr) throws Exception

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
@@ -159,6 +159,21 @@ public class JMSQueueControlUsingJMSTest extends JMSQueueControlTest
             return (String)proxy.retrieveAttributeValue("expiryAddress");
          }
 
+         public String getFirstMessageAsJSON() throws Exception
+         {
+            return (String)proxy.retrieveAttributeValue("firstMessageAsJSON");
+         }
+
+         public Long getFirstMessageTimestamp() throws Exception
+         {
+            return (Long)proxy.retrieveAttributeValue("firstMessageTimestamp");
+         }
+
+         public Long getFirstMessageAge() throws Exception
+         {
+            return (Long)proxy.retrieveAttributeValue("firstMessageAge");
+         }
+
          public long getMessageCount()
          {
             return ((Number)proxy.retrieveAttributeValue("messageCount")).longValue();

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/management/QueueControlUsingCoreTest.java
@@ -183,6 +183,21 @@ public class QueueControlUsingCoreTest extends QueueControlTest
             return (String) proxy.invokeOperation("getFirstMessageAsJSON");
          }
 
+         /**
+          * Returns the timestamp of the first message in milliseconds.
+          */
+         public Long getFirstMessageTimestamp() throws Exception
+         {
+            return (Long) proxy.invokeOperation("getFirstMessageTimestamp");
+         }
+
+         /**
+          * Returns the age of the first message in milliseconds.
+          */
+         public Long getFirstMessageAge() throws Exception
+         {
+            return (Long) proxy.invokeOperation("getFirstMessageAge");
+         }
 
          public String listMessageCounterHistoryAsHTML() throws Exception
          {


### PR DESCRIPTION
This basically extends the getFirstMessageAsJSON() concept to extract just the timestamp.

For large messages in particular, this is much more efficient than returning the whole message as JSON and then extracting the timestamp.

I tested with JConsole and it is OK, but there are a few things that could be done differently, if anybody has an opinion on these things I don't mind changing them:

- should getFirstMessageTimestamp() return a java.util.Date object, the Java way of doing things, or return a long, just like the message header?

- when there are no messages in the queue, should the methods return null?  There are two other possibilities that came to mind: if the return values are doubles, they could return NaN when the queue is empty.  The other possibility is throwing IllegalStateException.

I'd like to have this merged into 2.3.x as well, so I've tried to keep it as simple as possible.