### PR TITLE
[BZ-1339881] HornetQ still logs truststore and keystore passwords in …

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/api/core/TransportConfiguration.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/api/core/TransportConfiguration.java
@@ -262,7 +262,7 @@ public class TransportConfiguration implements Serializable
 
             // HORNETQ-1281 - don't log passwords
             String val;
-            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD))
+            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME))
             {
                val = "****";
             }

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/TransportConfigurationTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/config/impl/TransportConfigurationTest.java
@@ -13,12 +13,18 @@
 
 package org.hornetq.tests.unit.core.config.impl;
 
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
 import org.junit.Test;
 
 import org.junit.Assert;
 
 import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.tests.util.UnitTestCase;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 
 /**
  * A TransportConfigurationTest
@@ -71,6 +77,18 @@ public class TransportConfigurationTest extends UnitTestCase
       Assert.assertEquals("localhost", addresses[0]);
       Assert.assertEquals("127.0.0.1", addresses[1]);
       Assert.assertEquals("192.168.0.10", addresses[2]);
+   }
+
+   @Test
+   public void testToStringObfuscatesPasswords()
+   {
+      HashMap<String, Object> params = new HashMap<String, Object>();
+      params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "secret_password");
+      params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "secret_password");
+
+      TransportConfiguration configuration = new TransportConfiguration("SomeClass", params, null);
+
+      Assert.assertThat(configuration.toString(), not(containsString("secret_password")));
    }
 
    // Package protected ---------------------------------------------


### PR DESCRIPTION
…plain text

Merged upstream PR: https://github.com/apache/activemq-artemis/pull/557
Upstream JIRA: https://issues.apache.org/jira/browse/ARTEMIS-551
EAP 7 JIRA: https://issues.jboss.org/browse/JBEAP-4852
EAP 6 BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1339881

Question: does this also need to go into 2.4.x? Thank you very much
