### PR TITLE
BZ1373953 max-saved-replicated-journal-size = 0 should preserve no old

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1364,4 +1364,8 @@ public interface HornetQServerLogger extends BasicLogger
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 224072, value = "Message Counter Sample Period too short: {0}", format = Message.Format.MESSAGE_FORMAT)
    void invalidMessageCounterPeriod(long value);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 224073, value = "Deleting old data directory {0} as the max folders is set to 0", format = Message.Format.MESSAGE_FORMAT)
+   void backupDeletingData(String oldPath);
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/FileMoveManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/FileMoveManager.java
@@ -102,19 +102,31 @@ public class FileMoveManager
 
       int whereToMove = getMaxID() + 1;
 
-      File folderTo = getFolder(whereToMove);
-      folderTo.mkdirs();
-
-      HornetQServerLogger.LOGGER.backupMovingDataAway(folder.getPath(), folderTo.getPath());
-
-      for (String fileMove : files)
+      if (maxFolders == 0)
       {
-         File fileFrom = new File(folder, fileMove);
-         File fileTo = new File(folderTo, fileMove);
-         logger.tracef("doMove:: moving %s as %s", fileFrom, fileTo);
-         fileFrom.renameTo(fileTo);
+         HornetQServerLogger.LOGGER.backupDeletingData(folder.getPath());
+         for (String fileMove : files)
+         {
+            File fileFrom = new File(folder, fileMove);
+            logger.tracef("deleting %s", fileFrom);
+            deleteTree(fileFrom);
+         }
       }
+      else
+      {
+         File folderTo = getFolder(whereToMove);
+         folderTo.mkdirs();
 
+         HornetQServerLogger.LOGGER.backupMovingDataAway(folder.getPath(), folderTo.getPath());
+
+         for (String fileMove : files)
+         {
+            File fileFrom = new File(folder, fileMove);
+            File fileTo = new File(folderTo, fileMove);
+            logger.tracef("doMove:: moving %s as %s", fileFrom, fileTo);
+            fileFrom.renameTo(fileTo);
+         }
+      }
    }
 
    public void checkOldFolders()
@@ -124,9 +136,15 @@ public class FileMoveManager
 
    private void internalCheckOldFolders(int creating)
    {
-      if (maxFolders > 0)
+      if (maxFolders >= 0)
       {
          int folders = getNumberOfFolders();
+
+         if (folders == 0)
+         {
+            // no folders.. nothing to be done
+            return;
+         }
 
          // We are counting the next one to be created
          int foldersToDelete = folders + creating - maxFolders;

--- a/hornetq-server/src/test/java/org/hornetq/core/server/impl/FileMoveManagerTest.java
+++ b/hornetq-server/src/test/java/org/hornetq/core/server/impl/FileMoveManagerTest.java
@@ -210,7 +210,7 @@ public class FileMoveManagerTest
 
       Assert.assertEquals(manager.getMaxFolders(), manager.getNumberOfFolders());
 
-      manager.setMaxFolders(0).checkOldFolders();
+      manager.setMaxFolders(-1).checkOldFolders();
 
       Assert.assertEquals(3, manager.getNumberOfFolders());
 
@@ -271,7 +271,7 @@ public class FileMoveManagerTest
 
       Assert.assertEquals(manager.getMaxFolders(), manager.getNumberOfFolders());
 
-      manager.setMaxFolders(0).checkOldFolders();
+      manager.setMaxFolders(-1).checkOldFolders();
 
       Assert.assertEquals(3, manager.getNumberOfFolders());
 
@@ -281,6 +281,38 @@ public class FileMoveManagerTest
 
       Assert.assertEquals(10, manager.getMaxID());
       Assert.assertEquals(10, manager.getMinID());
+   }
+
+   @Test
+   public void testMaxZero() throws Exception
+   {
+      manager.setMaxFolders(0);
+
+      int NUMBER_OF_FOLDERS = 10;
+      int FILES_PER_FOLDER = 10;
+
+      for (int bkp = 1; bkp <= 10; bkp++)
+      {
+         for (int f = 0; f < NUMBER_OF_FOLDERS; f++)
+         {
+            File folderF = new File(dataLocation, "folder" + f);
+            folderF.mkdirs();
+
+            // FILES_PER_FOLDER + f, I'm just creating more files as f grows.
+            // this is just to make each folder unique somehow
+            for (int i = 0; i < FILES_PER_FOLDER + f; i++)
+            {
+               createFile(folderF, i);
+            }
+         }
+
+         manager.doMove();
+
+         // We will always have maximum of 3 folders
+         Assert.assertEquals(0, manager.getNumberOfFolders());
+      }
+
+      Assert.assertEquals(0, manager.getMaxID());
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/hornetq/tests/integration/cluster/failover/FailoverTestBase.java
@@ -205,7 +205,7 @@ public abstract class FailoverTestBase extends ServiceTestBase
       backupConfig.setPagingDirectory(backupConfig.getPagingDirectory() + suffix);
       backupConfig.setLargeMessagesDirectory(backupConfig.getLargeMessagesDirectory() + suffix);
       backupConfig.setSecurityEnabled(false);
-      backupConfig.setMaxSavedReplicatedJournalSize(0);
+      backupConfig.setMaxSavedReplicatedJournalSize(-1);
       nodeManager = new InVMNodeManager(true, backupConfig.getJournalDirectory());
 
       backupServer = createTestableServer(backupConfig);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1373953

EAP 7.0: https://github.com/rh-messaging/jboss-activemq-artemis/pull/187 https://issues.apache.org/jira/browse/ARTEMIS-716

Upstream: https://issues.apache.org/jira/browse/ARTEMIS-716
https://github.com/apache/activemq-artemis/pull/758 - merged and released with Artemis 1.5.0 on 2016-11-03 (the current version in WF being 1.5.4.jbossorg-004 )



