### PR TITLE
HORNETQ-1578 Adding error log message SharedNothingLiveActivation#isNodeIdUsed

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1382,4 +1382,8 @@ public interface HornetQServerLogger extends BasicLogger
    @Message(id = 224081, value = "The component {0} is not responsive", format = Message.Format.MESSAGE_FORMAT)
    void criticalSystemLog(Object component);
 
+   @LogMessage(level = Logger.Level.DEBUG)
+   @Message(id = 223001, value = "The server failed to connect to get topology.", format = Message.Format.MESSAGE_FORMAT)
+   void serverFailedToConnectTopology(@Cause Exception e);
+
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -3061,6 +3061,7 @@ public class HornetQServerImpl implements HornetQServer
             }
             catch (Exception notConnected)
             {
+               HornetQServerLogger.LOGGER.serverFailedToConnectTopology(notConnected);
                return false;
             }
 


### PR DESCRIPTION
When replicated live server starts up it needs to find out if a backup
is live in the cluster so it can decide whether to go live or perform
a fail back. This method catches the exception and silently return false.
Adding an error log here will help debugging the issue.