### PR TITLE
Added possibility to intercept stomp frames

### DIFF
--- a/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompFrameInterceptor.java
+++ b/hornetq-protocols/hornetq-stomp-protocol/src/main/java/org/hornetq/core/protocol/stomp/StompFrameInterceptor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2005-2014 Red Hat, Inc.
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.hornetq.core.protocol.stomp;
+
+import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.Interceptor;
+import org.hornetq.core.protocol.core.Packet;
+import org.hornetq.spi.core.protocol.RemotingConnection;
+
+public abstract class StompFrameInterceptor implements Interceptor
+{
+
+   @Override
+   public boolean intercept(Packet packet, RemotingConnection connection) throws HornetQException
+   {
+      return true;
+   }
+
+   public abstract boolean intercept(StompFrame stompFrame, RemotingConnection connection);
+}


### PR DESCRIPTION
Added possibility to intercept stomp frames via interceptor section in hornetq-configuration.xml (could not find any other possibility to do it in order to log all incoming messages).
Decided to introduce new abstract class which implements Interceptor interface as the simplest solution. Clients need to extend this class and put it under hornetq class path, just as a regular jms interceptor.