### PR TITLE
[HORNETQ-1482] Add WARN log when setting connection-ttl OR connection…

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/config/ConfigurationUtils.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/ConfigurationUtils.java
@@ -1,6 +1,7 @@
 package org.hornetq.core.config;
 
 import org.hornetq.api.core.HornetQIllegalStateException;
+import org.hornetq.core.server.HornetQServerLogger;
 
 public final class ConfigurationUtils
 {
@@ -22,5 +23,30 @@ public final class ConfigurationUtils
       }
       throw new HornetQIllegalStateException("Missing cluster-configuration for replication-cluster-name '" +
                                                 replicationCluster + "'.");
+   }
+
+   // A method to check the passed Configuration object and warn users if semantically unwise parameters are present
+   public static void validateConfiguration(Configuration configuration)
+   {
+      // Warn if connection-ttl-override/connection-ttl == check-period
+      compareTTLWithCheckPeriod(configuration);
+   }
+
+   private static void compareTTLWithCheckPeriod(Configuration configuration)
+   {
+      for (ClusterConnectionConfiguration c : configuration.getClusterConfigurations())
+         compareTTLWithCheckPeriod(c.getName(), c.getConnectionTTL(), configuration.getConnectionTTLOverride(), c.getClientFailureCheckPeriod());
+
+      for (BridgeConfiguration c : configuration.getBridgeConfigurations())
+         compareTTLWithCheckPeriod(c.getName(), c.getConnectionTTL(), configuration.getConnectionTTLOverride(), c.getClientFailureCheckPeriod());
+   }
+
+   private static void compareTTLWithCheckPeriod(String name, long connectionTTL, long connectionTTLOverride, long checkPeriod)
+   {
+      if (connectionTTLOverride == checkPeriod)
+         HornetQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod(name, "connection-ttl-override", "check-period");
+
+      if (connectionTTL == checkPeriod)
+         HornetQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod(name, "connection-ttl", "check-period");
    }
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/deployers/impl/FileConfigurationParser.java
@@ -1153,9 +1153,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
          }
       }
 
-      // Warn if connection-ttl-override/connection-ttl == check-period
-      compareTTLWithCheckPeriod(mainConfig, connectionTTL, clientFailureCheckPeriod);
-
       ClusterConnectionConfiguration config;
 
       if (discoveryGroupName == null)
@@ -1317,9 +1314,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
          }
       }
 
-      // Warn if connection-ttl-override/connection-ttl == check-period
-      compareTTLWithCheckPeriod(mainConfig, connectionTTL, clientFailureCheckPeriod);
-
       BridgeConfiguration config;
 
       if (!staticConnectorNames.isEmpty())
@@ -1451,14 +1445,5 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
       }
 
       return new ConnectorServiceConfiguration(clazz, params, name);
-   }
-
-   private void compareTTLWithCheckPeriod(final Configuration config, final long connectionTTL, final long checkPeriod)
-   {
-      if (config.getConnectionTTLOverride() == checkPeriod)
-          HornetQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod("connection-ttl-override", "check-period");
-
-      if (connectionTTL == checkPeriod)
-          HornetQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod("connection-ttl", "check-period");
    }
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1023,11 +1023,11 @@ public interface HornetQServerLogger extends BasicLogger
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222191,
-           value = "<{0}> should not be set to the same value as <{1}>.  " +
+           value = "{0}: <{1}> should not be set to the same value as <{2}>.  " +
                    "If a system is under high load, or there is a minor network delay, " +
                    "there is a high probability of a cluster split/failure due to connection timeout.",
            format = Message.Format.MESSAGE_FORMAT)
-   void connectionTTLEqualsCheckPeriod(String ttl, String checkPeriod);
+   void connectionTTLEqualsCheckPeriod(String connectionName, String ttl, String checkPeriod);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -336,6 +336,10 @@ public class HornetQServerImpl implements HornetQServer
       {
          configuration = new ConfigurationImpl();
       }
+      else
+      {
+         ConfigurationUtils.validateConfiguration(configuration);
+      }
 
       if (mbeanServer == null)
       {


### PR DESCRIPTION
…-ttl-override equal to check-period.

Now works when HornetQ is deployed in an application server as well as standalone.

BZ-1175722: https://bugzilla.redhat.com/show_bug.cgi?id=1175722
