### PR TITLE
HORNETQ-1581 LargeMessage copy(long) leak files

### DIFF
--- a/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/hornetq-server/src/main/java/org/hornetq/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -355,6 +355,10 @@ public final class LargeServerMessageImpl extends ServerMessageImpl implements L
          }
          finally
          {
+            if (!file.isOpen())
+            {
+               newMessage.getFile().close();
+            }
             cloneFile.close();
          }
          return newMessage;


### PR DESCRIPTION
In LargeServerMessageImpl.copy(long) after the newMessage
is copied, its file should be properly closed.
Otherwise the file is leaking.