### PR TITLE
bz-1350595-revert Revert "[bz-1350595] HornetQ Client fails to connec…

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/HornetQClientLogger.java
@@ -421,10 +421,4 @@ public interface HornetQClientLogger extends BasicLogger
                value = "Couldn't reattach session {0}, performing as a failover operation now and recreating objects",
                format = Message.Format.MESSAGE_FORMAT)
    void creatingNewSession(long id);
-
-   @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 214028,
-         value = "Disallowing use of vulnerable protocol: {0}. See http://www.oracle.com/technetwork/topics/security/poodlecve-2014-3566-2339408.html for more details.",
-         format = Message.Format.MESSAGE_FORMAT)
-   void disallowedProtocol(String protocol);
 }

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/netty/NettyConnector.java
@@ -107,8 +107,6 @@ public class NettyConnector extends AbstractConnector
    public static final String HORNETQ_TRUSTSTORE_PATH_PROP_NAME = "org.hornetq.ssl.trustStore";
    public static final String HORNETQ_TRUSTSTORE_PASSWORD_PROP_NAME = "org.hornetq.ssl.trustStorePassword";
 
-   private static String CLIENT_ENABLED_SSL_PROTOCOLS = System.getProperty("org.hornetq.ssl.client.enabled.protocols", "");
-
    // Attributes ----------------------------------------------------
 
    private ClientSocketChannelFactory channelFactory;
@@ -524,13 +522,6 @@ public class NettyConnector extends AbstractConnector
             if (sslEnabled && !useServlet)
             {
                SSLEngine engine = context.createSSLEngine();
-
-               List<String> disallowedProtocols = SSLSupport.setEnabledProtocols(engine, CLIENT_ENABLED_SSL_PROTOCOLS);
-
-               for (String disallowedProtocol : disallowedProtocols)
-               {
-                  HornetQClientLogger.LOGGER.disallowedProtocol(disallowedProtocol);
-               }
 
                engine.setUseClientMode(true);
 

--- a/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/ssl/SSLSupport.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/remoting/impl/ssl/SSLSupport.java
@@ -16,7 +16,6 @@ package org.hornetq.core.remoting.impl.ssl;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
@@ -24,11 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.security.AccessController;
 import java.security.KeyStore;
 import java.security.PrivilegedAction;
@@ -42,7 +36,6 @@ import org.hornetq.utils.ClassloadingUtil;
 public class SSLSupport
 {
    // Constants -----------------------------------------------------
-   private static String ENABLED_SSL_PROTOCOLS = System.getProperty("org.hornetq.ssl.enabled.protocols", "");
 
    // Attributes ----------------------------------------------------
 
@@ -60,42 +53,6 @@ public class SSLSupport
       TrustManager[] trustManagers = SSLSupport.loadTrustManager(trustStoreProvider, trustStorePath, trustStorePassword);
       context.init(keyManagers, trustManagers, new SecureRandom());
       return context;
-   }
-
-   public static List<String> setEnabledProtocols(SSLEngine engine, String enabledProtocols)
-   {
-      List<String> disallowedProtocols = new ArrayList<String>();
-      List<String> protocols = new ArrayList<String>();
-      Set<String> set = new HashSet<String>();
-      boolean warnDisallowedProtocol = false;
-
-      if (enabledProtocols.isEmpty())
-      {
-         enabledProtocols = ENABLED_SSL_PROTOCOLS;
-      }
-
-      if (enabledProtocols.isEmpty())
-      {
-         protocols.addAll(Arrays.asList(engine.getEnabledProtocols()));
-      }
-      else
-      {
-         for (String s : enabledProtocols.trim().split(","))
-         {
-            protocols.add(s.trim());
-         }
-      }
-      for (String s : protocols)
-      {
-         if (s.equals("SSLv3") || s.equals("SSLv2Hello"))
-         {
-            disallowedProtocols.add(s);
-            continue;
-         }
-         set.add(s);
-      }
-      engine.setEnabledProtocols(set.toArray(new String[0]));
-      return disallowedProtocols;
    }
 
    // Package protected ---------------------------------------------

--- a/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/remoting/impl/netty/NettyAcceptor.java
@@ -18,11 +18,12 @@ import javax.net.ssl.SSLEngine;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -90,8 +91,6 @@ import org.jboss.netty.util.VirtualExecutorService;
  */
 public class NettyAcceptor implements Acceptor
 {
-   private static String SERVER_ENABLED_SSL_PROTOCOLS = System.getProperty("org.hornetq.ssl.server.enabled.protocols", "");
-
    private final ClusterConnection clusterConnection;
 
    private ChannelFactory channelFactory;
@@ -408,11 +407,18 @@ public class NettyAcceptor implements Acceptor
 
                // Strip "SSLv3" from the current enabled protocols to address the POODLE exploit.
                // This recommendation came from http://www.oracle.com/technetwork/java/javase/documentation/cve-2014-3566-2342133.html
-               List<String> disallowedProtocols = SSLSupport.setEnabledProtocols(engine, SERVER_ENABLED_SSL_PROTOCOLS);
-               for (String disallowedProtocol : disallowedProtocols)
+               String[] protocols = engine.getEnabledProtocols();
+               Set<String> set = new HashSet<String>();
+               for (String s : protocols)
                {
-                  HornetQServerLogger.LOGGER.disallowedProtocol(disallowedProtocol);
+                  if (s.equals("SSLv3") || s.equals("SSLv2Hello"))
+                  {
+                     HornetQServerLogger.LOGGER.disallowedProtocol(s);
+                     continue;
+                  }
+                  set.add(s);
                }
+               engine.setEnabledProtocols(set.toArray(new String[0]));
 
                SslHandler handler = new SslHandler(engine);
 


### PR DESCRIPTION
…t to server if server does not allow TLSv1"

This reverts commit 9bc36b2875cd880860a92cb25284b486e4304e3b.

A JDK update makes this change no longer necessary

https://bugzilla.redhat.com/show_bug.cgi?id=1350595
