### PR TITLE
HORNETQ-1508 - TwoWayTwoNodeClusterTest.testRestartServers fails on t…

### DIFF
--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/TwoWayTwoNodeClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/distribution/TwoWayTwoNodeClusterTest.java
@@ -135,7 +135,7 @@ public class TwoWayTwoNodeClusterTest extends ClusterTestBase
             log.info("#start #test #" + i);
             startServers(1);
             waitForTopology(servers[0], 2, -1, 2000);
-            waitForTopology(servers[1], 2, -1, 2000);
+            waitForTopology(servers[1], 2, -1, 10000);
          }
       }
       finally


### PR DESCRIPTION
…imeout
Exceeded timeout from 2seconds to 10 seconds.

Jira link : https://issues.jboss.org/browse/HORNETQ-1508
