### PR TITLE
BZ-1195210 Backup fails to announce to live server

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/protocol/core/impl/CoreProtocolManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/protocol/core/impl/CoreProtocolManager.java
@@ -352,6 +352,7 @@ class CoreProtocolManager implements ProtocolManager
                }
                catch (HornetQException e)
                {
+                  HornetQServerLogger.LOGGER.debug("Failed to process backup registration packet", e);
                   channel0.send(new BackupReplicationStartFailedMessage(BackupReplicationStartFailedMessage.BackupRegistrationProblem.EXCEPTION));
                }
             }

--- a/hornetq-server/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/BackupReplicationStartFailedMessage.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/protocol/core/impl/wireformat/BackupReplicationStartFailedMessage.java
@@ -98,4 +98,10 @@ public final class BackupReplicationStartFailedMessage extends PacketImpl
       result = 31 * result + (problem != null ? problem.hashCode() : 0);
       return result;
    }
+
+   @Override
+   public String toString()
+   {
+      return getParentString() + ", problem=" + problem.name() + "]";
+   }
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/RemotingService.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/RemotingService.java
@@ -50,6 +50,8 @@ public interface RemotingService
 
    void start() throws Exception;
 
+   void startAcceptors() throws Exception;
+
    boolean isStarted();
 
    /**

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/server/impl/RemotingServiceImpl.java
@@ -257,10 +257,10 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
          }
       }
 
-      for (Acceptor a : acceptors)
-      {
-         a.start();
-      }
+      /**
+       * Don't start the acceptors here.  Only start the acceptors at the every end of the start-up process to avoid
+       * race conditions. See {@link #startAcceptors()}.
+       */
 
       // This thread checks connections that need to be closed, and also flushes confirmations
       failureCheckAndFlushThread = new FailureCheckAndFlushThread(RemotingServiceImpl.CONNECTION_TTL_CHECK_INTERVAL);
@@ -268,6 +268,17 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
       failureCheckAndFlushThread.start();
 
       started = true;
+   }
+
+   public synchronized void startAcceptors() throws Exception
+   {
+      if (isStarted())
+      {
+         for (Acceptor a : acceptors)
+         {
+            a.start();
+         }
+      }
    }
 
    public synchronized void allowInvmSecurityOverride(HornetQPrincipal principal)

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -460,7 +460,6 @@ public class HornetQServerImpl implements HornetQServer
          }
          else
          {
-            state = SERVER_STATE.STARTED;
             HornetQServerLogger.LOGGER.serverStarted(getVersion().getFullVersion(), nodeManager.getNodeId(),
                                                      identity != null ? identity : "");
          }
@@ -1663,7 +1662,6 @@ public class HornetQServerImpl implements HornetQServer
       {
          throw HornetQMessageBundle.BUNDLE.nodeIdNull();
       }
-      activationLatch.countDown();
 
       // We can only do this after everything is started otherwise we may get nasty races with expired messages
       postOffice.startExpiryScanner();
@@ -2314,6 +2312,10 @@ public class HornetQServerImpl implements HornetQServer
 
             initialisePart2();
 
+            state = SERVER_STATE.STARTED;
+            remotingService.startAcceptors();
+            activationLatch.countDown();
+
             HornetQServerLogger.LOGGER.serverIsLive();
          }
          catch (Exception e)
@@ -2370,6 +2372,10 @@ public class HornetQServerImpl implements HornetQServer
             initialisePart2();
 
             clusterManager.activate();
+
+            remotingService.startAcceptors();
+
+            activationLatch.countDown();
 
             HornetQServerLogger.LOGGER.backupServerIsLive();
 
@@ -2687,6 +2693,8 @@ public class HornetQServerImpl implements HornetQServer
                storageManager.start();
                initialisePart2();
                clusterManager.activate();
+               remotingService.startAcceptors();
+               activationLatch.countDown();
             }
          }
          catch (Exception e)
@@ -2832,6 +2840,10 @@ public class HornetQServerImpl implements HornetQServer
             initialisePart1();
 
             initialisePart2();
