### PR TITLE
Use the context class loader in FileConfiguration

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
@@ -59,7 +59,7 @@ public final class FileConfiguration extends ConfigurationImpl
       }
 
 
-      URL url = getClass().getClassLoader().getResource(configurationUrl);
+      URL url = Thread.currentThread().getContextClassLoader().getResource(configurationUrl);
 
       if (url == null)
       {

--- a/hornetq-server/src/test/java/org/hornetq/core/config/impl/FileConfigurationTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/config/impl/FileConfigurationTest.java
@@ -12,6 +12,12 @@
  */
 package org.hornetq.core.config.impl;
 
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 
 import org.hornetq.api.core.BroadcastGroupConfiguration;
@@ -37,6 +43,9 @@ import org.junit.Test;
  */
 public class FileConfigurationTest extends ConfigurationImplTest
 {
+
+   private final String fullConfigurationName = "ConfigurationTest-full-config.xml";
+
    @Override
    @Test
    public void testDefaults()
@@ -360,10 +369,76 @@ public class FileConfigurationTest extends ConfigurationImplTest
 
    }
 
+   @Test
+   public void testContextClassLoaderUsage() throws Exception
+   {
+
+      final File customConfiguration = File.createTempFile("hornetq-unittest", ".xml");
+
+      try
+      {
+
+         // copy working configuration to a location where the standard classloader cannot find it
+         final Path workingConfiguration = new File(getClass().getResource(File.separator + fullConfigurationName).toURI()).toPath();
+         final Path targetFile = customConfiguration.toPath();
+
+         Files.copy(workingConfiguration, targetFile, StandardCopyOption.REPLACE_EXISTING);
+
+         // build a custom classloader knowing the location of the config created above (used as context class loader)
+         final URL customConfigurationDirUrl = new URL("file://" + customConfiguration.getParentFile().getAbsolutePath() + File.separator);
+         final ClassLoader testWebappClassLoader = new URLClassLoader(new URL[]{customConfigurationDirUrl});
+
+         /*
+            run this in an own thread, avoid polluting the class loader of the thread context of the unit test engine,
+            expect no exception in this thread when the class loading works as expected
+          */
+
+         final class ThrowableHolder
+         {
+            public Exception t = null;
+         }
+
+         final ThrowableHolder holder = new ThrowableHolder();
+
+         final Thread webappContextThread = new Thread(new Runnable()
+         {
+            @Override
+            public void run()
+            {
+               FileConfiguration fileConfiguration = new FileConfiguration(customConfiguration.getName());
+
+               try
+               {
+                  fileConfiguration.start();
+               }
+               catch (Exception e)
+               {
+                  holder.t = e;
+               }
+            }
+         });
+
+         webappContextThread.setContextClassLoader(testWebappClassLoader);
+
+         webappContextThread.start();
+         webappContextThread.join();
+
+         if (holder.t != null)
+         {
+            fail("Exception caught while loading configuration with the context class loader: " + holder.t.getMessage());
+         }
+
+      }
+      finally
+      {
+         customConfiguration.delete();
+      }
+   }
+
    @Override
    protected Configuration createConfiguration() throws Exception
    {
-      FileConfiguration fc = new FileConfiguration("ConfigurationTest-full-config.xml");
+      FileConfiguration fc = new FileConfiguration(fullConfigurationName);
 
       fc.start();
 


### PR DESCRIPTION
Avoid loading problems of file configurations in
servlet containers when packaging the hornetq libs
not in the war file (e.g. in tomcat/lib/)