### PR TITLE
HORNETQ-626: Allows udp.broadcast.group.ttl System property to be set…

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/UDPBroadcastGroupConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/UDPBroadcastGroupConfiguration.java
@@ -190,7 +190,8 @@ public final class UDPBroadcastGroupConfiguration implements BroadcastEndpointFa
             broadcastingSocket = new MulticastSocket();
          }
 
-         if (System.getProperties().containsKey(PROPERTY_UDP_TTL)) {
+         if (System.getProperties().containsKey(PROPERTY_UDP_TTL))
+         {
             int ttl = Integer.parseInt(System.getProperty(PROPERTY_UDP_TTL));
             HornetQClientLogger.LOGGER.info("Setting broadcast multicast udp ttl to: " + ttl + " from System property: " + PROPERTY_UDP_TTL);
             broadcastingSocket.setTimeToLive(ttl);


### PR DESCRIPTION
… to specify udp broadcast ttl, which is necessary to transmit beyond immediate network
