### PR TITLE
BZ-1203869 adding logs for customer

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
@@ -21,6 +21,7 @@
 */
 package org.hornetq.core.client;
 
+import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.HornetQExceptionType;
 import org.hornetq.api.core.Interceptor;
 import org.hornetq.core.protocol.core.Packet;
@@ -403,4 +404,21 @@ public interface HornetQClientLogger extends BasicLogger
             format = Message.Format.MESSAGE_FORMAT)
    void outOfCreditOnFlowControl(String address);
 
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 214025,
+      value = "Failure captured on connectionID={0}, performing failover or reconnection now",
+      format = Message.Format.MESSAGE_FORMAT)
+   void failoverOrReconnect(Object connectionID, @Cause HornetQException me);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 214026,
+               value = "Replaying commands for channelID={0} with lastCommandID from the server={1}",
+               format = Message.Format.MESSAGE_FORMAT)
+   void replayingCommands(long id, int lastConfirmedCommandID);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 214027,
+               value = "Couldn't reattach session {0}, performing as a failover operation now and recreating objects",
+               format = Message.Format.MESSAGE_FORMAT)
+   void creatingNewSession(long id);
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -595,6 +595,8 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
    private void failoverOrReconnect(final Object connectionID, final HornetQException me)
    {
+      HornetQClientLogger.LOGGER.failoverOrReconnect(connectionID, me);
+
       Set<ClientSessionInternal> sessionsToClose = null;
       if (exitLoop)
          return;

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionImpl.java
@@ -1035,12 +1035,16 @@ final class ClientSessionImpl implements ClientSessionInternal, FailureListener,
                {
                   HornetQClientLogger.LOGGER.debug("ClientSession reattached fine, replaying commands");
                }
+
+               HornetQClientLogger.LOGGER.replayingCommands(channel.getID(), response.getLastConfirmedCommandID());
                // The session was found on the server - we reattached transparently ok
 
                channel.replayCommands(response.getLastConfirmedCommandID());
             }
             else
             {
+
+               HornetQClientLogger.LOGGER.creatingNewSession(channel.getID());
 
                if (HornetQClientLogger.LOGGER.isDebugEnabled())
                {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1203869

This is adding some Log.Info around the time reattachment is happening.
This is because an user is reporting some messages around reattachment and we don't know where it's coming from.