### PR TITLE
Bug 1469369 Messages get stuck after changing configuration

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/QueueImpl.java
@@ -2089,7 +2089,6 @@ public class QueueImpl implements Queue
 
                if (status == HandleStatus.HANDLED)
                {
-
                   deliveriesInTransit.countUp();
 
                   handledconsumer = consumer;
@@ -2181,7 +2180,7 @@ public class QueueImpl implements Queue
     */
    private boolean needsDepage()
    {
-      return queueMemorySize.get() < pageSubscription.getPagingStore().getMaxSize();
+      return queueMemorySize.get() < pageSubscription.getPagingStore().getMaxSize() || pageSubscription.getPagingStore().getMaxSize() == -1;
    }
 
    private SimpleString extractGroupID(MessageReference ref)

--- a/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
+++ b/hornetq-server/src/test/java/org/hornetq/tests/util/UnitTestCase.java
@@ -1591,6 +1591,22 @@ public abstract class UnitTestCase extends CoreUnitTestCase
       return message;
    }
 
+   protected ClientMessage createTextMessage(final ClientSession session, final boolean durable, final int numChars)
+   {
+      ClientMessage message = session.createMessage(Message.TEXT_TYPE,
+                                                    durable,
+                                                    0,
+                                                    System.currentTimeMillis(),
+                                                    (byte)4);
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < numChars; i++)
+      {
+         builder.append('a');
+      }
+      message.getBodyBuffer().writeString(builder.toString());
+      return message;
+   }
+
    protected XidImpl newXID()
    {
       return new XidImpl("xa1".getBytes(), 1, UUIDGenerator.getInstance().generateStringUUID().getBytes());


### PR DESCRIPTION
If user changes max-size-bytes from a limited value to -1 and
restart the broker, the paged messages in storage will get
stuck after restarting. This is because that the broker
doesn't do depaging when max-size-bytes is -1.

To fix it, just makes the broke do a depage even if
max-size-bytes is -1.