### PR TITLE
[HORNETQ-1483] outbound connections from RA don't load-balance as exp…

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ServerLocatorImpl.java
@@ -600,6 +600,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // if the topologyArray is null, we will use the initialConnectors
       if (usedTopology != null)
       {
+         if (HornetQClientLogger.LOGGER.isTraceEnabled())
+         {
+            HornetQClientLogger.LOGGER.trace("Selecting connector from toplogy.");
+         }
          int pos = loadBalancingPolicy.select(usedTopology.length);
          Pair<TransportConfiguration, TransportConfiguration> pair = usedTopology[pos];
 
@@ -607,6 +611,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       }
       else
       {
+         if (HornetQClientLogger.LOGGER.isTraceEnabled())
+         {
+            HornetQClientLogger.LOGGER.trace("Selecting connector from initial connectors.");
+         }
          // Get from initialconnectors
 
          int pos = loadBalancingPolicy.select(initialConnectors.length);

--- a/hornetq-ra/src/main/java/org/hornetq/ra/ConnectionFactoryProperties.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/ConnectionFactoryProperties.java
@@ -838,4 +838,361 @@ public class ConnectionFactoryProperties
    {
       return hasBeenUpdated;
    }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      ConnectionFactoryProperties other = (ConnectionFactoryProperties)obj;
+      if (this.autoGroup == null)
+      {
+         if (other.autoGroup != null)
+            return false;
+      }
+      else if (!this.autoGroup.equals(other.autoGroup))
+         return false;
+      if (this.blockOnAcknowledge == null)
+      {
+         if (other.blockOnAcknowledge != null)
+            return false;
+      }
+      else if (!this.blockOnAcknowledge.equals(other.blockOnAcknowledge))
+         return false;
+      if (this.blockOnDurableSend == null)
+      {
+         if (other.blockOnDurableSend != null)
+            return false;
+      }
+      else if (!this.blockOnDurableSend.equals(other.blockOnDurableSend))
+         return false;
+      if (this.blockOnNonDurableSend == null)
+      {
+         if (other.blockOnNonDurableSend != null)
+            return false;
+      }
+      else if (!this.blockOnNonDurableSend.equals(other.blockOnNonDurableSend))
+         return false;
+      if (this.cacheLargeMessagesClient == null)
+      {
+         if (other.cacheLargeMessagesClient != null)
+            return false;
+      }
+      else if (!this.cacheLargeMessagesClient.equals(other.cacheLargeMessagesClient))
+         return false;
+      if (this.compressLargeMessage == null)
+      {
+         if (other.compressLargeMessage != null)
+            return false;
+      }
+      else if (!this.compressLargeMessage.equals(other.compressLargeMessage))
+         return false;
+      if (this.failoverOnInitialConnection == null)
+      {
+         if (other.failoverOnInitialConnection != null)
+            return false;
+      }
+      else if (!this.failoverOnInitialConnection.equals(other.failoverOnInitialConnection))
+         return false;
+      if (this.ha == null)
+      {
+         if (other.ha != null)
+            return false;
+      }
+      else if (!this.ha.equals(other.ha))
+         return false;
+      if (this.preAcknowledge == null)
+      {
+         if (other.preAcknowledge != null)
+            return false;
+      }
+      else if (!this.preAcknowledge.equals(other.preAcknowledge))
+         return false;
+      if (this.callFailoverTimeout == null)
+      {
+         if (other.callFailoverTimeout != null)
+            return false;
+      }
+      else if (!this.callFailoverTimeout.equals(other.callFailoverTimeout))
+         return false;
+      if (this.callTimeout == null)
+      {
+         if (other.callTimeout != null)
+            return false;
+      }
+      else if (!this.callTimeout.equals(other.callTimeout))
+         return false;
+      if (this.clientFailureCheckPeriod == null)
+      {
+         if (other.clientFailureCheckPeriod != null)
+            return false;
+      }
+      else if (!this.clientFailureCheckPeriod.equals(other.clientFailureCheckPeriod))
+         return false;
+      if (this.clientID == null)
+      {
+         if (other.clientID != null)
+            return false;
+      }
+      else if (!this.clientID.equals(other.clientID))
+         return false;
+      if (this.confirmationWindowSize == null)
+      {
+         if (other.confirmationWindowSize != null)
+            return false;
+      }
+      else if (!this.confirmationWindowSize.equals(other.confirmationWindowSize))
+         return false;
+      if (this.connectionLoadBalancingPolicyClassName == null)
+      {
+         if (other.connectionLoadBalancingPolicyClassName != null)
+            return false;
+      }
+      else if (!this.connectionLoadBalancingPolicyClassName.equals(other.connectionLoadBalancingPolicyClassName))
+         return false;
+      if (this.connectionTTL == null)
+      {
+         if (other.connectionTTL != null)
+            return false;
+      }
+      else if (!this.connectionTTL.equals(other.connectionTTL))
+         return false;
+      if (this.consumerMaxRate == null)
+      {
+         if (other.consumerMaxRate != null)
+            return false;
+      }
+      else if (!this.consumerMaxRate.equals(other.consumerMaxRate))
+         return false;
+      if (this.consumerWindowSize == null)
+      {
+         if (other.consumerWindowSize != null)
+            return false;
+      }
+      else if (!this.consumerWindowSize.equals(other.consumerWindowSize))
+         return false;
+      if (this.discoveryAddress == null)
+      {
+         if (other.discoveryAddress != null)
+            return false;
+      }
+      else if (!this.discoveryAddress.equals(other.discoveryAddress))
+         return false;
+      if (this.discoveryInitialWaitTimeout == null)
+      {
+         if (other.discoveryInitialWaitTimeout != null)
+            return false;
+      }
+      else if (!this.discoveryInitialWaitTimeout.equals(other.discoveryInitialWaitTimeout))
+         return false;
+      if (this.discoveryLocalBindAddress == null)
+      {
+         if (other.discoveryLocalBindAddress != null)
+            return false;
+      }
+      else if (!this.discoveryLocalBindAddress.equals(other.discoveryLocalBindAddress))
+         return false;
+      if (this.discoveryPort == null)
+      {
+         if (other.discoveryPort != null)
+            return false;
+      }
+      else if (!this.discoveryPort.equals(other.discoveryPort))
+         return false;
+      if (this.discoveryRefreshTimeout == null)
+      {
+         if (other.discoveryRefreshTimeout != null)
+            return false;
+      }
+      else if (!this.discoveryRefreshTimeout.equals(other.discoveryRefreshTimeout))
+         return false;
+      if (this.dupsOKBatchSize == null)
+      {
+         if (other.dupsOKBatchSize != null)
+            return false;
+      }
+      else if (!this.dupsOKBatchSize.equals(other.dupsOKBatchSize))
+         return false;
+      if (this.groupID == null)
+      {
+         if (other.groupID != null)
+            return false;
+      }
+      else if (!this.groupID.equals(other.groupID))
+         return false;
+      if (this.initialConnectAttempts == null)
+      {
+         if (other.initialConnectAttempts != null)
+            return false;
+      }
+      else if (!this.initialConnectAttempts.equals(other.initialConnectAttempts))
+         return false;
+      if (this.initialMessagePacketSize == null)
+      {
+         if (other.initialMessagePacketSize != null)
+            return false;
+      }
+      else if (!this.initialMessagePacketSize.equals(other.initialMessagePacketSize))
+         return false;
+      if (this.jgroupsChannelName == null)
+      {
+         if (other.jgroupsChannelName != null)
+            return false;
+      }
+      else if (!this.jgroupsChannelName.equals(other.jgroupsChannelName))
+         return false;
+      if (this.jgroupsFile == null)
+      {
+         if (other.jgroupsFile != null)
+            return false;
+      }
+      else if (!this.jgroupsFile.equals(other.jgroupsFile))
+         return false;
+      if (this.maxRetryInterval == null)
+      {
+         if (other.maxRetryInterval != null)
+            return false;
+      }
+      else if (!this.maxRetryInterval.equals(other.maxRetryInterval))
+         return false;
+      if (this.minLargeMessageSize == null)
+      {
+         if (other.minLargeMessageSize != null)
+            return false;
+      }
+      else if (!this.minLargeMessageSize.equals(other.minLargeMessageSize))
+         return false;
+      if (this.producerMaxRate == null)
+      {
+         if (other.producerMaxRate != null)
+            return false;
+      }
+      else if (!this.producerMaxRate.equals(other.producerMaxRate))
+         return false;
+      if (this.producerWindowSize == null)
+      {
+         if (other.producerWindowSize != null)
+            return false;
+      }
+      else if (!this.producerWindowSize.equals(other.producerWindowSize))
+         return false;
+      if (this.reconnectAttempts == null)
+      {
+         if (other.reconnectAttempts != null)
+            return false;
+      }
+      else if (!this.reconnectAttempts.equals(other.reconnectAttempts))
+         return false;
+      if (this.retryInterval == null)
+      {
+         if (other.retryInterval != null)
+            return false;
+      }
+      else if (!this.retryInterval.equals(other.retryInterval))
+         return false;
+      if (this.retryIntervalMultiplier == null)
+      {
+         if (other.retryIntervalMultiplier != null)
+            return false;
+      }
+      else if (!this.retryIntervalMultiplier.equals(other.retryIntervalMultiplier))
+         return false;
+      if (this.scheduledThreadPoolMaxSize == null)
+      {
+         if (other.scheduledThreadPoolMaxSize != null)
+            return false;
+      }
+      else if (!this.scheduledThreadPoolMaxSize.equals(other.scheduledThreadPoolMaxSize))
+         return false;
+      if (this.threadPoolMaxSize == null)
+      {
+         if (other.threadPoolMaxSize != null)
+            return false;
+      }
+      else if (!this.threadPoolMaxSize.equals(other.threadPoolMaxSize))
+         return false;
+      if (this.transactionBatchSize == null)
+      {
+         if (other.transactionBatchSize != null)
+            return false;
+      }
+      else if (!this.transactionBatchSize.equals(other.transactionBatchSize))
+         return false;
+      if (this.useGlobalPools == null)
+      {
+         if (other.useGlobalPools != null)
+            return false;
+      }
+      else if (!this.useGlobalPools.equals(other.useGlobalPools))
+         return false;
+      if (connectorClassName == null)
+      {
+         if (other.connectorClassName != null)
+            return false;
+      }
+      else if (!connectorClassName.equals(other.connectorClassName))
+         return false;
+      if (this.connectionParameters == null)
+      {
+         if (other.connectionParameters != null)
+            return false;
+      }
+      else if (!connectionParameters.equals(other.connectionParameters))
+         return false;
+      return true;
+   }
+
+   @Override
+   public int hashCode()
+   {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((ha == null) ? 0 : ha.hashCode());
+      result = prime * result + ((connectionLoadBalancingPolicyClassName == null) ? 0 : connectionLoadBalancingPolicyClassName.hashCode());
+      result = prime * result + ((jgroupsFile == null) ? 0 : jgroupsFile.hashCode());
+      result = prime * result + ((jgroupsChannelName == null) ? 0 : jgroupsChannelName.hashCode());
+      result = prime * result + ((discoveryAddress == null) ? 0 : discoveryAddress.hashCode());
+      result = prime * result + ((discoveryPort == null) ? 0 : discoveryPort.hashCode());
+      result = prime * result + ((discoveryLocalBindAddress == null) ? 0 : discoveryLocalBindAddress.hashCode());
+      result = prime * result + ((discoveryRefreshTimeout == null) ? 0 : discoveryRefreshTimeout.hashCode());
+      result = prime * result + ((discoveryInitialWaitTimeout == null) ? 0 : discoveryInitialWaitTimeout.hashCode());
+      result = prime * result + ((clientID == null) ? 0 : clientID.hashCode());
+      result = prime * result + ((dupsOKBatchSize == null) ? 0 : dupsOKBatchSize.hashCode());
+      result = prime * result + ((transactionBatchSize == null) ? 0 : transactionBatchSize.hashCode());
+      result = prime * result + ((clientFailureCheckPeriod == null) ? 0 : clientFailureCheckPeriod.hashCode());
+      result = prime * result + ((connectionTTL == null) ? 0 : connectionTTL.hashCode());
+      result = prime * result + ((cacheLargeMessagesClient == null) ? 0 : cacheLargeMessagesClient.hashCode());
+      result = prime * result + ((callTimeout == null) ? 0 : callTimeout.hashCode());
+      result = prime * result + ((callFailoverTimeout == null) ? 0 : callFailoverTimeout.hashCode());
+      result = prime * result + ((compressLargeMessage == null) ? 0 : compressLargeMessage.hashCode());
+      result = prime * result + ((consumerWindowSize == null) ? 0 : consumerWindowSize.hashCode());
+      result = prime * result + ((producerWindowSize == null) ? 0 : producerWindowSize.hashCode());
+      result = prime * result + ((consumerMaxRate == null) ? 0 : consumerMaxRate.hashCode());
+      result = prime * result + ((confirmationWindowSize == null) ? 0 : confirmationWindowSize.hashCode());
+      result = prime * result + ((failoverOnInitialConnection == null) ? 0 : failoverOnInitialConnection.hashCode());
+      result = prime * result + ((producerMaxRate == null) ? 0 : producerMaxRate.hashCode());
+      result = prime * result + ((minLargeMessageSize == null) ? 0 : minLargeMessageSize.hashCode());
+      result = prime * result + ((blockOnAcknowledge == null) ? 0 : blockOnAcknowledge.hashCode());
+      result = prime * result + ((blockOnNonDurableSend == null) ? 0 : blockOnNonDurableSend.hashCode());
+      result = prime * result + ((blockOnDurableSend == null) ? 0 : blockOnDurableSend.hashCode());
+      result = prime * result + ((autoGroup == null) ? 0 : autoGroup.hashCode());
+      result = prime * result + ((preAcknowledge == null) ? 0 : preAcknowledge.hashCode());
+      result = prime * result + ((initialConnectAttempts == null) ? 0 : initialConnectAttempts.hashCode());
+      result = prime * result + ((retryInterval == null) ? 0 : retryInterval.hashCode());
+      result = prime * result + ((retryIntervalMultiplier == null) ? 0 : retryIntervalMultiplier.hashCode());
+      result = prime * result + ((maxRetryInterval == null) ? 0 : maxRetryInterval.hashCode());
+      result = prime * result + ((reconnectAttempts == null) ? 0 : reconnectAttempts.hashCode());
+      result = prime * result + ((useGlobalPools == null) ? 0 : useGlobalPools.hashCode());
+      result = prime * result + ((initialMessagePacketSize == null) ? 0 : initialMessagePacketSize.hashCode());
+      result = prime * result + ((scheduledThreadPoolMaxSize == null) ? 0 : scheduledThreadPoolMaxSize.hashCode());
+      result = prime * result + ((threadPoolMaxSize == null) ? 0 : threadPoolMaxSize.hashCode());
+      result = prime * result + ((groupID == null) ? 0 : groupID.hashCode());
+      result = prime * result + ((connectorClassName == null) ? 0 : connectorClassName.hashCode());
+      result = prime * result + ((connectionParameters == null) ? 0 : connectionParameters.hashCode());
+      return result;
+   }
 }

