### PR TITLE
[BZ1288578] HornetQ Client trying to use wrong keystore

### DIFF
--- a/docs/user-manual/en/configuring-transports.xml
+++ b/docs/user-manual/en/configuring-transports.xml
@@ -324,8 +324,12 @@ buffer_size = bandwidth * RTT.</programlisting>
                         SSL key store which holds the client certificates. This is only relevant
                         for a <literal>connector</literal> if you are using 2-way SSL (i.e. mutual
                         authentication). Although this value is configured on the server, it is
-                        downloaded and used by the client. Furthermore, it can be overridden on the
-                        client-side by using the customary "javax.net.ssl.keyStore" system property.</para>
+                        downloaded and used by the client. If the client needs to use a different path
+                        from that set on the server then it can override the server-side setting by either
+                        using the customary "javax.net.ssl.keyStore" system property or the HornetQ-specific
+                        "org.hornetq.ssl.keyStore" system property. The HornetQ-specific system property
+                        is useful if another component on client is already making use of the standard, Java
+                        system property.</para>
                 </listitem>
                 <listitem>
                     <para><literal>key-store-password</literal></para>
@@ -334,9 +338,12 @@ buffer_size = bandwidth * RTT.</programlisting>
                     <para>When used on a <literal>connector</literal> this is the password for the
                         client-side keystore.  This is only relevant for a <literal>connector</literal>
                         if you are using 2-way SSL (i.e. mutual authentication). Although this value can
-                        be configured on the server, it is downloaded and used by the client. If
-                        necessary, it can be overridden on the client-side by using the customary
-                        "javax.net.ssl.keyStorePassword" system property.</para>
+                        be configured on the server, it is downloaded and used by the client.  If the client
+                        needs to use a different password from that set on the server then it can override
+                        the server-side setting by either using the customary "javax.net.ssl.keyStorePassword"
+                        system property or the HornetQ-specific "org.hornetq.ssl.keyStorePassword" system
+                        property. The HornetQ-specific system property is useful if another component on client
+                        is already making use of the standard, Java system property.</para>
                 </listitem>
                 <listitem>
                     <para><literal>trust-store-path</literal></para>
@@ -347,8 +354,12 @@ buffer_size = bandwidth * RTT.</programlisting>
                     <para>When used on a <literal>connector</literal> this is the path to the client-side
                         SSL key store which holds the public keys of all the servers that the client
                         trusts. Although this value can be configured on the server, it is downloaded and
-                        used by the client. If necessary, it can be overridden on the client-side by using
-                        the customary "javax.net.ssl.trustStore" system property.</para>
+                        used by the client.  If the client needs to use a different path
+                        from that set on the server then it can override the server-side setting by either
+                        using the customary "javax.net.ssl.trustStore" system property or the HornetQ-specific
+                        "org.hornetq.ssl.trustStore" system property. The HornetQ-specific system property
+                        is useful if another component on client is already making use of the standard, Java
+                        system property.</para>
                 </listitem>
                 <listitem>
                     <para><literal>trust-store-password</literal></para>
@@ -357,9 +368,12 @@ buffer_size = bandwidth * RTT.</programlisting>
                         if you are using 2-way SSL (i.e. mutual authentication).</para>
                     <para>When used on a <literal>connector</literal> this is the password for the
                         client-side truststore. Although this value can be configured on the server, it is
-                        downloaded and used by the client. If necessary, it can be overridden on the
-                        client-side by using the customary "javax.net.ssl.trustStorePassword" system
-                        property.</para>
+                        downloaded and used by the client.   If the client
+                        needs to use a different password from that set on the server then it can override
+                        the server-side setting by either using the customary "javax.net.ssl.trustStorePassword"
+                        system property or the HornetQ-specific "org.hornetq.ssl.trustStorePassword" system
+                        property. The HornetQ-specific system property is useful if another component on client
+                        is already making use of the standard, Java system property.</para>
                 </listitem>
             </itemizedlist>
         </section>

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -102,6 +102,10 @@ public class NettyConnector extends AbstractConnector
 
    public static final String HORNETQ_KEYSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.keyStoreProvider";
    public static final String HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME = "org.hornetq.ssl.trustStoreProvider";
+   public static final String HORNETQ_KEYSTORE_PATH_PROP_NAME = "org.hornetq.ssl.keyStore";
+   public static final String HORNETQ_KEYSTORE_PASSWORD_PROP_NAME = "org.hornetq.ssl.keyStorePassword";
+   public static final String HORNETQ_TRUSTSTORE_PATH_PROP_NAME = "org.hornetq.ssl.trustStore";
+   public static final String HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME = "org.hornetq.ssl.trustStorePassword";
 
    // Attributes ----------------------------------------------------
 
@@ -449,10 +453,18 @@ public class NettyConnector extends AbstractConnector
             {
                realKeyStorePassword = System.getProperty(JAVAX_KEYSTORE_PASSWORD_PROP_NAME);
             }
