### PR TITLE
HORNETQ-1564 Failback not working on NFSv4

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/AIOFileLockNodeManager.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/AIOFileLockNodeManager.java
@@ -44,7 +44,7 @@ public final class AIOFileLockNodeManager extends FileLockNodeManager
    }
 
    @Override
-   protected FileLock tryLock(final int lockPos) throws Exception
+   protected FileLock tryLock(final long lockPos) throws Exception
    {
       File file = newFileForRegionLock(lockPos);
 
@@ -67,7 +67,7 @@ public final class AIOFileLockNodeManager extends FileLockNodeManager
    }
 
    @Override
-   protected FileLock lock(final int liveLockPos) throws IOException
+   protected FileLock lock(final long liveLockPos) throws IOException
    {
       File file = newFileForRegionLock(liveLockPos);
 
@@ -106,7 +106,7 @@ public final class AIOFileLockNodeManager extends FileLockNodeManager
     * @param liveLockPos
     * @return
     */
-   protected File newFileForRegionLock(final int liveLockPos)
+   protected File newFileForRegionLock(final long liveLockPos)
    {
       File file = newFile("server." + liveLockPos + ".lock");
       return file;


### PR DESCRIPTION
With NFSv4 it is now necessary to lock/unlock the byte of the server
lock file where the state information is written so that the
information is then flushed to the other clients looking at the file.

https://issues.jboss.org/browse/HORNETQ-1564
https://bugzilla.redhat.com/show_bug.cgi?id=1516650