### PR TITLE
Bug1276206 PageSubscriptionImpl NPE issue

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -1437,12 +1437,13 @@ final class PageSubscriptionImpl implements PageSubscription
       public void remove()
       {
          deliveredCount.incrementAndGet();
-         if (currentDelivery != null)
+         PagedReference delivery = currentDelivery;
+         if (delivery != null)
          {
-            PageCursorInfo info = PageSubscriptionImpl.this.getPageInfo(currentDelivery.getPosition());
+            PageCursorInfo info = PageSubscriptionImpl.this.getPageInfo(delivery.getPosition());
             if (info != null)
             {
-               info.remove(currentDelivery.getPosition());
+               info.remove(delivery.getPosition());
             }
          }
       }


### PR DESCRIPTION
  This issue is caused by a racing condition in remove() method.
  Using a copy of the original reference could avoid this.
  (Porting from upstream branch, which is artemis now)

ref:
https://bugzilla.redhat.com/show_bug.cgi?id=1276206
