### PR TITLE
HORNETQ-1575 Fix new connection establishment after failure during failover

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientSessionFactoryImpl.java
@@ -201,16 +201,38 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                             final List<Interceptor> outgoingInterceptors,
                             PacketDecoder packetDecoder)
    {
+      this(serverLocator, new Pair<TransportConfiguration, TransportConfiguration>(connectorConfig, null),
+               callTimeout, callFailoverTimeout, clientFailureCheckPeriod, connectionTTL,
+               retryInterval, retryIntervalMultiplier, maxRetryInterval, reconnectAttempts, threadPool,
+               scheduledThreadPool, incomingInterceptors, outgoingInterceptors, packetDecoder);
+   }
+
+   ClientSessionFactoryImpl(final ServerLocatorInternal serverLocator,
+                            final Pair<TransportConfiguration, TransportConfiguration> connectorConfig,
+                            final long callTimeout,
+                            final long callFailoverTimeout,
+                            final long clientFailureCheckPeriod,
+                            final long connectionTTL,
+                            final long retryInterval,
+                            final double retryIntervalMultiplier,
+                            final long maxRetryInterval,
+                            final int reconnectAttempts,
+                            final Executor threadPool,
+                            final ScheduledExecutorService scheduledThreadPool,
+                            final List<Interceptor> incomingInterceptors,
+                            final List<Interceptor> outgoingInterceptors,
+                            PacketDecoder packetDecoder)
+   {
 
       e.fillInStackTrace();
 
       this.serverLocator = serverLocator;
 
-      this.currentConnectorConfig = connectorConfig;
+      this.currentConnectorConfig = connectorConfig.getA();
 
-      connectorFactory = instantiateConnectorFactory(connectorConfig.getFactoryClassName());
+      connectorFactory = instantiateConnectorFactory(connectorConfig.getA().getFactoryClassName());
 
-      checkTransportKeys(connectorFactory, connectorConfig.getParams());
+      checkTransportKeys(connectorFactory, connectorConfig.getA().getParams());
 
       this.callTimeout = callTimeout;
 
@@ -241,6 +263,12 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
       this.outgoingInterceptors = outgoingInterceptors;
 
       this.packetDecoder = packetDecoder;
+
+      if (connectorConfig.getB() != null)
+      {
+         this.backupConfig = connectorConfig.getB();
+      }
+
    }
 
    @Override


### PR DESCRIPTION

In a live-backup scenario, when live is down and backup becomes live, clients
using HA Connection Factories can failover automatically. However if a
client decides to create a new connection by itself (as in camel jms case)
there is a chance that the new connection is pointing to the dead live
and the connection won't be successful. The reason is that if the old
connection is gone the backup will not get a chance to announce itself
back to client so it fails on initial connection.

The fix is to let CF remember the old topology and use it on any
initial connection attempts.