### PR TITLE
[BZ1477494] HQ222142: Error on resetting large message deliver - null: java.lang.NullPointerException

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/ServerConsumerImpl.java
@@ -553,9 +553,11 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener
 
       try
       {
-         if (largeMessageDeliverer != null)
+         LargeMessageDeliverer pendingLargeMessageDeliverer = largeMessageDeliverer;
+
+         if (pendingLargeMessageDeliverer != null)
          {
-            largeMessageDeliverer.finish();
+            pendingLargeMessageDeliverer.finish();
          }
       }
       catch (Throwable e)


### PR DESCRIPTION
This may happen if one thread is closing large message delivery while another is trying to roll it back.

[1] BZ1477494
[2] HORNETQ-1557