### PR TITLE
HORNETQ-1556 Avoid NPE in ServerConsumerImpl.removeReferenceByID()

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
@@ -895,6 +895,12 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
       synchronized (lock)
       {
          // This is an optimization, if the reference is the first one, we just poll it.
+         // But first we need to make sure deliveringRefs isn't empty
+         if (deliveringRefs.isEmpty())
+         {
+            return null;
+         }
+
          if (deliveringRefs.peek().getMessage().getMessageID() == messageID)
          {
             return deliveringRefs.poll();


### PR DESCRIPTION
It should check if queue is empty before poll the queue.
See https://issues.apache.org/jira/browse/ARTEMIS-502
Just back-port this to HornetQ.