### PR TITLE
NO-JIRA Avoid NPE during backup shutdown

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -475,7 +475,8 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
       {
          TypedProperties props = new TypedProperties();
          props.putSimpleStringProperty(new SimpleString("name"), name);
-         Notification notification = new Notification(nodeManager.getNodeId().toString(),
+         SimpleString nodeId = nodeManager.getNodeId();
+         Notification notification = new Notification(nodeId == null ? null : nodeId.toString(),
                                                       CoreNotificationType.CLUSTER_CONNECTION_STOPPED,
                                                       props);
          managementService.sendNotification(notification);


### PR DESCRIPTION
When a backup starts without a live, it's nodeID is null.
Added a null check in ClusterConnection's stop() to avoid
NPE if it's shut down.