### PR TITLE
fix of test ObjectInputStreamWithClassLoaderTest

### DIFF
--- a/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/ObjectInputStreamWithClassLoaderTest.java
+++ b/tests/unit-tests/src/test/java/org/hornetq/tests/unit/util/ObjectInputStreamWithClassLoaderTest.java
@@ -13,6 +13,7 @@
 
 package org.hornetq.tests.unit.util;
 
+import org.hornetq.tests.CoreUnitTestCase;
 import org.hornetq.tests.unit.util.deserialization.pkg1.EnclosingClass;
 import org.hornetq.tests.unit.util.deserialization.pkg1.TestClass1;
 import org.hornetq.tests.unit.util.deserialization.pkg1.TestClass2;
@@ -110,7 +111,7 @@ public class ObjectInputStreamWithClassLoaderTest extends UnitTestCase
          //Class.isAnonymousClass() call used in ObjectInputStreamWithClassLoader
          //need to access the enclosing class and its parent class of the obj
          //i.e. ActiveMQTestBase and Assert.
-         ClassLoader testClassLoader = ObjectInputStreamWithClassLoaderTest.newClassLoader(this.getClass());
+         ClassLoader testClassLoader = ObjectInputStreamWithClassLoaderTest.newClassLoader(this.getClass(), UnitTestCase.class, CoreUnitTestCase.class, Assert.class);
          Thread.currentThread().setContextClassLoader(testClassLoader);
 
          ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
@@ -152,7 +153,7 @@ public class ObjectInputStreamWithClassLoaderTest extends UnitTestCase
          byte[] bytes = ObjectInputStreamWithClassLoaderTest
                .toBytes(originalProxy);
 
-         ClassLoader testClassLoader = ObjectInputStreamWithClassLoaderTest.newClassLoader(this.getClass());
+         ClassLoader testClassLoader = ObjectInputStreamWithClassLoaderTest.newClassLoader(this.getClass(), UnitTestCase.class, CoreUnitTestCase.class, Assert.class);
          Thread.currentThread().setContextClassLoader(testClassLoader);
          ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
          org.hornetq.utils.ObjectInputStreamWithClassLoader ois = new ObjectInputStreamWithClassLoader(


### PR DESCRIPTION
Fixed test of ObjectInputStreamWithClassLoaderTest after commit https://github.com/hornetq/hornetq/pull/2125 -  [BZ-1444235] - CVE-2016-4978 hornetq: Apache ActiveMQ Artemis: Deserialization of untrusted input vulnerability [eap-6.4.z] (backport of rh-messaging/jboss-activemq-artemis#181) - https://github.com/hornetq/hornetq/commit/b72408fb0e19db227a2bae6fe590f9c7466a2d65