### PR TITLE
srvLocator null check in HornetQConnectionFactory

### DIFF
--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnectionFactory.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQConnectionFactory.java
@@ -809,7 +809,10 @@ public class HornetQConnectionFactory implements Serializable, Referenceable, Co
    {
       try
       {
-         serverLocator.close();
+         if (serverLocator != null)
+         {
+            serverLocator.close();
+         }
       }
       catch (Exception e)
       {


### PR DESCRIPTION
Checking serverLocator on null if HornetQConnectorFactory is created
using the default constructor where serverLocator attribute is set
to null.

Here is the reference to the forum:
https://developer.jboss.org/thread/253729