### PR TITLE
HORNETQ-1409/BZ1359194 - Do not flush internal executor when retrieving number …

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/messagecounter/MessageCounter.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/messagecounter/MessageCounter.java
@@ -118,7 +118,7 @@ public class MessageCounter
    {
       public void run()
       {
-         long latestMessagesAdded = serverQueue.getInstantMessagesAdded();
+         long latestMessagesAdded = serverQueue.getMessagesAdded();
 
          long newMessagesAdded = latestMessagesAdded - lastMessagesAdded;
 
@@ -201,7 +201,7 @@ public class MessageCounter
     */
    public long getMessageCount()
    {
-      return serverQueue.getInstantMessageCount();
+      return serverQueue.getMessageCount();
    }
 
    /**
@@ -210,7 +210,7 @@ public class MessageCounter
     */
    public long getMessageCountDelta()
    {
-      long current = serverQueue.getInstantMessageCount();
+      long current = serverQueue.getMessageCount();
       int delta = (int)(current - depthLast);
 
       depthLast = current;

--- a/hornetq-server/src/main/java/org/hornetq/core/server/Queue.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/Queue.java
@@ -87,27 +87,7 @@ public interface Queue extends Bindable
 
    void destroyPaging() throws Exception;
 
-   /**
-    * It will wait for up to 10 seconds for a flush on the executors and return the number of messages added.
-    * if the executor is busy for any reason (say an unbehaved consumer) we will just return the current value.
-    *
-    * @return
-    */
    long getMessageCount();
-
-   /**
-    * This method will return the messages added after waiting some time on the flush executors.
-    * If the executor couldn't be flushed within the timeout we will just return the current value without any warn
-    *
-    * @param timeout Time to wait for current executors to finish in milliseconds.
-    * @return
-    */
-   long getMessageCount(long timeout);
-
-   /**
-    * Return the current message count without waiting for scheduled executors to finish
-    */
-   long getInstantMessageCount();
 
    int getDeliveringCount();
 
@@ -125,24 +105,9 @@ public interface Queue extends Bindable
     */
    Map<String, List<MessageReference>> getDeliveringMessages();
 
-   /**
-    * It will wait for up to 10 seconds for a flush on the executors and return the number of messages added.
-    * if the executor is busy for any reason (say an unbehaved consumer) we will just return the current value.
-    *
-    * @return
-    */
    long getMessagesAdded();
 
-   /**
-    * This method will return the messages added after waiting some time on the flush executors.
-    * If the executor couldn't be flushed within the timeout we will just return the current value without any warn
-    *
-    * @param timeout Time to wait for current executors to finish in milliseconds.
-    * @return
-    */
-   long getMessagesAdded(long timeout);
-
-   long getInstantMessagesAdded();
+   long getMessagesAcknowledged();
 
    MessageReference removeReferenceWithID(long id) throws Exception;
 
@@ -236,6 +201,8 @@ public interface Queue extends Bindable
    boolean isInternalQueue();
 
    void setInternalQueue(boolean internalQueue);
+
+   void resetMessagesAdded();
 
    float getRate();
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
@@ -214,6 +214,8 @@ public class QueueImpl implements Queue
 
    private SlowConsumerReaperRunnable slowConsumerReaperRunnable;
 
+   private long messagesAcknowledged;
+
    /**
     * This is to avoid multi-thread races on calculating direct delivery,
     * to guarantee ordering will be always be correct
@@ -958,21 +960,6 @@ public class QueueImpl implements Queue
 
    public long getMessageCount()
    {
-      return getMessageCount(FLUSH_TIMEOUT);
-   }
-
-   public long getMessageCount(final long timeout)
-   {
-      if (timeout > 0)
-      {
-         internalFlushExecutor(timeout);
-      }
-      return getInstantMessageCount();
-   }
-
-
-   public long getInstantMessageCount()
-   {
       synchronized (this)
       {
          if (pageSubscription != null)
@@ -1174,17 +1161,6 @@ public class QueueImpl implements Queue
 
    public long getMessagesAdded()
    {
-      return getMessagesAdded(FLUSH_TIMEOUT);
-   }
-
-   public long getMessagesAdded(final long timeout)
-   {
-      if (timeout > 0) internalFlushExecutor(timeout);
-      return getInstantMessagesAdded();
-   }
-
-   public synchronized long getInstantMessagesAdded()
-   {
       if (pageSubscription != null)
       {
          return messagesAdded + pageSubscription.getCounter().getValue() - pagedReferences.get();
@@ -1193,6 +1169,11 @@ public class QueueImpl implements Queue
       {
          return messagesAdded;
       }
+   }
+
+   public long getMessagesAcknowledged()
+   {
+      return messagesAcknowledged;
    }
 
    public int deleteAllReferences() throws Exception
@@ -1775,6 +1756,11 @@ public class QueueImpl implements Queue
          }
          holder.iter = null;
       }
+   }
+
+   public synchronized void resetMessagesAdded()
+   {
+      messagesAdded = 0;
    }
 
    public synchronized void pause()

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerSessionImpl.java
@@ -606,7 +606,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener
                                          queue.isTemporary(),
                                          filterString,
                                          queue.getConsumerCount(),
-                                         queue.getMessageCount(QueueImpl.DELIVERY_TIMEOUT));
+                                         queue.getMessageCount());
       }
       // make an exception for the management address (see HORNETQ-29)
       else if (name.equals(managementAddress))

--- a/hornetq-server/src/test/java/org/hornetq/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1129,18 +1129,6 @@ public class ScheduledDeliveryHandlerTest extends Assert
       }
 
       @Override
-      public long getMessageCount(long timeout)
-      {
-         return 0;
-      }
-
-      @Override
-      public long getInstantMessageCount()
-      {
-         return 0;
-      }
-
-      @Override
       public int getDeliveringCount()
       {
          return 0;
@@ -1177,13 +1165,7 @@ public class ScheduledDeliveryHandlerTest extends Assert
       }
 
       @Override
-      public long getMessagesAdded(long timeout)
-      {
-         return 0;
-      }
-
-      @Override
-      public long getInstantMessagesAdded()
+      public long getMessagesAcknowledged()
       {
          return 0;
       }
@@ -1362,6 +1344,11 @@ public class ScheduledDeliveryHandlerTest extends Assert
 
       }
 
+      @Override
+      public void resetMessagesAdded()
+      {
+
+      }
       @Override
       public boolean flushExecutor()
       {

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/client/HangConsumerTest.java
@@ -145,8 +145,8 @@ public class HangConsumerTest extends ServiceTestBase
          sessionProducer.commit();
 
          // These two operations should finish without the test hanging
-         queue.getMessagesAdded(1);
-         queue.getMessageCount(1);
+         queue.getMessagesAdded();
+         queue.getMessageCount();
 
          releaseConsumers();
 

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PagingWithFailoverAndCountersTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/paging/PagingWithFailoverAndCountersTest.java
@@ -428,7 +428,7 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
       Queue queue = server.locateQueue(SimpleString.toSimpleString("cons2"));
 
 
-      int messageCount = (int) queue.getMessageCount(5000);
+      int messageCount = (int) queue.getMessageCount();
 
       assertTrue(messageCount >= 0);
 

--- a/tests/jms-tests/src/test/java/org/hornetq/jms/tests/HornetQServerTestCase.java
+++ b/tests/jms-tests/src/test/java/org/hornetq/jms/tests/HornetQServerTestCase.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.Set;
 
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+import org.hornetq.api.core.SimpleString;
+import org.hornetq.core.postoffice.Binding;
+import org.hornetq.core.postoffice.impl.LocalQueueBinding;
 import org.hornetq.core.security.Role;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.jms.server.JMSServerManager;
@@ -435,7 +438,13 @@ public abstract class HornetQServerTestCase extends ProxyAssertSupport
 
    protected boolean assertRemainingMessages(final int expected) throws Exception
    {
-      Long messageCount = HornetQServerTestCase.servers.get(0).getMessageCountForQueue("Queue1");
+      String queueName = "Queue1";
+      Binding binding = servers.get(0).getHornetQServer().getPostOffice().getBinding(SimpleString.toSimpleString("jms.queue." + queueName));
+      if (binding != null && binding instanceof LocalQueueBinding)
+      {
+         ((LocalQueueBinding)binding).getQueue().flushExecutor();
+      }
+      Long messageCount = HornetQServerTestCase.servers.get(0).getMessageCountForQueue(queueName);
 
       ProxyAssertSupport.assertEquals(expected, messageCount.intValue());
       return expected == messageCount.intValue();

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -301,12 +301,6 @@ public class FakeQueue implements Queue
    }
 
    @Override
-   public long getMessageCount(long timeout)
-   {
-      return 0;
-   }
-
-   @Override
    public long getMessagesAdded()
    {
       // no-op
@@ -314,11 +308,41 @@ public class FakeQueue implements Queue
    }
 
    @Override
-   public long getMessagesAdded(long timeout)
+   public long getMessagesAcknowledged()
    {
+      // no-op
       return 0;
    }
 
+
+   @Override
+   public void resetMessagesAdded()
+   {
+      // no-op
+
+   }
+
+   /*@Override
+   public void resetMessagesAcknowledged()
+   {
+      // no-op
+
+   }
+*/
+   /*
+   @Override
+   public void incrementMesssagesAdded()
+   {
+
+   }
+*/
+   /*
+   @Override
+   public List<MessageReference> cancelScheduledMessages()
+   {
+      return null;
+   }
+*/
    @Override
    public SimpleString getName()
    {
@@ -522,20 +546,6 @@ public class FakeQueue implements Queue
    public void deleteQueue() throws Exception
    {
       // no-op
-   }
-
-   @Override
-   public long getInstantMessageCount()
-   {
-      // no-op
-      return 0;
-   }
-
-   @Override
-   public long getInstantMessagesAdded()
-   {
-      // no-op
-      return 0;
    }
 
    /* (non-Javadoc)

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/server/impl/QueueImplTest.java
@@ -265,6 +265,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(numMessages, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -330,6 +331,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -385,6 +387,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -440,6 +443,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -460,6 +464,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(20, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -577,6 +582,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(numMessages, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -897,6 +903,7 @@ public class QueueImplTest extends UnitTestCase
          refs.add(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(numMessages, queue.getMessageCount());
 
       Iterator<MessageReference> iterator = queue.iterator();
@@ -955,6 +962,8 @@ public class QueueImplTest extends UnitTestCase
 
       refs.add(ref2);
 
+      queue.flushExecutor();
+
       Assert.assertEquals(2, queue.getMessageCount());
 
       awaitExecution();
@@ -991,6 +1000,7 @@ public class QueueImplTest extends UnitTestCase
 
       refs.add(ref4);
 
+      queue.flushExecutor();
       Assert.assertEquals(3, queue.getMessageCount());
 
       awaitExecution();
@@ -1036,6 +1046,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1088,6 +1099,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1108,6 +1120,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(20, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1166,6 +1179,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1286,6 +1300,7 @@ public class QueueImplTest extends UnitTestCase
          queue.deliverNow();
       }
 
+      queue.flushExecutor();
       Assert.assertEquals(6, queue.getMessageCount());
 
       awaitExecution();
@@ -1366,6 +1381,7 @@ public class QueueImplTest extends UnitTestCase
       queue.addTail(messageReference);
       queue.addTail(messageReference2);
       queue.addTail(messageReference3);
+      queue.flushExecutor();
       Assert.assertEquals(queue.getMessagesAdded(), 3);
    }
 
@@ -1452,6 +1468,7 @@ public class QueueImplTest extends UnitTestCase
          queue.addTail(ref);
       }
       // even as this queue is paused, it will receive the messages anyway
+      queue.flushExecutor();
       Assert.assertEquals(10, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1525,6 +1542,7 @@ public class QueueImplTest extends UnitTestCase
 
       // the queue even if it's paused will receive the message but won't forward
       // directly to the consumer until resumed.
+      queue.flushExecutor();
       Assert.assertEquals(numMessages, queue.getMessageCount());
       Assert.assertEquals(0, queue.getScheduledCount());
       Assert.assertEquals(0, queue.getDeliveringCount());
@@ -1541,6 +1559,31 @@ public class QueueImplTest extends UnitTestCase
       Assert.assertEquals(numMessages, queue.getMessageCount());
       Assert.assertEquals(numMessages, queue.getDeliveringCount());
 
+   }
+
+
+   @Test
+   public void testResetMessagesAdded() throws Exception
+   {
+      QueueImpl queue = new QueueImpl(1,
+                                      QueueImplTest.address1,
+                                      QueueImplTest.queue1,
+                                      null,
+                                      false,
+                                      true,
+                                      scheduledExecutor,
+                                      null,
+                                      null,
+                                      null,
+                                      executor);
+      MessageReference messageReference = generateReference(queue, 1);
+      MessageReference messageReference2 = generateReference(queue, 2);
+      queue.addTail(messageReference);
+      queue.addTail(messageReference2);
+      queue.flushExecutor();
+      Assert.assertEquals(2, queue.getMessagesAdded());
+      queue.resetMessagesAdded();
+      Assert.assertEquals(0, queue.getMessagesAdded());
    }
 
    class AddtoQueueRunner implements Runnable


### PR DESCRIPTION
HORNETQ-1409 - Do not flush internal executor when retrieving number of messages or messages added. 
Back ported from 2.4 branch.

HORNETQ-1409 - https://issues.jboss.org/browse/HORNETQ-1409
BZ1359194 - https://bugzilla.redhat.com/show_bug.cgi?id=1359194
