### PR TITLE
Addresses CVE-2024-51127

### DIFF
--- a/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
+++ b/hornetq-core-client/src/main/java/org/hornetq/core/client/impl/ClientConsumerImpl.java
@@ -699,7 +699,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal
     */
    private File createLargeMessageTempFile(long messageId) throws IOException
    {
-      Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw");
+      Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-------");
       File messageTempFile = Files.createTempFile(
               "tmp-large-message-" + messageId + "-",
               ".tmp",

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -242,7 +242,9 @@
                           <goal>single</goal>
                       </goals>
                       <configuration>
-                          <descriptor>src/test/resources/rest/bwlist-rest-test-asm.xml</descriptor>
+                          <descriptors>
+                            <descriptor>src/test/resources/rest/bwlist-rest-test-asm.xml</descriptor>
+                          </descriptors>
                           <finalName>rest-test-bwlist</finalName>
                           <appendAssemblyId>false</appendAssemblyId>
                           <outputDirectory>target/test-classes/rest/</outputDirectory>
@@ -255,7 +257,9 @@
                           <goal>single</goal>
                       </goals>
                       <configuration>
-                          <descriptor>src/test/resources/rest/rest-test-asm.xml</descriptor>
+                          <descriptors>
+                            <descriptor>src/test/resources/rest/rest-test-asm.xml</descriptor>
+                          </descriptors>
                           <finalName>rest-test</finalName>
                           <appendAssemblyId>false</appendAssemblyId>
                           <outputDirectory>target/test-classes/rest/</outputDirectory>


### PR DESCRIPTION
Implements mitigation suggestion 1 from https://github.com/JAckLosingHeart/CWE-378/blob/main/CVE-2024-51127.md

The main part of this PR sets up a temporary directory created on demand after the first instance where a large message requires a temporary file.  This directory is then used for all subsequent temporary files and is removed on VM exit.  Using a directory negates the need to perform permissions updates per file.

Creating the temporary directory is done on demand as opposed to using a static initializer in the class because there's a possibility that creating a temporary directory would trigger an IO exception and the situations where that would happen are probably identical or very similar to situations where an IO exception would be triggered on temp file creation, and clients that have restrictions preventing the creation of temp files probably don't need large response handling, so eagerly creating the temporary directory would have resulted in a regression for those clients.

The POM also changes in this PR, in order to fix the configuration of the assembly plugin.