### PR TITLE
Bug 1422335 Invalid id-cache-size in the default configuration

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/config/impl/FileConfiguration.java
@@ -36,7 +36,7 @@ public final class FileConfiguration extends ConfigurationImpl
    private static final String DEFAULT_CONFIGURATION_URL = "hornetq-configuration.xml";
 
    // For a bridge confirmations must be activated or send acknowledgments won't return
-   public static final int DEFAULT_CONFIRMATION_WINDOW_SIZE = 1024 * 1024;
+   public static final int DEFAULT_CONFIRMATION_WINDOW_SIZE = 1024 * 1024 * 10;
 
    public FileConfiguration()
    {

--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1031,9 +1031,9 @@ public interface HornetQServerLogger extends BasicLogger
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222192,
-      value = "The size of duplicate cache detection (<id_cache-size/>) appears to be too large. It should be no greater than the number of messages that can be squeezed into conformation buffer (<confirmation-window-size/>).",
+      value = "The size of duplicate cache detection (<id_cache-size/>) appears to be too large {0}. It should be no greater than the number of messages that can be squeezed into conformation buffer (<confirmation-window-size/>) {1}.",
       format = Message.Format.MESSAGE_FORMAT)
-   void duplicateCacheSizeWarning();
+   void duplicateCacheSizeWarning(int idCacheSize, int confirmationWindowSize);
 
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 222193, value = "There were too many old replicated folders upon startup, removing {0}",

--- a/hornetq-server/src/main/java/org/hornetq/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -961,7 +961,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
       topology.updateAsLive(nodeID, localMember);
    }
 
-   public boolean checkoutDupCacheSize(final int windowSize, final int idCacheSize)
+   public static boolean checkoutDupCacheSize(final int windowSize, final int idCacheSize)
    {
       final int msgNumInFlight = windowSize / DEFAULT_JMS_MESSAGE_SIZE;
 
@@ -1100,7 +1100,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
 
       if ( !checkoutDupCacheSize(serverLocator.getConfirmationWindowSize(),server.getConfiguration().getIDCacheSize()))
       {
-         HornetQServerLogger.LOGGER.duplicateCacheSizeWarning();
+         HornetQServerLogger.LOGGER.duplicateCacheSizeWarning(server.getConfiguration().getIDCacheSize(), serverLocator.getConfirmationWindowSize());
       }
    }
 

--- a/hornetq-server/src/test/java/org/hornetq/core/config/impl/DefaultsFileConfigurationTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/config/impl/DefaultsFileConfigurationTest.java
@@ -13,6 +13,7 @@
 
 package org.hornetq.core.config.impl;
 
+import org.hornetq.core.server.cluster.impl.ClusterConnectionImpl;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -141,6 +142,12 @@ public class DefaultsFileConfigurationTest extends ConfigurationImplTest
       Assert.assertEquals(HornetQDefaultConfiguration.getDefaultMessageExpiryThreadPriority(),
                           conf.getMessageExpiryThreadPriority());
       Assert.assertEquals("replication cluster name", null, conf.getReplicationClustername());
+   }
+
+   @Test
+   public void testDefaultConstraints()
+   {
+      assertTrue(ClusterConnectionImpl.checkoutDupCacheSize(FileConfiguration.DEFAULT_CONFIRMATION_WINDOW_SIZE, conf.getIDCacheSize()));
    }
 
    // Protected ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
The default id-cache-size is 20000. It conflicts with the default
confirmation-window-size(1MB) used in ClusterConnection. When start
up a cluster the following WARN appears:

WARN  [org.hornetq.core.server] (Thread-16 (HornetQ-server-HornetQ
ServerImpl::serverUUID=dd22fac6-f327-11e6-a1c9-739b3b259544-27075288))
HQ222192: The size of duplicate cache detection (<id_cache-size/>)
appears to be too large. It should be no greater than the number
of messages that can be squeezed into conformation buffer
(<confirmation-window-size/>).

To fix it we adjust the confirmation-window-size to 10MB. Also
a test is added to guarantee it won't break this rule when this
default value is to be changed to any new value.