-
             if (System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME) != null)
             {
                realKeyStoreProvider = System.getProperty(HORNETQ_KEYSTORE_PROVIDER_PROP_NAME);
+            }
+            if (System.getProperty(HORNETQ_KEYSTORE_PASSWORD_PROP_NAME) != null)
+            {
+               realKeyStorePassword = System.getProperty(HORNETQ_KEYSTORE_PASSWORD_PROP_NAME);
+            }
+
+            if (System.getProperty(HORNETQ_KEYSTORE_PATH_PROP_NAME) != null)
+            {
+               realKeyStorePath = System.getProperty(HORNETQ_KEYSTORE_PATH_PROP_NAME);
             }
 
             String realTrustStorePath = trustStorePath;
@@ -471,6 +483,16 @@ public class NettyConnector extends AbstractConnector
             {
                realTrustStoreProvider = System.getProperty(HORNETQ_TRUSTSTORE_PROVIDER_PROP_NAME);
             }
+
+            if (System.getProperty(HORNETQ_TRUSTSTORE_PATH_PROP_NAME) != null)
+            {
+               realTrustStorePath = System.getProperty(HORNETQ_TRUSTSTORE_PATH_PROP_NAME);
+            }
+            if (System.getProperty(HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME) != null)
+            {
+               realTrustStorePassword = System.getProperty(HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME);
+            }
+
             context = SSLSupport.createContext(realKeyStoreProvider, realKeyStorePath, realKeyStorePassword, realTrustStoreProvider, realTrustStorePath, realTrustStorePassword);
          }
          catch (Exception e)

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
@@ -13,9 +13,13 @@
 
 package org.hornetq.tests.unit.core.remoting.impl.netty;
 
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;
+
+import org.junit.Assert;
 
 import org.hornetq.api.core.HornetQBuffer;
 import org.hornetq.api.core.HornetQException;
@@ -27,8 +31,6 @@ import org.hornetq.spi.core.remoting.BufferHandler;
 import org.hornetq.spi.core.remoting.Connection;
 import org.hornetq.spi.core.remoting.ConnectionLifeCycleListener;
 import org.hornetq.tests.util.UnitTestCase;
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
@@ -139,7 +141,7 @@ public class NettyConnectorTest extends UnitTestCase
       }
    }
    @Test
-   public void testSystemPropertyOverrides() throws Exception
+   public void testJavaSystemPropertyOverrides() throws Exception
    {
       BufferHandler handler = new BufferHandler()
       {
@@ -183,6 +185,63 @@ public class NettyConnectorTest extends UnitTestCase
       System.setProperty(NettyConnector.JAVAX_KEYSTORE_PASSWORD_PROP_NAME, "secureexample");
       System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PATH_PROP_NAME, "client-side.truststore");
       System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME, "secureexample");
+
+      connector.start();
+      Assert.assertTrue(connector.isStarted());
+      connector.close();
+      Assert.assertFalse(connector.isStarted());
+   }
+   @Test
+   public void testHornetQSystemPropertyOverrides() throws Exception
+   {
+      BufferHandler handler = new BufferHandler()
+      {
+         public void bufferReceived(final Object connectionID, final HornetQBuffer buffer)
+         {
+         }
+      };
+      Map<String, Object> params = new HashMap<String, Object>();
+      params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      params.put(TransportConstants.KEYSTORE_PATH_PROP_NAME, "bad path");
+      params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "bad password");
+      params.put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME, "bad path");
+      params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "bad password");
+      ConnectionLifeCycleListener listener = new ConnectionLifeCycleListener()
+      {
+         public void connectionException(final Object connectionID, final HornetQException me)
+         {
+         }
+
+         public void connectionDestroyed(final Object connectionID)
+         {
+         }
+
+         public void connectionCreated(final HornetQComponent component, final Connection connection, final ProtocolType protocol)
+         {
+         }
+         public void connectionReadyForWrites(Object connectionID, boolean ready)
+         {
+         }
+      };
+
+      NettyConnector connector = new NettyConnector(params,
+            handler,
+            listener,
+            Executors.newCachedThreadPool(),
+            Executors.newCachedThreadPool(),
+            Executors.newScheduledThreadPool(5));
+
+
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PATH_PROP_NAME, "bad path");
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PASSWORD_PROP_NAME, "bad password");
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PATH_PROP_NAME, "bad path");
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME, "bad password");
+
+      System.setProperty(NettyConnector.HORNETQ_KEYSTORE_PATH_PROP_NAME, "client-side.keystore");
+      System.setProperty(NettyConnector.HORNETQ_KEYSTORE_PASSWORD_PROP_NAME, "secureexample");
+      System.setProperty(NettyConnector.HORNETQ_TRUSTSTORE_PATH_PROP_NAME, "client-side.truststore");
+      System.setProperty(NettyConnector.HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME, "secureexample");
+
 
       connector.start();
       Assert.assertTrue(connector.isStarted());


### PR DESCRIPTION
[HORNETQ-1237] Add a HornetQ-specific system property for setting the keystore and truststore path on the client
BZ 6.4.x https://bugzilla.redhat.com/show_bug.cgi?id=1288578
no upstream required
pr to 2.3.25 https://github.com/hornetq/hornetq/pull/2065
(cherry picked from commit efafa577940f89118d2b751bd64a980db8c1199d)
