### PR TITLE
HORNETQ-1551(2) Consumer hangs on corrupted 'forced delivery' message

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
@@ -132,7 +132,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
 
    private boolean stopped = false;
 
-   private long forceDeliveryCount;
+   private volatile long forceDeliveryCount;
 
    private final SessionQueueQueryResponseMessage queueInfo;
 
@@ -330,7 +330,6 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
                      {
                         HornetQClientLogger.LOGGER.trace("There was nothing on the queue, leaving it now:: returning null");
                      }
-
                      return null;
                   }
                   else
@@ -563,6 +562,12 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
    public SessionQueueQueryResponseMessage getQueueInfo()
    {
       return queueInfo;
+   }
+
+   @Override
+   public long getForceDeliveryCount()
+   {
+      return forceDeliveryCount;
    }
 
    public long getID()

--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerInternal.java
@@ -77,4 +77,6 @@ public interface ClientConsumerInternal extends ClientConsumer
    void start();
 
    SessionQueueQueryResponseMessage getQueueInfo();
+
+   long getForceDeliveryCount();
 }

--- a/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/DisconnectOnCriticalFailureTest.java
+++ b/tests/byteman-tests/src/test/java/org/hornetq/byteman/tests/DisconnectOnCriticalFailureTest.java
@@ -17,7 +17,9 @@
 package org.hornetq.byteman.tests;
 
 import org.hornetq.api.core.HornetQBuffer;
+import org.hornetq.api.core.client.ServerLocator;
 import org.hornetq.core.protocol.core.impl.PacketImpl;
+import org.hornetq.jms.client.HornetQConnectionFactory;
 import org.hornetq.tests.util.JMSTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
 import javax.jms.Connection;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -142,6 +145,79 @@ public class DisconnectOnCriticalFailureTest extends JMSTestBase
          corruptPacket.set(true);
          MessageConsumer consumer = session.createConsumer(q1);
          consumer.receive(2000);
+
+         assertTrue(latch.await(5, TimeUnit.SECONDS));
+      }
+      finally
+      {
+         corruptPacket.set(false);
+
+         if (connection != null)
+         {
+            connection.close();
+         }
+      }
+   }
+
+   @Test(timeout = 60000)
+   @BMRules
+      (
+         rules =
+            {
+               @BMRule
+                  (
+                     name = "Corrupt Decoding",
+                     targetClass = "org.hornetq.core.protocol.ClientPacketDecoder",
+                     targetMethod = "decode(org.hornetq.api.core.HornetQBuffer)",
+                     targetLocation = "ENTRY",
+                     action = "org.hornetq.byteman.tests.DisconnectOnCriticalFailureTest.doThrow($1);"
+                  )
+            }
+      )
+   public void testClientDisconnectLarge() throws Exception
+   {
+      Queue q1 = createQueue("queue1");
+      final Connection connection = nettyCf.createConnection();
+      final CountDownLatch latch = new CountDownLatch(1);
+      ServerLocator locator = ((HornetQConnectionFactory)nettyCf).getServerLocator();
+      int minSize = locator.getMinLargeMessageSize();
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < minSize; i++)
+      {
+         builder.append("a");
+      }
+
+      try
+      {
+         connection.setExceptionListener(new ExceptionListener()
+         {
+            @Override
+            public void onException(JMSException e)
+            {
+               latch.countDown();
+            }
+         });
+
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         MessageProducer producer = session.createProducer(q1);
+         TextMessage m = session.createTextMessage(builder.toString());
+         producer.send(m);
+         connection.start();
+
+         corruptPacket.set(true);
+         MessageConsumer consumer = session.createConsumer(q1);
+         Message lm = consumer.receive(2000);
+
+         //first receive won't crash because the packet
+         //is SESS_RECEIVE_LARGE_MSG
+         assertNotNull(lm);
+
+         //second receive will force server to send a
+         //"forced delivery" message, and will cause
+         //the exception to be thrown.
+         lm = consumer.receive(5000);
+         assertNull(lm);
 
          assertTrue(latch.await(5, TimeUnit.SECONDS));
       }

--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/core/client/impl/LargeMessageBufferTest.java
@@ -932,6 +932,12 @@ public class LargeMessageBufferTest extends UnitTestCase
          return null;
       }
 
+      @Override
+      public long getForceDeliveryCount()
+      {
+         return 0;
+      }
+
       /* (non-Javadoc)
        * @see org.hornetq.core.client.impl.ClientConsumerInternal#getNonXAsession()
        */


### PR DESCRIPTION
It can happen when the consumer sends a 'forced delivery' then
waits forever while the connection is broken and the server's
'forced delivery' message never gets to consumer. If session is
reconnected, its consumer never knows and stays waiting.

To fix this, send a "forced delivery" message as part of session
reconnection.