--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnection.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQRAManagedConnection.java
@@ -893,4 +893,8 @@ public final class HornetQRAManagedConnection implements ManagedConnection, Exce
       this.inManagedTx = inManagedTx;
    }
 
+   public HornetQConnectionFactory getConnectionFactory()
+   {
+      return connectionFactory;
+   }
 }

--- a/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
+++ b/hornetq-ra/src/main/java/org/hornetq/ra/HornetQResourceAdapter.java
@@ -112,6 +112,13 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
    private final List<HornetQRAManagedConnectionFactory> managedConnectionFactories = new ArrayList<HornetQRAManagedConnectionFactory>();
 
    /**
+    * Keep track of the connection factories that we create so we don't create a bunch of instances of factories
+    * configured the exact same way. Using the same connection factory instance also makes connection load-balancing
+    * behave as expected for outbound connections.
+    */
+   private Map<ConnectionFactoryProperties, HornetQConnectionFactory> knownConnectionFactories = new HashMap<ConnectionFactoryProperties, HornetQConnectionFactory>();
+
+   /**
     * Constructor
     */
    public HornetQResourceAdapter()
@@ -284,6 +291,8 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
       }
 
       managedConnectionFactories.clear();
+
+      knownConnectionFactories.clear();
 
       if (defaultHornetQConnectionFactory != null)
       {
@@ -1848,137 +1857,149 @@ public class HornetQResourceAdapter implements ResourceAdapter, Serializable
    public HornetQConnectionFactory createHornetQConnectionFactory(final ConnectionFactoryProperties overrideProperties)
    {
       HornetQConnectionFactory cf;
-      List<String> connectorClassName = overrideProperties.getParsedConnectorClassNames() != null ? overrideProperties.getParsedConnectorClassNames()
-         : raProperties.getParsedConnectorClassNames();
+      boolean known = false;
 
-      String discoveryAddress = overrideProperties.getDiscoveryAddress() != null ? overrideProperties.getDiscoveryAddress()
-         : getDiscoveryAddress();
-
-      Boolean ha = overrideProperties.isHA() != null ? overrideProperties.isHA() : getHA();
-
-      String jgroupsFileName = overrideProperties.getJgroupsFile() != null ? overrideProperties.getJgroupsFile()
-         : getJgroupsFile();
-
-      String jgroupsChannel = overrideProperties.getJgroupsChannelName() != null ? overrideProperties.getJgroupsChannelName()
-         : getJgroupsChannelName();
-
-      String jgroupsLocatorClassName = raProperties.getJgroupsChannelLocatorClass();
-
-      if (ha == null)
+      synchronized (knownConnectionFactories)
       {
-         ha = HornetQClient.DEFAULT_IS_HA;
-      }
-
-      if (discoveryAddress != null || jgroupsFileName != null || jgroupsLocatorClassName != null)
-      {
-         BroadcastEndpointFactoryConfiguration endpointFactoryConfiguration = null;
-
-         if (jgroupsLocatorClassName != null)
+         if (!knownConnectionFactories.keySet().contains(overrideProperties))
          {
-            String jchannelRefName = raProperties.getJgroupsChannelRefName();
-            JChannel jchannel = HornetQRaUtils.locateJGroupsChannel(jgroupsLocatorClassName, jchannelRefName);
-            endpointFactoryConfiguration = new JGroupsBroadcastGroupConfiguration(jchannel, jgroupsChannel);
-         }
-         else if (discoveryAddress != null)
-         {
-            Integer discoveryPort = overrideProperties.getDiscoveryPort() != null ? overrideProperties.getDiscoveryPort()
-               : getDiscoveryPort();
-            if (discoveryPort == null)
+            List<String> connectorClassName = overrideProperties.getParsedConnectorClassNames() != null ? overrideProperties.getParsedConnectorClassNames() : raProperties.getParsedConnectorClassNames();
+
+            String discoveryAddress = overrideProperties.getDiscoveryAddress() != null ? overrideProperties.getDiscoveryAddress() : getDiscoveryAddress();
+
+            Boolean ha = overrideProperties.isHA() != null ? overrideProperties.isHA() : getHA();
+
+            String jgroupsFileName = overrideProperties.getJgroupsFile() != null ? overrideProperties.getJgroupsFile() : getJgroupsFile();
+
+            String jgroupsChannel = overrideProperties.getJgroupsChannelName() != null ? overrideProperties.getJgroupsChannelName() : getJgroupsChannelName();
+
+            String jgroupsLocatorClassName = raProperties.getJgroupsChannelLocatorClass();
+
+            if (ha == null)
             {
-               discoveryPort = HornetQClient.DEFAULT_DISCOVERY_PORT;
+               ha = HornetQClient.DEFAULT_IS_HA;
             }
 
-            String localBindAddress = overrideProperties.getDiscoveryLocalBindAddress() != null ? overrideProperties.getDiscoveryLocalBindAddress()
-               : raProperties.getDiscoveryLocalBindAddress();
-            endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(discoveryAddress, discoveryPort, localBindAddress, -1);
-         }
-         else if (jgroupsFileName != null)
-         {
-            endpointFactoryConfiguration = new JGroupsBroadcastGroupConfiguration(jgroupsFileName, jgroupsChannel);
-         }
-         Long refreshTimeout = overrideProperties.getDiscoveryRefreshTimeout() != null ? overrideProperties.getDiscoveryRefreshTimeout()
-            : raProperties.getDiscoveryRefreshTimeout();
-         if (refreshTimeout == null)
-         {
-            refreshTimeout = HornetQClient.DEFAULT_DISCOVERY_REFRESH_TIMEOUT;
-         }
-
-         Long initialTimeout = overrideProperties.getDiscoveryInitialWaitTimeout() != null ? overrideProperties.getDiscoveryInitialWaitTimeout()
-            : raProperties.getDiscoveryInitialWaitTimeout();
-
-         if (initialTimeout == null)
-         {
-            initialTimeout = HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT;
-         }
-
-         DiscoveryGroupConfiguration groupConfiguration = new DiscoveryGroupConfiguration(refreshTimeout, initialTimeout, endpointFactoryConfiguration);
-
-         if (HornetQRALogger.LOGGER.isDebugEnabled())
-         {
-            HornetQRALogger.LOGGER.debug("Creating Connection Factory on the resource adapter for discovery=" + groupConfiguration + " with ha=" + ha);
-         }
-
-         if (ha)
-         {
-            cf = HornetQJMSClient.createConnectionFactoryWithHA(groupConfiguration, JMSFactoryType.XA_CF);
-         }
-         else
-         {
-            cf = HornetQJMSClient.createConnectionFactoryWithoutHA(groupConfiguration, JMSFactoryType.XA_CF);
-         }
-      }
-      else if (connectorClassName != null)
-      {
-         TransportConfiguration[] transportConfigurations = new TransportConfiguration[connectorClassName.size()];
-
-         List<Map<String, Object>> connectionParams;
-         if (overrideProperties.getParsedConnectorClassNames() != null)
-         {
-            connectionParams = overrideProperties.getParsedConnectionParameters();
-         }
-         else
-         {
-            connectionParams = raProperties.getParsedConnectionParameters();
-         }
-
-         for (int i = 0; i < connectorClassName.size(); i++)
-         {
-            TransportConfiguration tc;
-            if (connectionParams == null || i >= connectionParams.size())
+            if (discoveryAddress != null || jgroupsFileName != null || jgroupsLocatorClassName != null)
             {
-               tc = new TransportConfiguration(connectorClassName.get(i));
-               HornetQRALogger.LOGGER.debug("No connector params provided using default");
+               BroadcastEndpointFactoryConfiguration endpointFactoryConfiguration = null;
+
+               if (jgroupsLocatorClassName != null)
+               {
+                  String jchannelRefName = raProperties.getJgroupsChannelRefName();
+                  JChannel jchannel = HornetQRaUtils.locateJGroupsChannel(jgroupsLocatorClassName, jchannelRefName);
+                  endpointFactoryConfiguration = new JGroupsBroadcastGroupConfiguration(jchannel, jgroupsChannel);
+               }
+               else if (discoveryAddress != null)
+               {
+                  Integer discoveryPort = overrideProperties.getDiscoveryPort() != null ? overrideProperties.getDiscoveryPort() : getDiscoveryPort();
+                  if (discoveryPort == null)
+                  {
+                     discoveryPort = HornetQClient.DEFAULT_DISCOVERY_PORT;
+                  }
+
+                  String localBindAddress = overrideProperties.getDiscoveryLocalBindAddress() != null ? overrideProperties.getDiscoveryLocalBindAddress() : raProperties.getDiscoveryLocalBindAddress();
+                  endpointFactoryConfiguration = new UDPBroadcastGroupConfiguration(discoveryAddress, discoveryPort, localBindAddress, -1);
+               }
+               else if (jgroupsFileName != null)
+               {
+                  endpointFactoryConfiguration = new JGroupsBroadcastGroupConfiguration(jgroupsFileName, jgroupsChannel);
+               }
+               Long refreshTimeout = overrideProperties.getDiscoveryRefreshTimeout() != null ? overrideProperties.getDiscoveryRefreshTimeout() : raProperties.getDiscoveryRefreshTimeout();
+               if (refreshTimeout == null)
+               {
+                  refreshTimeout = HornetQClient.DEFAULT_DISCOVERY_REFRESH_TIMEOUT;
+               }
+
+               Long initialTimeout = overrideProperties.getDiscoveryInitialWaitTimeout() != null ? overrideProperties.getDiscoveryInitialWaitTimeout() : raProperties.getDiscoveryInitialWaitTimeout();
+
+               if (initialTimeout == null)
+               {
+                  initialTimeout = HornetQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT;
+               }
+
+               DiscoveryGroupConfiguration groupConfiguration = new DiscoveryGroupConfiguration(refreshTimeout, initialTimeout, endpointFactoryConfiguration);
+
+               if (HornetQRALogger.LOGGER.isDebugEnabled())
+               {
+                  HornetQRALogger.LOGGER.debug("Creating Connection Factory on the resource adapter for discovery=" + groupConfiguration + " with ha=" + ha);
+               }
+
+               if (ha)
+               {
+                  cf = HornetQJMSClient.createConnectionFactoryWithHA(groupConfiguration, JMSFactoryType.XA_CF);
+               }
+               else
+               {
+                  cf = HornetQJMSClient.createConnectionFactoryWithoutHA(groupConfiguration, JMSFactoryType.XA_CF);
+               }
+            }
+            else if (connectorClassName != null)
+            {
+               TransportConfiguration[] transportConfigurations = new TransportConfiguration[connectorClassName.size()];
+
+               List<Map<String, Object>> connectionParams;
+               if (overrideProperties.getParsedConnectorClassNames() != null)
+               {
+                  connectionParams = overrideProperties.getParsedConnectionParameters();
+               }
+               else
+               {
+                  connectionParams = raProperties.getParsedConnectionParameters();
+               }
+
+               for (int i = 0; i < connectorClassName.size(); i++)
+               {
+                  TransportConfiguration tc;
+                  if (connectionParams == null || i >= connectionParams.size())
+                  {
+                     tc = new TransportConfiguration(connectorClassName.get(i));
+                     HornetQRALogger.LOGGER.debug("No connector params provided using default");
+                  }
+                  else
+                  {
+                     tc = new TransportConfiguration(connectorClassName.get(i), connectionParams.get(i));
+                  }
+
+                  transportConfigurations[i] = tc;
+               }
+
+               if (HornetQRALogger.LOGGER.isDebugEnabled())
+               {
+                  HornetQRALogger.LOGGER.debug("Creating Connection Factory on the resource adapter for transport=" +
+                                                  Arrays.toString(transportConfigurations) + " with ha=" + ha);
+               }
+
+               if (ha)
+               {
+                  cf = HornetQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.XA_CF, transportConfigurations);
+               }
+               else
+               {
+                  cf = HornetQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.XA_CF, transportConfigurations);
+               }
             }
             else
             {
-               tc = new TransportConfiguration(connectorClassName.get(i), connectionParams.get(i));
+               throw new IllegalArgumentException("must provide either TransportType or DiscoveryGroupAddress and DiscoveryGroupPort for HornetQ ResourceAdapter Connection Factory");
             }
 
-            transportConfigurations[i] = tc;
-         }
-
-
-         if (HornetQRALogger.LOGGER.isDebugEnabled())
-         {
-            HornetQRALogger.LOGGER.debug("Creating Connection Factory on the resource adapter for transport=" +
-                                            Arrays.toString(transportConfigurations) + " with ha=" + ha);
-         }
-
-         if (ha)
-         {
-            cf = HornetQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.XA_CF, transportConfigurations);
+            setParams(cf, overrideProperties);
+            knownConnectionFactories.put(overrideProperties, cf);
          }
          else
          {
-            cf = HornetQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.XA_CF, transportConfigurations);
+            cf = knownConnectionFactories.get(overrideProperties);
+            known = true;
          }
       }
