### PR TITLE
HORNETQ-1578 Exceptions are swallowed, making it hard to diagnose issues

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/HornetQServerLogger.java
@@ -1382,4 +1382,7 @@ public interface HornetQServerLogger extends BasicLogger
    @Message(id = 224081, value = "The component {0} is not responsive", format = Message.Format.MESSAGE_FORMAT)
    void criticalSystemLog(Object component);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 224082, value = "Connecting to cluster failed")
+   void failedConnectingToCluster(@Cause Exception e);
 }

--- a/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/server/impl/HornetQServerImpl.java
@@ -53,6 +53,7 @@ import org.hornetq.api.config.HornetQDefaultConfiguration;
 import org.hornetq.api.core.DiscoveryGroupConfiguration;
 import org.hornetq.api.core.HornetQAlreadyReplicatingException;
 import org.hornetq.api.core.HornetQException;
+import org.hornetq.api.core.HornetQExceptionType;
 import org.hornetq.api.core.HornetQIllegalStateException;
 import org.hornetq.api.core.HornetQInternalErrorException;
 import org.hornetq.api.core.Pair;
@@ -3061,6 +3062,12 @@ public class HornetQServerImpl implements HornetQServer
             }
             catch (Exception notConnected)
             {
+               if (!(notConnected instanceof HornetQException)
+                       || HornetQExceptionType.INTERNAL_ERROR.equals(((HornetQException) notConnected).getType()))
+               {
+                  // report all exceptions that aren't HornetQException and all INTERNAL_ERRORs
+                  HornetQServerLogger.LOGGER.failedConnectingToCluster(notConnected);
+               }
                return false;
             }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/HORNETQ-1578

I've seen also HornetQExceptionType.CONNECTION_TIMEDOUT exceptions being swallowed by the same catch block, but I don't think it's desirable to log those. So I limited logging to INTERNAL_ERROR exceptions and exceptions that aren't HornetQException.

Feel free to throw away, if you have something better in mind.