### PR TITLE
HORNETQ-1559 Page.write() should throw exception if file is closed

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/paging/impl/Page.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/paging/impl/Page.java
@@ -191,8 +191,7 @@ public final class Page implements Comparable<Page>
    {
       if (!file.isOpen())
       {
-
-         return;
+         throw new IllegalStateException("can't write to closed file " + file);
       }
 
       ByteBuffer buffer = fileFactory.newBuffer(message.getEncodeSize() + Page.SIZE_RECORD);


### PR DESCRIPTION
In Page.write(final PagedMessage message) if the page file is closed
it returns silently. The caller has no way to know that if the message
is paged to file or not. It should throw an exception so that the
caller can handle it correctly.
This causes random failure in PagingTest#testExpireLargeMessageOnPaging().