-      else
+
+      if (known && cf.getServerLocator().isClosed())
       {
-         throw new IllegalArgumentException("must provide either TransportType or DiscoveryGroupAddress and DiscoveryGroupPort for HornetQ ResourceAdapter Connection Factory");
+         knownConnectionFactories.remove(overrideProperties);
+         cf = createHornetQConnectionFactory(overrideProperties);
       }
 
-      setParams(cf, overrideProperties);
       return cf;
    }
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/ConnectionFactoryPropertiesTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/ra/ConnectionFactoryPropertiesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2009 Red Hat, Inc.
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package org.hornetq.tests.integration.ra;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hornetq.ra.ConnectionFactoryProperties;
+import org.hornetq.tests.util.UnitTestCase;
+import org.junit.Test;
+
+public class ConnectionFactoryPropertiesTest extends UnitTestCase
+{
+   @Test
+   public void testEquality() throws Exception
+   {
+      ConnectionFactoryProperties cfp1 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames1 = new ArrayList<String>();
+      connectorClassNames1.add("myConnector");
+      cfp1.setParsedConnectorClassNames(connectorClassNames1);
+      List<Map<String, Object>> connectionParameters1 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params1 = new HashMap<String, Object>();
+      params1.put("port", "0");
+      connectionParameters1.add(params1);
+      cfp1.setParsedConnectionParameters(connectionParameters1);
+      cfp1.setAutoGroup(true);
+
+      ConnectionFactoryProperties cfp2 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames2 = new ArrayList<String>();
+      connectorClassNames2.add("myConnector");
+      cfp2.setParsedConnectorClassNames(connectorClassNames2);
+      List<Map<String, Object>> connectionParameters2 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params2 = new HashMap<String, Object>();
+      params2.put("port", "0");
+      connectionParameters2.add(params2);
+      cfp2.setParsedConnectionParameters(connectionParameters2);
+      cfp2.setAutoGroup(true);
+
+      assertTrue(cfp1.equals(cfp2));
+   }
+
+   @Test
+   public void testInequality() throws Exception
+   {
+      ConnectionFactoryProperties cfp1 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames1 = new ArrayList<String>();
+      connectorClassNames1.add("myConnector");
+      cfp1.setParsedConnectorClassNames(connectorClassNames1);
+      List<Map<String, Object>> connectionParameters1 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params1 = new HashMap<String, Object>();
+      params1.put("port", "0");
+      connectionParameters1.add(params1);
+      cfp1.setParsedConnectionParameters(connectionParameters1);
+      cfp1.setAutoGroup(true);
+
+      ConnectionFactoryProperties cfp2 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames2 = new ArrayList<String>();
+      connectorClassNames2.add("myConnector");
+      cfp2.setParsedConnectorClassNames(connectorClassNames2);
+      List<Map<String, Object>> connectionParameters2 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params2 = new HashMap<String, Object>();
+      params2.put("port", "1");
+      connectionParameters2.add(params2);
+      cfp2.setParsedConnectionParameters(connectionParameters2);
+      cfp2.setAutoGroup(true);
+
+      assertFalse(cfp1.equals(cfp2));
+   }
+
+   @Test
+   public void testInequality2() throws Exception
+   {
+      ConnectionFactoryProperties cfp1 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames1 = new ArrayList<String>();
+      connectorClassNames1.add("myConnector");
+      cfp1.setParsedConnectorClassNames(connectorClassNames1);
+      List<Map<String, Object>> connectionParameters1 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params1 = new HashMap<String, Object>();
+      params1.put("port", "0");
+      connectionParameters1.add(params1);
+      cfp1.setParsedConnectionParameters(connectionParameters1);
+      cfp1.setAutoGroup(true);
+
+      ConnectionFactoryProperties cfp2 = new ConnectionFactoryProperties();
+      List<String> connectorClassNames2 = new ArrayList<String>();
+      connectorClassNames2.add("myConnector2");
+      cfp2.setParsedConnectorClassNames(connectorClassNames2);
+      List<Map<String, Object>> connectionParameters2 = new ArrayList<Map<String, Object>>();
+      Map<String, Object> params2 = new HashMap<String, Object>();
+      params2.put("port", "0");
+      connectionParameters2.add(params2);
+      cfp2.setParsedConnectionParameters(connectionParameters2);
+      cfp2.setAutoGroup(true);
+
+      assertFalse(cfp1.equals(cfp2));
+   }
+}


### PR DESCRIPTION
…ected

According to : https://bugzilla.redhat.com/show_bug.cgi?id=1259753

Inbound sessions are always created from the same HornetQConnectionFactory
which means the load-balancing policy is applied to them in the expected
manner. However, outbound sessions are created from independent, unique
HornetQConnectionFactory instances which means that the load-balancing
doesn't follow the expected pattern.

This commit changes this behavior by caching each unique
HornetQConnectionFactory instance and using it for both inbound and outbound
sessions potentially. This ensures the sessions are load-balanced as
expected.
