### PR TITLE
Bug1431406 specific properties not removed from messages

### DIFF
--- a/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQMessage.java
+++ b/hornetq-jms-client/src/main/java/org/hornetq/jms/client/HornetQMessage.java
@@ -41,6 +41,7 @@ import org.hornetq.api.core.client.ClientMessage;
 import org.hornetq.api.core.client.ClientSession;
 import org.hornetq.api.jms.HornetQJMSConstants;
 import org.hornetq.core.client.impl.ClientMessageImpl;
+import org.hornetq.core.message.impl.MessageImpl;
 import org.hornetq.utils.UUID;
 
 /**
@@ -733,7 +734,8 @@ public class HornetQMessage implements javax.jms.Message
       for (SimpleString propName : message.getPropertyNames())
       {
          if ((!propName.startsWith(HornetQMessage.JMS) || propName.startsWith(HornetQMessage.JMSX) ||
-             propName.startsWith(HornetQMessage.JMS_)) && !propName.startsWith(HornetQConnection.CONNECTION_ID_PROPERTY_NAME))
+             propName.startsWith(HornetQMessage.JMS_)) && !propName.startsWith(HornetQConnection.CONNECTION_ID_PROPERTY_NAME) &&
+             !propName.startsWith(MessageImpl.HDR_ROUTE_TO_IDS))
          {
             set.add(propName.toString());
          }

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/cluster/TopicClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/jms/cluster/TopicClusterTest.java
@@ -15,16 +15,24 @@ package org.hornetq.tests.integration.jms.cluster;
 
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
+import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 
+import org.hornetq.api.core.SimpleString;
+import org.hornetq.api.core.client.ClientMessage;
+import org.hornetq.core.message.impl.MessageImpl;
+import org.hornetq.jms.client.HornetQMessage;
 import org.hornetq.tests.util.JMSClusteredTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Enumeration;
+import java.util.Set;
 
 /**
  * A TopicClusterTest
@@ -116,6 +124,97 @@ public class TopicClusterTest extends JMSClusteredTestBase
       jmsServer2.destroyTopic("t1");
 
 
+   }
+
+   @Test
+   public void testInternalPropertyNotExposed() throws Exception
+   {
+      Connection conn1 = cf1.createConnection();
+
+      conn1.setClientID("someClient1");
+
+      Connection conn2 = cf2.createConnection();
+
+      conn2.setClientID("someClient2");
+
+      conn1.start();
+
+      conn2.start();
+
+      try
+      {
+
+         Topic topic1 = createTopic("t1");
+
+         Session session1 = conn1.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session session2 = conn2.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         MessageProducer prod1 = session1.createProducer(topic1);
+         prod1.setDeliveryMode(DeliveryMode.PERSISTENT);
+
+         MessageConsumer cons1 = session1.createDurableSubscriber(topic1, "sub1");
+         MessageConsumer cons2 = session2.createDurableSubscriber(topic1, "sub2");
+
+         final int num = 1;
+         for (int i = 0; i < num; i++)
+         {
+            prod1.send(session1.createTextMessage("someMessage" + i));
+         }
+
+         for (int i = 0; i < num; i++)
+         {
+            TextMessage m1 = (TextMessage)cons1.receive(5000);
+            assertNotNull(m1);
+            TextMessage m2 = (TextMessage)cons2.receive(5000);
+            assertNotNull(m2);
+            checkInternalProperty(m1, m2);
+         }
+
+      }
+      finally
+      {
+         conn1.close();
+         conn2.close();
+
+         jmsServer1.destroyTopic("t1");
+         jmsServer2.destroyTopic("t1");
+      }
+   }
+
+   //check that the internal property is in the core
+   //but didn't exposed to jms
+   private void checkInternalProperty(Message... msgs) throws Exception
+   {
+      boolean checked = false;
+      for (Message m : msgs)
+      {
+         HornetQMessage hqMessage = (HornetQMessage) m;
+         ClientMessage coreMessage = hqMessage.getCoreMessage();
+         Set<SimpleString> coreProps = coreMessage.getPropertyNames();
+         System.out.println("core props: " + coreProps);
+         boolean exist = false;
+         for (SimpleString prop : coreProps)
+         {
+            if (prop.startsWith(MessageImpl.HDR_ROUTE_TO_IDS))
+            {
+               exist = true;
+               break;
+            }
+         }
+
+         if (exist)
+         {
+            Enumeration enumProps = m.getPropertyNames();
+            while (enumProps.hasMoreElements())
+            {
+               String propName = (String) enumProps.nextElement();
+               assertFalse("Shouldn't be in jms property: " + propName, propName.startsWith(MessageImpl.HDR_ROUTE_TO_IDS.toString()));
+            }
+            checked = true;
+         }
+      }
+      assertTrue(checked);
    }
 
    // Package protected ---------------------------------------------


### PR DESCRIPTION
In a cluster if a node is shut down (or crashed) when a
message is being routed to a remote binding, a internal
property may be added to the message and persisted. The
name of the property is like _HQ_ROUTE_TOsf.my-cluster*.
if the node starts back, it will reroute this message
and if it goes to a local consumer, this property won't
get removed and goes to the client.

The fix is to remove this internal property before it
is sent to any client.