### PR TITLE
HORNETQ-1511 - test fix - IBM JDK 6/7/8 does not allow byteman agent …

### DIFF
--- a/tests/byteman-tests/pom.xml
+++ b/tests/byteman-tests/pom.xml
@@ -169,6 +169,15 @@
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <goals><goal>properties</goal></goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <executions>
                <execution>
@@ -215,7 +224,11 @@
                -->
                <parallel>false</parallel>
                <!--<argLine>${hornetq-surefire-argline} -Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.contrib.bmunit.verbose</argLine>-->
-               <argLine>${hornetq-surefire-argline}</argLine>
+               <argLine>${hornetq-surefire-argline} -javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+               <systemPropertyVariables>
+                  <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+                  <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+               </systemPropertyVariables>
             </configuration>
          </plugin>
       </plugins>

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/LinkedListTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/LinkedListTest.java
@@ -104,6 +104,10 @@ public class LinkedListTest extends UnitTestCase
 
       assertCount(0, count);
 
+      //IBM garbage collector is aggressive and collects objs,
+      //that couses fail in assert above
+      objs.size();
+
    }
 
    @Test
@@ -176,6 +180,9 @@ public class LinkedListTest extends UnitTestCase
 
       assertCount(999, count);
 
+      //IBM garbage collector is aggressive and collects objs,
+      //that couses fail in assert above
+      objs.size();
    }
 
    /**


### PR DESCRIPTION
…to modify classes. This is workaround taken from Wildfy AS test suite to get it working
