### PR TITLE
HORNETQ-1510 [Testsuite] LinkedListTest.testAddAndRemove fails using …

### DIFF
--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/LinkedListTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/LinkedListTest.java
@@ -176,6 +176,9 @@ public class LinkedListTest extends UnitTestCase
 
       assertCount(999, count);
 
+      //IBM garbage collector is aggressive and collects objs,
+      //that couses fail in assert above
+      objs.size();
    }
 
    /**


### PR DESCRIPTION
…g IBM JDK

Use of linked list reference at the end of test, that it doesn`t get garbage collected

JIRA : https://issues.jboss.org/browse/HORNETQ-1510