+
+            state = SERVER_STATE.STARTED;
+            remotingService.startAcceptors();
+            activationLatch.countDown();
 
             if (identity != null)
             {

--- a/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/ReplicationBackupTest.java
+++ b/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/ReplicationBackupTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2013 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.hornetq.byteman.tests;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.core.config.Configuration;
+import org.hornetq.core.server.HornetQServer;
+import org.hornetq.core.server.JournalType;
+import org.hornetq.tests.util.ReplicatedBackupUtils;
+import org.hornetq.tests.util.ServiceTestBase;
+import org.hornetq.tests.util.TransportConfigurationUtils;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BMUnitRunner.class)
+public class ReplicationBackupTest extends ServiceTestBase
+{
+   private static final CountDownLatch ruleFired = new CountDownLatch(1);
+   private HornetQServer backupServer;
+   private HornetQServer liveServer;
+
+   /*
+   * simple test to induce a potential race condition where the server's acceptors are active, but the server's
+   * state != STARTED
+   */
+   @Test
+   @BMRules
+      (
+         rules =
+            {
+               @BMRule
+                  (
+                     name = "prevent backup annoucement",
+                     targetClass = "org.hornetq.core.server.impl.HornetQServerImpl$SharedNothingLiveActivation",
+                     targetMethod = "run",
+                     targetLocation = "AT EXIT",
+                     action = "org.hornetq.byteman.tests.ReplicationBackupTest.breakIt();"
+                  )
+            }
+      )
+   public void testBasicConnection() throws Exception
+   {
+      TransportConfiguration liveConnector = TransportConfigurationUtils.getNettyConnector(true, 0);
+      TransportConfiguration liveAcceptor = TransportConfigurationUtils.getNettyAcceptor(true, 0);
+      TransportConfiguration backupConnector = TransportConfigurationUtils.getNettyConnector(false, 0);
+      TransportConfiguration backupAcceptor = TransportConfigurationUtils.getNettyAcceptor(false, 0);
+
+      Configuration backupConfig = createDefaultConfig();
+      Configuration liveConfig = createDefaultConfig();
+
+      liveConfig.setJournalType(JournalType.NIO);
+      backupConfig.setJournalType(JournalType.NIO);
+
+      backupConfig.setBackup(true);
+
+      final String suffix = "_backup";
+      backupConfig.setBindingsDirectory(backupConfig.getBindingsDirectory() + suffix);
+      backupConfig.setJournalDirectory(backupConfig.getJournalDirectory() + suffix);
+      backupConfig.setPagingDirectory(backupConfig.getPagingDirectory() + suffix);
+      backupConfig.setLargeMessagesDirectory(backupConfig.getLargeMessagesDirectory() + suffix);
+
+      ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig, liveConnector, liveAcceptor);
+
+      liveServer = createServer(liveConfig);
+
+      // start the live server in a new thread so we can start the backup simultaneously to induce a potential race
+      Thread startThread = new Thread(new Runnable()
+      {
+         @Override
+         public void run()
+         {
+            try
+            {
+               liveServer.start();
+            }
+            catch (Exception e)
+            {
+               e.printStackTrace();
+            }
+         }
+      });
+      startThread.start();
+
+      ruleFired.await();
+
+      backupServer = createServer(backupConfig);
+      backupServer.start();
+      ServiceTestBase.waitForRemoteBackup(null, 3, true, backupServer);
+   }
+
+   public static void breakIt()
+   {
+      ruleFired.countDown();
+      try
+      {
+         /* before the fix this sleep would put the "live" server into a state where the acceptors were started
+          * but the server's state != STARTED which would cause the backup to fail to announce
+          */
+         Thread.sleep(2000);
+      }
+      catch (InterruptedException e)
+      {
+         e.printStackTrace();
+      }
+   }
+}


### PR DESCRIPTION
When a live and backup server are both started at or near the same moment
there is a small window where the live server's acceptors have been
started but the server's state != STARTED. During this window if the
backup sends its announcement the announcement will fail and the backup
will shutdown. This fix closes this small window by only starting the
acceptors until the server is fully started.

I got a clean run from the full test-suite on our internal hardware (see param-build #872) and also on my own machine.